### PR TITLE
Show task name in notifications, focus on click

### DIFF
--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -62,26 +62,23 @@ export function registerAppIpc(): void {
     }
   });
 
-  ipcMain.on(
-    'app:setDesktopNotification',
-    async (_event, opts: { enabled: boolean; message: string }) => {
-      const { setDesktopNotification } = await import('../services/ptyManager');
-      setDesktopNotification(opts);
+  ipcMain.on('app:setDesktopNotification', async (_event, opts: { enabled: boolean }) => {
+    const { setDesktopNotification } = await import('../services/ptyManager');
+    setDesktopNotification(opts);
 
-      // Fire a test notification when newly enabled so macOS prompts for permission
-      if (opts.enabled) {
-        try {
-          const n = new Notification({
-            title: 'Dash',
-            body: 'Notifications enabled!',
-          });
-          n.show();
-        } catch {
-          // Ignore — user may have denied permission
-        }
+    // Fire a test notification when newly enabled so macOS prompts for permission
+    if (opts.enabled) {
+      try {
+        const n = new Notification({
+          title: 'Dash',
+          body: 'Notifications enabled!',
+        });
+        n.show();
+      } catch {
+        // Ignore — user may have denied permission
       }
-    },
-  );
+    }
+  });
 
   ipcMain.handle('app:detectClaude', async () => {
     try {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -82,9 +82,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.removeListener('app:beforeQuit', handler);
     };
   },
+  onFocusTask: (callback: (taskId: string) => void) => {
+    const handler = (_event: unknown, taskId: string) => callback(taskId);
+    ipcRenderer.on('app:focusTask', handler);
+    return () => {
+      ipcRenderer.removeListener('app:focusTask', handler);
+    };
+  },
 
   // Settings
-  setDesktopNotification: (opts: { enabled: boolean; message: string }) =>
+  setDesktopNotification: (opts: { enabled: boolean }) =>
     ipcRenderer.send('app:setDesktopNotification', opts),
 
   // Git detection

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -18,7 +18,7 @@ interface PtyRecord {
 
 const ptys = new Map<string, PtyRecord>();
 
-export function setDesktopNotification(opts: { enabled: boolean; message: string }): void {
+export function setDesktopNotification(opts: { enabled: boolean }): void {
   hookServer.setDesktopNotification(opts);
 }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -53,20 +53,12 @@ export function App() {
   const [desktopNotification, setDesktopNotification] = useState(() => {
     return localStorage.getItem('desktopNotification') === 'true';
   });
-  const [desktopNotificationMessage, setDesktopNotificationMessage] = useState(() => {
-    return (
-      localStorage.getItem('desktopNotificationMessage') ||
-      'Claude finished and needs your attention'
-    );
-  });
-
   // Sync desktop notification settings to main process
   useEffect(() => {
     window.electronAPI.setDesktopNotification?.({
       enabled: desktopNotification,
-      message: desktopNotificationMessage,
     });
-  }, [desktopNotification, desktopNotificationMessage]);
+  }, [desktopNotification]);
 
   // Activity state — keys are PTY IDs that have active sessions
   const [taskActivity, setTaskActivity] = useState<Record<string, 'busy' | 'idle'>>({});
@@ -120,6 +112,13 @@ export function App() {
   useEffect(() => {
     return window.electronAPI.onBeforeQuit(() => {
       sessionRegistry.saveAllSnapshots();
+    });
+  }, []);
+
+  // Focus a specific task when notification is clicked
+  useEffect(() => {
+    return window.electronAPI.onFocusTask((taskId) => {
+      setActiveTaskId(taskId);
     });
   }, []);
 
@@ -830,11 +829,6 @@ export function App() {
           onDesktopNotificationChange={(v) => {
             setDesktopNotification(v);
             localStorage.setItem('desktopNotification', String(v));
-          }}
-          desktopNotificationMessage={desktopNotificationMessage}
-          onDesktopNotificationMessageChange={(v) => {
-            setDesktopNotificationMessage(v);
-            localStorage.setItem('desktopNotificationMessage', v);
           }}
           keybindings={keybindings}
           onKeybindingsChange={(b) => {

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -19,8 +19,6 @@ interface SettingsModalProps {
   onNotificationSoundChange: (value: NotificationSound) => void;
   desktopNotification: boolean;
   onDesktopNotificationChange: (value: boolean) => void;
-  desktopNotificationMessage: string;
-  onDesktopNotificationMessageChange: (value: string) => void;
   keybindings: KeyBindingMap;
   onKeybindingsChange: (bindings: KeyBindingMap) => void;
   onClose: () => void;
@@ -111,8 +109,6 @@ export function SettingsModal({
   onNotificationSoundChange,
   desktopNotification,
   onDesktopNotificationChange,
-  desktopNotificationMessage,
-  onDesktopNotificationMessageChange,
   keybindings,
   onKeybindingsChange,
   onClose,
@@ -317,17 +313,8 @@ export function SettingsModal({
                   </div>
                   Show macOS notification when a task finishes
                 </button>
-                {desktopNotification && (
-                  <input
-                    type="text"
-                    value={desktopNotificationMessage}
-                    onChange={(e) => onDesktopNotificationMessageChange(e.target.value)}
-                    placeholder="Notification message..."
-                    className="mt-2 w-full px-3 py-2 rounded-lg text-[12px] border border-border/60 bg-transparent text-foreground placeholder:text-muted-foreground/30 focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary/40 transition-all duration-150"
-                  />
-                )}
                 <p className="text-[10px] text-muted-foreground/40 mt-2">
-                  Takes effect for newly started tasks
+                  Notification will include the task name
                 </p>
               </div>
 

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -100,9 +100,10 @@ export interface ElectronAPI {
 
   // App lifecycle
   onBeforeQuit: (callback: () => void) => () => void;
+  onFocusTask: (callback: (taskId: string) => void) => () => void;
 
   // Settings
-  setDesktopNotification: (opts: { enabled: boolean; message: string }) => void;
+  setDesktopNotification: (opts: { enabled: boolean }) => void;
 
   // Git detection
   detectGit: (


### PR DESCRIPTION
## Summary
- Notifications now show which task finished (e.g. `"my-task" finished`) by looking up the task name from SQLite
- Clicking a notification brings the window to front and switches to that task
- Notifications are suppressed when the app window is already focused
- Removed the custom message text input from settings (no longer needed)

## Test plan
- [ ] Enable desktop notifications in settings, run a task while app is unfocused — notification should show the task name
- [ ] Click the notification — app should come to front with that task selected
- [ ] Keep app focused while a task finishes — no notification should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)