### PR TITLE
Remember yolo mode setting across new tasks

### DIFF
--- a/src/renderer/components/TaskModal.tsx
+++ b/src/renderer/components/TaskModal.tsx
@@ -9,7 +9,7 @@ interface TaskModalProps {
 export function TaskModal({ onClose, onCreate }: TaskModalProps) {
   const [name, setName] = useState('');
   const [useWorktree, setUseWorktree] = useState(true);
-  const [autoApprove, setAutoApprove] = useState(false);
+  const [autoApprove, setAutoApprove] = useState(() => localStorage.getItem('yoloMode') === 'true');
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -83,7 +83,10 @@ export function TaskModal({ onClose, onCreate }: TaskModalProps) {
                 <input
                   type="checkbox"
                   checked={autoApprove}
-                  onChange={(e) => setAutoApprove(e.target.checked)}
+                  onChange={(e) => {
+                    setAutoApprove(e.target.checked);
+                    localStorage.setItem('yoloMode', String(e.target.checked));
+                  }}
                   className="sr-only peer"
                 />
                 <div className="w-8 h-[18px] rounded-full bg-accent peer-checked:bg-primary/80 transition-colors duration-200" />


### PR DESCRIPTION
## Summary
- Persist the yolo mode toggle to `localStorage` so it defaults to the user's last choice when creating new tasks
- No more re-enabling yolo mode every time you create a task

## Test plan
- [ ] Enable yolo mode on a new task, close modal, open "New Task" again — toggle should be pre-enabled
- [ ] Disable yolo mode, create another task — toggle should default to off

🤖 Generated with [Claude Code](https://claude.com/claude-code)