### PR TITLE
Fix EPIPE crash when clicking terminal links

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -6,6 +6,12 @@ import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
 
+// ── Stderr EPIPE Guard ───────────────────────────────────────
+process.stderr.on('error', (err) => {
+  if ((err as NodeJS.ErrnoException).code === 'EPIPE') return;
+  throw err;
+});
+
 // ── PATH Fix ──────────────────────────────────────────────────
 function fixPath(): void {
   const currentPath = process.env.PATH || '';

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -26,7 +26,7 @@ export function createWindow(): BrowserWindow {
 
   // Open external links in default browser
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    shell.openExternal(url).catch(() => {});
     return { action: 'deny' };
   });
 


### PR DESCRIPTION
## Summary
- Catch `shell.openExternal()` promise rejection to prevent unhandled rejection warnings
- Add stderr EPIPE guard in main process to prevent crashes when the stderr pipe is broken/closed

## Test plan
- [ ] Build the app and launch it
- [ ] Click a URL link in the terminal output
- [ ] Confirm the link opens in the default browser without an EPIPE crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)