### PR TITLE
Use Electron Notification API for desktop notifications

### DIFF
--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, app, BrowserWindow } from 'electron';
+import { ipcMain, dialog, app, BrowserWindow, Notification } from 'electron';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import * as fs from 'fs';
@@ -67,6 +67,19 @@ export function registerAppIpc(): void {
     async (_event, opts: { enabled: boolean; message: string }) => {
       const { setDesktopNotification } = await import('../services/ptyManager');
       setDesktopNotification(opts);
+
+      // Fire a test notification when newly enabled so macOS prompts for permission
+      if (opts.enabled) {
+        try {
+          const n = new Notification({
+            title: 'Dash',
+            body: 'Notifications enabled!',
+          });
+          n.show();
+        } catch {
+          // Ignore — user may have denied permission
+        }
+      }
     },
   );
 


### PR DESCRIPTION
## Summary
- Replace `osascript`-based desktop notifications with Electron's native `Notification` API so Dash properly appears in macOS System Settings > Notifications
- Fire a test notification when the user toggles the setting on, triggering the macOS permission prompt
- Remove per-task osascript hook entries; notifications are now handled centrally in the hook server on task stop

## Test plan
- [ ] Enable desktop notifications in Settings, verify macOS permission prompt appears
- [ ] Verify "Dash" now shows up in System Settings > Notifications
- [ ] Run a task to completion, verify native notification fires
- [ ] Disable notifications, verify no notification on task completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)