### PR TITLE
Disable resize handle when sidebar is collapsed

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -497,7 +497,7 @@ export function App() {
             onToggleCollapse={toggleSidebar}
           />
         </Panel>
-        <PanelResizeHandle className="w-[1px] bg-border/40" />
+        <PanelResizeHandle disabled={sidebarCollapsed} className="w-[1px] bg-border/40" />
 
         <Panel minSize={35}>
           <MainContent activeTask={activeTask} activeProject={activeProject} />


### PR DESCRIPTION
## Summary
- Disables the left sidebar's `PanelResizeHandle` when the sidebar is collapsed, removing the drag cursor on hover since resizing doesn't apply in that state.

## Test plan
- [ ] Collapse the left sidebar and hover over the border — no resize cursor should appear
- [ ] Expand the sidebar and verify the resize handle still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)