### PR TITLE
Add branch selection for task creation

### DIFF
--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -158,6 +158,16 @@ export function registerGitIpc(): void {
     }
   });
 
+  // List remote branches (fetch + list)
+  ipcMain.handle('git:listBranches', async (_event, cwd: string) => {
+    try {
+      const branches = await GitService.fetchAndListBranches(cwd);
+      return { success: true, data: branches };
+    } catch (error) {
+      return { success: false, error: String(error) };
+    }
+  });
+
   // Start watching a directory for file changes
   ipcMain.handle('git:watch', async (_event, args: { id: string; cwd: string }) => {
     try {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -106,9 +106,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   gitUnstageAll: (cwd: string) => ipcRenderer.invoke('git:unstageAll', cwd),
   gitDiscardFile: (args: { cwd: string; filePath: string }) =>
     ipcRenderer.invoke('git:discardFile', args),
-  gitCommit: (args: { cwd: string; message: string }) =>
-    ipcRenderer.invoke('git:commit', args),
+  gitCommit: (args: { cwd: string; message: string }) => ipcRenderer.invoke('git:commit', args),
   gitPush: (cwd: string) => ipcRenderer.invoke('git:push', cwd),
+
+  // Branch listing
+  gitListBranches: (cwd: string) => ipcRenderer.invoke('git:listBranches', cwd),
 
   // File watcher
   gitWatch: (args: { id: string; cwd: string }) => ipcRenderer.invoke('git:watch', args),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -494,7 +494,12 @@ export function App() {
     setShowTaskModal(true);
   }
 
-  async function handleCreateTask(name: string, useWorktree: boolean, autoApprove: boolean) {
+  async function handleCreateTask(
+    name: string,
+    useWorktree: boolean,
+    autoApprove: boolean,
+    baseRef?: string,
+  ) {
     const targetProjectId = taskModalProjectId || activeProjectId;
     const targetProject = projects.find((p) => p.id === targetProjectId);
     if (!targetProject) return;
@@ -505,6 +510,7 @@ export function App() {
       const claimResp = await window.electronAPI.worktreeClaimReserve({
         projectId: targetProject.id,
         taskName: name,
+        baseRef,
       });
 
       if (claimResp.success && claimResp.data) {
@@ -513,6 +519,7 @@ export function App() {
         const createResp = await window.electronAPI.worktreeCreate({
           projectPath: targetProject.path,
           taskName: name,
+          baseRef,
           projectId: targetProject.id,
         });
         if (createResp.success && createResp.data) {
@@ -760,7 +767,13 @@ export function App() {
       )}
 
       {showTaskModal && (
-        <TaskModal onClose={() => setShowTaskModal(false)} onCreate={handleCreateTask} />
+        <TaskModal
+          projectPath={
+            projects.find((p) => p.id === (taskModalProjectId || activeProjectId))?.path ?? ''
+          }
+          onClose={() => setShowTaskModal(false)}
+          onCreate={handleCreateTask}
+        />
       )}
 
       {showSettings && (

--- a/src/renderer/components/TaskModal.tsx
+++ b/src/renderer/components/TaskModal.tsx
@@ -1,20 +1,85 @@
-import React, { useState } from 'react';
-import { X, GitBranch, Zap } from 'lucide-react';
+import React, { useState, useEffect, useRef } from 'react';
+import { X, GitBranch, Zap, ChevronDown, Loader2, AlertCircle, Search } from 'lucide-react';
+import type { BranchInfo } from '../../shared/types';
 
 interface TaskModalProps {
+  projectPath: string;
   onClose: () => void;
-  onCreate: (name: string, useWorktree: boolean, autoApprove: boolean) => void;
+  onCreate: (name: string, useWorktree: boolean, autoApprove: boolean, baseRef?: string) => void;
 }
 
-export function TaskModal({ onClose, onCreate }: TaskModalProps) {
+export function TaskModal({ projectPath, onClose, onCreate }: TaskModalProps) {
   const [name, setName] = useState('');
   const [useWorktree, setUseWorktree] = useState(true);
   const [autoApprove, setAutoApprove] = useState(() => localStorage.getItem('yoloMode') === 'true');
 
+  // Branch selector state
+  const [branches, setBranches] = useState<BranchInfo[]>([]);
+  const [branchLoading, setBranchLoading] = useState(false);
+  const [branchError, setBranchError] = useState<string | null>(null);
+  const [selectedBranch, setSelectedBranch] = useState<BranchInfo | null>(null);
+  const [branchSearch, setBranchSearch] = useState('');
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Fetch branches when worktree is enabled
+  useEffect(() => {
+    if (useWorktree) {
+      fetchBranches();
+    }
+  }, [useWorktree, projectPath]);
+
+  // Close dropdown on click outside
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    }
+    if (dropdownOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [dropdownOpen]);
+
+  // Focus search input when dropdown opens
+  useEffect(() => {
+    if (dropdownOpen) {
+      searchInputRef.current?.focus();
+    }
+  }, [dropdownOpen]);
+
+  async function fetchBranches() {
+    setBranchLoading(true);
+    setBranchError(null);
+    try {
+      const resp = await window.electronAPI.gitListBranches(projectPath);
+      if (resp.success && resp.data) {
+        setBranches(resp.data);
+        if (!selectedBranch && resp.data.length > 0) {
+          setSelectedBranch(resp.data[0]);
+        }
+      } else {
+        setBranchError(resp.error || 'Failed to load branches');
+      }
+    } catch (err) {
+      setBranchError(String(err));
+    } finally {
+      setBranchLoading(false);
+    }
+  }
+
+  const filteredBranches = branches.filter((b) =>
+    b.name.toLowerCase().includes(branchSearch.toLowerCase()),
+  );
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (name.trim()) {
-      onCreate(name.trim(), useWorktree, autoApprove);
+      const baseRef = useWorktree ? selectedBranch?.ref : undefined;
+      onCreate(name.trim(), useWorktree, autoApprove, baseRef);
       onClose();
     }
   }
@@ -29,7 +94,10 @@ export function TaskModal({ onClose, onCreate }: TaskModalProps) {
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-5 h-12 border-b border-border/60" style={{ background: 'hsl(var(--surface-2))' }}>
+        <div
+          className="flex items-center justify-between px-5 h-12 border-b border-border/60"
+          style={{ background: 'hsl(var(--surface-2))' }}
+        >
           <h2 className="text-[14px] font-semibold text-foreground">New Task</h2>
           <button
             onClick={onClose}
@@ -74,6 +142,127 @@ export function TaskModal({ onClose, onCreate }: TaskModalProps) {
                 <span className="text-[11px] text-muted-foreground/40">isolated branch</span>
               </div>
             </label>
+          </div>
+
+          {/* Branch selector — animated collapse */}
+          <div
+            className="grid transition-[grid-template-rows] duration-200 ease-in-out"
+            style={{ gridTemplateRows: useWorktree ? '1fr' : '0fr' }}
+          >
+            <div className="overflow-hidden">
+              <div className="mb-4" ref={dropdownRef}>
+                <label className="block text-[12px] font-medium text-muted-foreground/70 mb-2">
+                  Base branch
+                </label>
+
+                {branchError ? (
+                  <div className="flex items-center gap-2 px-3 py-2.5 rounded-lg bg-destructive/10 border border-destructive/20 text-[12px] text-destructive">
+                    <AlertCircle size={13} strokeWidth={2} />
+                    <span className="flex-1 truncate">{branchError}</span>
+                    <button
+                      type="button"
+                      onClick={fetchBranches}
+                      className="text-[11px] font-medium underline underline-offset-2 hover:no-underline shrink-0"
+                    >
+                      Retry
+                    </button>
+                  </div>
+                ) : (
+                  <div className="relative">
+                    <button
+                      type="button"
+                      onClick={() => !branchLoading && setDropdownOpen((v) => !v)}
+                      disabled={branchLoading}
+                      className="w-full flex items-center gap-2 px-3.5 py-2.5 rounded-lg bg-background border border-input/60 text-[13px] text-left hover:border-ring/50 focus:outline-none focus:ring-2 focus:ring-ring/30 focus:border-ring/50 transition-all duration-150 disabled:opacity-50"
+                    >
+                      {branchLoading ? (
+                        <>
+                          <Loader2 size={13} className="animate-spin text-muted-foreground/50" />
+                          <span className="text-muted-foreground/50">Fetching branches...</span>
+                        </>
+                      ) : selectedBranch ? (
+                        <>
+                          <GitBranch
+                            size={12}
+                            className="text-muted-foreground/50 shrink-0"
+                            strokeWidth={1.8}
+                          />
+                          <span className="flex-1 truncate text-foreground">
+                            {selectedBranch.name}
+                          </span>
+                          <span className="text-[11px] text-muted-foreground/40 font-mono shrink-0">
+                            {selectedBranch.shortHash}
+                          </span>
+                        </>
+                      ) : (
+                        <span className="text-muted-foreground/30">Select branch...</span>
+                      )}
+                      <ChevronDown
+                        size={13}
+                        className={`text-muted-foreground/40 shrink-0 transition-transform duration-150 ${dropdownOpen ? 'rotate-180' : ''}`}
+                      />
+                    </button>
+
+                    {/* Dropdown */}
+                    {dropdownOpen && (
+                      <div className="absolute z-50 mt-1 w-full bg-card border border-border/60 rounded-lg shadow-xl shadow-black/30 overflow-hidden">
+                        {/* Search */}
+                        <div className="flex items-center gap-2 px-3 py-2 border-b border-border/40">
+                          <Search size={12} className="text-muted-foreground/40 shrink-0" />
+                          <input
+                            ref={searchInputRef}
+                            type="text"
+                            value={branchSearch}
+                            onChange={(e) => setBranchSearch(e.target.value)}
+                            placeholder="Filter branches..."
+                            className="flex-1 bg-transparent text-[12px] text-foreground placeholder:text-muted-foreground/30 outline-none"
+                          />
+                        </div>
+
+                        {/* Branch list */}
+                        <div className="max-h-[200px] overflow-y-auto">
+                          {filteredBranches.length === 0 ? (
+                            <div className="px-3 py-3 text-[12px] text-muted-foreground/40 text-center">
+                              No branches found
+                            </div>
+                          ) : (
+                            filteredBranches.map((branch) => (
+                              <button
+                                key={branch.ref}
+                                type="button"
+                                onClick={() => {
+                                  setSelectedBranch(branch);
+                                  setDropdownOpen(false);
+                                  setBranchSearch('');
+                                }}
+                                className={`w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-accent/60 transition-colors duration-100 ${
+                                  selectedBranch?.ref === branch.ref ? 'bg-accent/40' : ''
+                                }`}
+                              >
+                                <GitBranch
+                                  size={11}
+                                  className="text-muted-foreground/40 shrink-0"
+                                  strokeWidth={1.8}
+                                />
+                                <span className="flex-1 truncate text-[12px] text-foreground/80">
+                                  {branch.name}
+                                </span>
+                                <span className="text-[10px] text-muted-foreground/40 font-mono shrink-0">
+                                  {branch.shortHash}
+                                </span>
+                                <span className="text-[10px] text-muted-foreground/30 shrink-0">
+                                  {branch.relativeDate}
+                                </span>
+                              </button>
+                            ))
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
 
           {/* Yolo mode toggle */}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -77,9 +77,24 @@ export interface TerminalSnapshot {
   data: string;
 }
 
+// ── Branch Types ─────────────────────────────────────────────
+
+export interface BranchInfo {
+  name: string; // "main", "develop"
+  ref: string; // "origin/main", "origin/develop"
+  shortHash: string; // "a1b2c3d"
+  relativeDate: string; // "2 days ago"
+}
+
 // ── Git Types ────────────────────────────────────────────────
 
-export type FileChangeStatus = 'modified' | 'added' | 'deleted' | 'renamed' | 'untracked' | 'conflicted';
+export type FileChangeStatus =
+  | 'modified'
+  | 'added'
+  | 'deleted'
+  | 'renamed'
+  | 'untracked'
+  | 'conflicted';
 
 export interface FileChange {
   path: string;

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -7,6 +7,7 @@ import type {
   TerminalSnapshot,
   GitStatus,
   DiffResult,
+  BranchInfo,
 } from '../shared/types';
 
 export interface ElectronAPI {
@@ -132,6 +133,9 @@ export interface ElectronAPI {
   gitDiscardFile: (args: { cwd: string; filePath: string }) => Promise<IpcResponse<void>>;
   gitCommit: (args: { cwd: string; message: string }) => Promise<IpcResponse<void>>;
   gitPush: (cwd: string) => Promise<IpcResponse<void>>;
+
+  // Branch listing
+  gitListBranches: (cwd: string) => Promise<IpcResponse<BranchInfo[]>>;
 
   // File watcher
   gitWatch: (args: { id: string; cwd: string }) => Promise<IpcResponse<void>>;


### PR DESCRIPTION
## Summary
- When creating a new task with worktree enabled, users can now choose which remote branch to base the worktree on
- Adds a searchable dropdown in the TaskModal that fetches remote branches (sorted by most recent commit)
- Threads `baseRef` through to `worktreeClaimReserve` and `worktreeCreate` calls

## Test plan
- [ ] Open a project, click "New Task" — verify branches load (spinner → dropdown)
- [ ] Search/filter branches in the dropdown, select a non-default branch
- [ ] Create task → confirm worktree is based on chosen branch
- [ ] Toggle worktree off → branch selector hides with animation
- [ ] Test error case: disconnect network, open modal → should show error with retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)