### PR TITLE
Remove .dmg download link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ The main idea: you open a project, create tasks, and each task gets an isolated 
 
 ## Install
 
-Download the latest `.dmg` from [Releases](https://github.com/syv-ai/dash/releases).
-
-Or build and install locally:
+Build and install locally:
 
 ```bash
 git clone git@github.com:syv-ai/dash.git


### PR DESCRIPTION
## Summary
- Removed the "Download the latest .dmg from Releases" line from the Install section of README.md

## Test plan
- [x] Verify README renders correctly without the removed line

🤖 Generated with [Claude Code](https://claude.com/claude-code)