### PR TITLE
Add Yolo mode toggle to task creation

### DIFF
--- a/src/main/db/migrate.ts
+++ b/src/main/db/migrate.ts
@@ -34,6 +34,7 @@ export function runMigrations(): void {
       path TEXT NOT NULL,
       status TEXT NOT NULL DEFAULT 'idle',
       use_worktree INTEGER DEFAULT 1,
+      auto_approve INTEGER DEFAULT 0,
       archived_at TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP
@@ -56,6 +57,9 @@ export function runMigrations(): void {
   `);
 
   rawDb.exec(`CREATE INDEX IF NOT EXISTS idx_conversations_task_id ON conversations(task_id);`);
+
+  // Migrations for existing databases
+  try { rawDb.exec(`ALTER TABLE tasks ADD COLUMN auto_approve INTEGER DEFAULT 0`); } catch { /* already exists */ }
 
   rawDb.pragma('foreign_keys = ON');
 }

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -30,6 +30,7 @@ export const tasks = sqliteTable(
     path: text('path').notNull(),
     status: text('status').notNull().default('idle'),
     useWorktree: integer('use_worktree', { mode: 'boolean' }).default(true),
+    autoApprove: integer('auto_approve', { mode: 'boolean' }).default(false),
     archivedAt: text('archived_at'),
     createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`),
     updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`),

--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -88,6 +88,7 @@ export class DatabaseService {
         path: data.path,
         status: data.status ?? 'idle',
         useWorktree: data.useWorktree ?? true,
+        autoApprove: data.autoApprove ?? false,
         createdAt: now,
         updatedAt: now,
       })
@@ -197,6 +198,7 @@ export class DatabaseService {
       path: row.path,
       status: row.status,
       useWorktree: row.useWorktree ?? true,
+      autoApprove: row.autoApprove ?? false,
       archivedAt: row.archivedAt,
       createdAt: row.createdAt ?? '',
       updatedAt: row.updatedAt ?? '',

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -282,7 +282,7 @@ export function App() {
     setShowTaskModal(true);
   }
 
-  async function handleCreateTask(name: string, useWorktree: boolean) {
+  async function handleCreateTask(name: string, useWorktree: boolean, autoApprove: boolean) {
     const targetProjectId = taskModalProjectId || activeProjectId;
     const targetProject = projects.find((p) => p.id === targetProjectId);
     if (!targetProject) return;
@@ -318,6 +318,7 @@ export function App() {
       branch,
       path: taskPath,
       useWorktree,
+      autoApprove,
     });
 
     if (saveResp.success && saveResp.data) {

--- a/src/renderer/components/MainContent.tsx
+++ b/src/renderer/components/MainContent.tsx
@@ -70,6 +70,7 @@ export function MainContent({ activeTask, activeProject }: MainContentProps) {
           key={activeTask.id}
           id={activeTask.id}
           cwd={activeTask.path}
+          autoApprove={activeTask.autoApprove}
         />
       </div>
     </div>

--- a/src/renderer/components/TaskModal.tsx
+++ b/src/renderer/components/TaskModal.tsx
@@ -1,19 +1,20 @@
 import React, { useState } from 'react';
-import { X, GitBranch } from 'lucide-react';
+import { X, GitBranch, Zap } from 'lucide-react';
 
 interface TaskModalProps {
   onClose: () => void;
-  onCreate: (name: string, useWorktree: boolean) => void;
+  onCreate: (name: string, useWorktree: boolean, autoApprove: boolean) => void;
 }
 
 export function TaskModal({ onClose, onCreate }: TaskModalProps) {
   const [name, setName] = useState('');
   const [useWorktree, setUseWorktree] = useState(true);
+  const [autoApprove, setAutoApprove] = useState(false);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (name.trim()) {
-      onCreate(name.trim(), useWorktree);
+      onCreate(name.trim(), useWorktree, autoApprove);
       onClose();
     }
   }
@@ -55,7 +56,7 @@ export function TaskModal({ onClose, onCreate }: TaskModalProps) {
           </div>
 
           {/* Worktree toggle */}
-          <div className="mb-6">
+          <div className="mb-4">
             <label className="flex items-center gap-3 cursor-pointer group">
               <div className="relative">
                 <input
@@ -71,6 +72,27 @@ export function TaskModal({ onClose, onCreate }: TaskModalProps) {
                 <GitBranch size={13} className="text-muted-foreground/40" strokeWidth={1.8} />
                 <span className="text-[13px] text-foreground/80">Git worktree</span>
                 <span className="text-[11px] text-muted-foreground/40">isolated branch</span>
+              </div>
+            </label>
+          </div>
+
+          {/* Yolo mode toggle */}
+          <div className="mb-6">
+            <label className="flex items-center gap-3 cursor-pointer group">
+              <div className="relative">
+                <input
+                  type="checkbox"
+                  checked={autoApprove}
+                  onChange={(e) => setAutoApprove(e.target.checked)}
+                  className="sr-only peer"
+                />
+                <div className="w-8 h-[18px] rounded-full bg-accent peer-checked:bg-primary/80 transition-colors duration-200" />
+                <div className="absolute top-[3px] left-[3px] w-3 h-3 rounded-full bg-muted-foreground/40 peer-checked:bg-primary-foreground peer-checked:translate-x-[14px] transition-all duration-200" />
+              </div>
+              <div className="flex items-center gap-2">
+                <Zap size={13} className="text-muted-foreground/40" strokeWidth={1.8} />
+                <span className="text-[13px] text-foreground/80">Yolo mode</span>
+                <span className="text-[11px] text-muted-foreground/40">skip permissions</span>
               </div>
             </label>
           </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,6 +17,7 @@ export interface Task {
   path: string;
   status: string;
   useWorktree: boolean;
+  autoApprove: boolean;
   archivedAt: string | null;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary
- Adds an `auto_approve` column to the tasks DB table (with ALTER TABLE migration for existing DBs)
- Adds a "Yolo mode" toggle in the new-task modal (Zap icon, matching the worktree toggle pattern)
- Passes `autoApprove` through the full stack: DB → types → DatabaseService → App → MainContent → TerminalPane, which already wires it to `--dangerously-skip-permissions`

## Test plan
- [ ] `npm run build` succeeds
- [ ] Create a task with Yolo mode off → Claude starts normally (prompts for permissions)
- [ ] Create a task with Yolo mode on → Claude starts with `--dangerously-skip-permissions`
- [ ] Existing tasks (before migration) default to `false` without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)