### PR TITLE
Persist terminal sessions across app restarts

### DIFF
--- a/src/main/ipc/ptyIpc.ts
+++ b/src/main/ipc/ptyIpc.ts
@@ -1,4 +1,8 @@
 import { ipcMain } from 'electron';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as crypto from 'crypto';
 import {
   startDirectPty,
   startPty,
@@ -90,4 +94,40 @@ export function registerPtyIpc(): void {
       return { success: false, error: String(error) };
     }
   });
+
+  // Check if a Claude session exists for a given working directory
+  ipcMain.handle('pty:hasClaudeSession', async (_event, cwd: string) => {
+    try {
+      return { success: true, data: hasClaudeSession(cwd) };
+    } catch (error) {
+      return { success: false, data: false, error: String(error) };
+    }
+  });
+}
+
+/**
+ * Check if Claude Code has an existing session for the given working directory.
+ * Claude stores sessions in ~/.claude/projects/ with various naming schemes.
+ */
+function hasClaudeSession(cwd: string): boolean {
+  try {
+    const projectsDir = path.join(os.homedir(), '.claude', 'projects');
+    if (!fs.existsSync(projectsDir)) return false;
+
+    // Check hash-based directory name
+    const cwdHash = crypto.createHash('sha256').update(cwd).digest('hex').slice(0, 16);
+    if (fs.existsSync(path.join(projectsDir, cwdHash))) return true;
+
+    // Check path-based directory name (slashes replaced with hyphens)
+    const pathBasedName = cwd.replace(/\//g, '-');
+    if (fs.existsSync(path.join(projectsDir, pathBasedName))) return true;
+
+    // Scan for partial path match (last 3 segments)
+    const cwdParts = cwd.split('/').filter((p) => p.length > 0);
+    const lastParts = cwdParts.slice(-3).join('-');
+    const dirs = fs.readdirSync(projectsDir);
+    return dirs.some((dir) => dir.includes(lastParts));
+  } catch {
+    return false;
+  }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -131,6 +131,19 @@ app.on('activate', async () => {
 });
 
 app.on('before-quit', async () => {
+  // Signal renderer to save all terminal snapshots before we kill PTYs
+  try {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) {
+        win.webContents.send('app:beforeQuit');
+      }
+    }
+    // Give renderer a moment to save snapshots
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  } catch {
+    // Best effort
+  }
+
   // Kill all PTYs
   try {
     const { killAll } = await import('./services/ptyManager');

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -61,6 +61,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('pty:snapshot:save', id, payload),
   ptyClearSnapshot: (id: string) => ipcRenderer.invoke('pty:snapshot:clear', id),
 
+  // Session detection
+  ptyHasClaudeSession: (cwd: string) => ipcRenderer.invoke('pty:hasClaudeSession', cwd),
+
+  // App lifecycle
+  onBeforeQuit: (callback: () => void) => {
+    const handler = () => callback();
+    ipcRenderer.on('app:beforeQuit', handler);
+    return () => {
+      ipcRenderer.removeListener('app:beforeQuit', handler);
+    };
+  },
+
   // Git detection
   detectGit: (folderPath: string) => ipcRenderer.invoke('app:detectGit', folderPath),
   detectClaude: () => ipcRenderer.invoke('app:detectClaude'),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import { SettingsModal } from './components/SettingsModal';
 import type { Project, Task, GitStatus, DiffResult } from '../shared/types';
 import { loadKeybindings, saveKeybindings, matchesBinding } from './keybindings';
 import type { KeyBindingMap } from './keybindings';
+import { sessionRegistry } from './terminal/SessionRegistry';
 
 const GIT_POLL_INTERVAL = 5000;
 
@@ -62,6 +63,13 @@ export function App() {
   // Load projects on mount
   useEffect(() => {
     loadProjects();
+  }, []);
+
+  // Save all terminal snapshots when app is about to quit
+  useEffect(() => {
+    return window.electronAPI.onBeforeQuit(() => {
+      sessionRegistry.saveAllSnapshots();
+    });
   }, []);
 
   // Load tasks for all projects when projects change

--- a/src/renderer/terminal/SessionRegistry.ts
+++ b/src/renderer/terminal/SessionRegistry.ts
@@ -51,6 +51,16 @@ class SessionRegistryImpl {
       this.sessions.delete(id);
     }
   }
+
+  /**
+   * Force-save snapshots for all active sessions.
+   * Called before app quit so terminal state persists across restarts.
+   */
+  async saveAllSnapshots(): Promise<void> {
+    for (const session of this.sessions.values()) {
+      await session.forceSaveSnapshot();
+    }
+  }
 }
 
 export const sessionRegistry = new SessionRegistryImpl();

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -45,6 +45,12 @@ export interface ElectronAPI {
   ptySaveSnapshot: (id: string, payload: TerminalSnapshot) => Promise<IpcResponse<void>>;
   ptyClearSnapshot: (id: string) => Promise<IpcResponse<void>>;
 
+  // Session detection
+  ptyHasClaudeSession: (cwd: string) => Promise<IpcResponse<boolean>>;
+
+  // App lifecycle
+  onBeforeQuit: (callback: () => void) => () => void;
+
   // Git detection
   detectGit: (folderPath: string) => Promise<IpcResponse<{ remote: string | null; branch: string | null }>>;
   detectClaude: () => Promise<IpcResponse<{ installed: boolean; version: string | null; path: string | null }>>;


### PR DESCRIPTION
## Summary
- On app quit, signals renderer to force-save all terminal snapshots before killing PTYs
- On restart, detects existing Claude sessions in `~/.claude/projects/` (hash, path-based, and partial match) and spawns Claude with `-c -r` resume flag
- For non-resume cases (no existing session / shell fallback), restores the visual snapshot so users see their previous terminal output

## Test plan
- [ ] Open a task, run Claude, then quit and reopen Dash — Claude should resume the conversation
- [ ] Open a task with no prior Claude session — terminal starts fresh (no stale snapshot)
- [ ] Switch between tasks — sessions still preserved in-memory as before
- [ ] Kill app mid-session — on restart, snapshot from last 2-min interval is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)