### PR TITLE
Add Solarized Dark and Nord themes

### DIFF
--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -1,5 +1,16 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { X, Check, AlertCircle, Sun, Moon, Terminal, RotateCcw } from 'lucide-react';
+import {
+  X,
+  Check,
+  AlertCircle,
+  Sun,
+  Moon,
+  Palette,
+  Snowflake,
+  Terminal,
+  RotateCcw,
+  type LucideIcon,
+} from 'lucide-react';
 import type { KeyBindingMap, KeyBinding } from '../keybindings';
 import {
   getBindingKeys,
@@ -9,10 +20,19 @@ import {
 } from '../keybindings';
 import { NOTIFICATION_SOUNDS, SOUND_LABELS } from '../sounds';
 import type { NotificationSound } from '../sounds';
+import type { ThemeId } from '../../shared/types';
+import { THEMES } from '../themes';
+
+const THEME_ICONS: Record<string, LucideIcon> = {
+  Sun,
+  Moon,
+  Palette,
+  Snowflake,
+};
 
 interface SettingsModalProps {
-  theme: 'light' | 'dark';
-  onThemeChange: (theme: 'light' | 'dark') => void;
+  theme: ThemeId;
+  onThemeChange: (theme: ThemeId) => void;
   diffContextLines: number | null;
   onDiffContextLinesChange: (value: number | null) => void;
   notificationSound: NotificationSound;
@@ -205,28 +225,23 @@ export function SettingsModal({
                   Appearance
                 </label>
                 <div className="grid grid-cols-2 gap-2">
-                  <button
-                    onClick={() => onThemeChange('light')}
-                    className={`flex items-center gap-2.5 px-4 py-3 rounded-lg text-[13px] border transition-all duration-150 ${
-                      theme === 'light'
-                        ? 'border-primary/40 bg-primary/8 text-foreground ring-1 ring-primary/20'
-                        : 'border-border/60 text-muted-foreground/60 hover:bg-accent/40 hover:text-foreground'
-                    }`}
-                  >
-                    <Sun size={15} strokeWidth={1.8} />
-                    Light
-                  </button>
-                  <button
-                    onClick={() => onThemeChange('dark')}
-                    className={`flex items-center gap-2.5 px-4 py-3 rounded-lg text-[13px] border transition-all duration-150 ${
-                      theme === 'dark'
-                        ? 'border-primary/40 bg-primary/8 text-foreground ring-1 ring-primary/20'
-                        : 'border-border/60 text-muted-foreground/60 hover:bg-accent/40 hover:text-foreground'
-                    }`}
-                  >
-                    <Moon size={15} strokeWidth={1.8} />
-                    Dark
-                  </button>
+                  {THEMES.map((t) => {
+                    const Icon = THEME_ICONS[t.icon];
+                    return (
+                      <button
+                        key={t.id}
+                        onClick={() => onThemeChange(t.id)}
+                        className={`flex items-center gap-2.5 px-4 py-3 rounded-lg text-[13px] border transition-all duration-150 ${
+                          theme === t.id
+                            ? 'border-primary/40 bg-primary/8 text-foreground ring-1 ring-primary/20'
+                            : 'border-border/60 text-muted-foreground/60 hover:bg-accent/40 hover:text-foreground'
+                        }`}
+                      >
+                        {Icon && <Icon size={15} strokeWidth={1.8} />}
+                        {t.label}
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
 

--- a/src/renderer/components/TerminalPane.tsx
+++ b/src/renderer/components/TerminalPane.tsx
@@ -84,7 +84,7 @@ export function TerminalPane({ id, cwd, autoApprove }: TerminalPaneProps) {
       <div ref={containerRef} className="terminal-container w-full h-full" />
       {showOverlay && (
         <div
-          className="absolute inset-0 z-10 pointer-events-none dark:bg-[#1f1f1f] bg-[#fafafa] flex flex-col items-center justify-center gap-4"
+          className="absolute inset-0 z-10 pointer-events-none bg-background flex flex-col items-center justify-center gap-4"
           style={{
             opacity: overlayVisible ? 1 : 0,
             transition: `opacity ${OVERLAY_FADE_MS}ms ease-out`,
@@ -106,25 +106,10 @@ export function TerminalPane({ id, cwd, autoApprove }: TerminalPaneProps) {
               </linearGradient>
             </defs>
             <rect width="512" height="512" rx="108" fill="url(#restart-bg)" />
-            <rect
-              x="136"
-              y="240"
-              width="240"
-              height="36"
-              rx="18"
-              fill="url(#restart-dash)"
-            />
-            <rect
-              x="396"
-              y="232"
-              width="4"
-              height="52"
-              rx="2"
-              fill="#00ff88"
-              opacity="0.7"
-            />
+            <rect x="136" y="240" width="240" height="36" rx="18" fill="url(#restart-dash)" />
+            <rect x="396" y="232" width="4" height="52" rx="2" fill="#00ff88" opacity="0.7" />
           </svg>
-          <span className="text-[13px] dark:text-neutral-400 text-neutral-500 font-medium">
+          <span className="text-[13px] text-muted-foreground font-medium">
             Resuming your session...
           </span>
         </div>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -78,6 +78,78 @@
     --git-untracked: 0 0% 56%;
     --git-conflicted: 25 95% 53%;
   }
+
+  .solarized-dark {
+    /* Solarized Dark — base03 bg (#002b36), base0 fg (#839496), yellow primary (#b58900) */
+    --background: 192 100% 11%;
+    --foreground: 186 13% 55%;
+    --card: 192 81% 14%;
+    --card-foreground: 186 13% 55%;
+    --popover: 192 81% 14%;
+    --popover-foreground: 186 13% 55%;
+    --primary: 45 100% 35%;
+    --primary-foreground: 192 100% 11%;
+    --secondary: 192 81% 14%;
+    --secondary-foreground: 186 13% 55%;
+    --muted: 192 81% 14%;
+    --muted-foreground: 186 8% 44%;
+    --accent: 192 49% 18%;
+    --accent-foreground: 186 13% 55%;
+    --destructive: 1 71% 52%;
+    --destructive-foreground: 44 87% 94%;
+    --border: 192 49% 18%;
+    --input: 192 49% 20%;
+    --ring: 45 100% 35%;
+    --radius: 0.5rem;
+
+    --surface-0: 192 100% 11%;
+    --surface-1: 192 81% 14%;
+    --surface-2: 192 49% 17%;
+    --surface-3: 192 49% 20%;
+
+    --git-added: 68 100% 30%;
+    --git-modified: 45 100% 35%;
+    --git-deleted: 1 71% 52%;
+    --git-renamed: 205 69% 49%;
+    --git-untracked: 186 8% 44%;
+    --git-conflicted: 18 89% 45%;
+  }
+
+  .nord {
+    /* Nord — polar night bg (#2e3440), snow storm fg (#d8dee9), frost blue primary (#5e81ac) */
+    --background: 220 16% 22%;
+    --foreground: 213 27% 84%;
+    --card: 220 17% 24%;
+    --card-foreground: 213 27% 84%;
+    --popover: 220 17% 24%;
+    --popover-foreground: 213 27% 84%;
+    --primary: 213 32% 52%;
+    --primary-foreground: 220 16% 22%;
+    --secondary: 220 17% 27%;
+    --secondary-foreground: 213 27% 84%;
+    --muted: 220 17% 27%;
+    --muted-foreground: 219 16% 50%;
+    --accent: 220 17% 30%;
+    --accent-foreground: 213 27% 84%;
+    --destructive: 354 42% 56%;
+    --destructive-foreground: 219 28% 88%;
+    --border: 220 17% 27%;
+    --input: 220 17% 30%;
+    --ring: 213 32% 52%;
+    --radius: 0.5rem;
+
+    --surface-0: 220 16% 22%;
+    --surface-1: 220 17% 24%;
+    --surface-2: 220 17% 27%;
+    --surface-3: 220 17% 30%;
+
+    --git-added: 92 28% 65%;
+    --git-modified: 40 71% 73%;
+    --git-deleted: 354 42% 56%;
+    --git-renamed: 193 43% 67%;
+    --git-untracked: 219 16% 50%;
+    --git-conflicted: 14 51% 63%;
+  }
 }
 
 @layer base {
@@ -276,7 +348,7 @@
   background: hsl(var(--primary) / 0.12) !important;
 }
 .diff-line-commented {
-  border-left: 2px solid hsl(var(--primary) / 0.50);
+  border-left: 2px solid hsl(var(--primary) / 0.5);
 }
 .diff-gutter-clickable {
   cursor: pointer;
@@ -287,7 +359,9 @@
 
 /* ── Panel Collapse/Expand Animation ─────────────────────── */
 .panel-transition {
-  transition: flex-grow 200ms ease-out, flex-shrink 200ms ease-out;
+  transition:
+    flex-grow 200ms ease-out,
+    flex-shrink 200ms ease-out;
 }
 
 /* ── File Item Enter Animation ───────────────────────────── */

--- a/src/renderer/terminal/SessionRegistry.ts
+++ b/src/renderer/terminal/SessionRegistry.ts
@@ -1,3 +1,4 @@
+import type { ThemeId } from '../../shared/types';
 import { TerminalSessionManager } from './TerminalSessionManager';
 
 interface AttachOptions {
@@ -9,7 +10,7 @@ interface AttachOptions {
 
 class SessionRegistryImpl {
   private sessions = new Map<string, TerminalSessionManager>();
-  private _isDark = true;
+  private _themeId: ThemeId = 'dark';
 
   getOrCreate(opts: Omit<AttachOptions, 'container'>): TerminalSessionManager {
     let session = this.sessions.get(opts.id);
@@ -18,7 +19,7 @@ class SessionRegistryImpl {
         id: opts.id,
         cwd: opts.cwd,
         autoApprove: opts.autoApprove,
-        isDark: this._isDark,
+        themeId: this._themeId,
       });
       this.sessions.set(opts.id, session);
     }
@@ -54,10 +55,10 @@ class SessionRegistryImpl {
     }
   }
 
-  setAllThemes(isDark: boolean): void {
-    this._isDark = isDark;
+  setAllThemes(themeId: ThemeId): void {
+    this._themeId = themeId;
     for (const session of this.sessions.values()) {
-      session.setTheme(isDark);
+      session.setTheme(themeId);
     }
   }
 

--- a/src/renderer/themes.ts
+++ b/src/renderer/themes.ts
@@ -1,0 +1,123 @@
+import type { ITheme } from 'xterm';
+import type { ThemeId } from '../shared/types';
+
+export interface ThemeMeta {
+  id: ThemeId;
+  label: string;
+  isDark: boolean;
+  icon: string; // lucide-react icon name
+}
+
+export const THEMES: ThemeMeta[] = [
+  { id: 'light', label: 'Light', isDark: false, icon: 'Sun' },
+  { id: 'dark', label: 'Dark', isDark: true, icon: 'Moon' },
+  { id: 'solarized-dark', label: 'Solarized', isDark: true, icon: 'Palette' },
+  { id: 'nord', label: 'Nord', isDark: true, icon: 'Snowflake' },
+];
+
+export function isThemeDark(id: ThemeId): boolean {
+  return THEMES.find((t) => t.id === id)?.isDark ?? true;
+}
+
+const lightTheme: ITheme = {
+  background: '#fafafa',
+  foreground: '#383a42',
+  cursor: '#383a42',
+  cursorAccent: '#fafafa',
+  selectionBackground: '#bfceff',
+  black: '#383a42',
+  red: '#e45649',
+  green: '#50a14f',
+  yellow: '#c18401',
+  blue: '#4078f2',
+  magenta: '#a626a4',
+  cyan: '#0184bc',
+  white: '#a0a1a7',
+  brightBlack: '#696c77',
+  brightRed: '#e45649',
+  brightGreen: '#50a14f',
+  brightYellow: '#c18401',
+  brightBlue: '#4078f2',
+  brightMagenta: '#a626a4',
+  brightCyan: '#0184bc',
+  brightWhite: '#ffffff',
+};
+
+const darkTheme: ITheme = {
+  background: '#1f1f1f',
+  foreground: '#d4d4d4',
+  cursor: '#d4d4d4',
+  cursorAccent: '#1f1f1f',
+  selectionBackground: '#3a3a5a',
+  black: '#000000',
+  red: '#e06c75',
+  green: '#98c379',
+  yellow: '#e5c07b',
+  blue: '#61afef',
+  magenta: '#c678dd',
+  cyan: '#56b6c2',
+  white: '#d4d4d4',
+  brightBlack: '#5c6370',
+  brightRed: '#e06c75',
+  brightGreen: '#98c379',
+  brightYellow: '#e5c07b',
+  brightBlue: '#61afef',
+  brightMagenta: '#c678dd',
+  brightCyan: '#56b6c2',
+  brightWhite: '#ffffff',
+};
+
+const solarizedDarkTheme: ITheme = {
+  background: '#002b36',
+  foreground: '#839496',
+  cursor: '#839496',
+  cursorAccent: '#002b36',
+  selectionBackground: '#073642',
+  black: '#073642',
+  red: '#dc322f',
+  green: '#859900',
+  yellow: '#b58900',
+  blue: '#268bd2',
+  magenta: '#d33682',
+  cyan: '#2aa198',
+  white: '#eee8d5',
+  brightBlack: '#586e75',
+  brightRed: '#cb4b16',
+  brightGreen: '#586e75',
+  brightYellow: '#657b83',
+  brightBlue: '#839496',
+  brightMagenta: '#6c71c4',
+  brightCyan: '#93a1a1',
+  brightWhite: '#fdf6e3',
+};
+
+const nordTheme: ITheme = {
+  background: '#2e3440',
+  foreground: '#d8dee9',
+  cursor: '#d8dee9',
+  cursorAccent: '#2e3440',
+  selectionBackground: '#434c5e',
+  black: '#3b4252',
+  red: '#bf616a',
+  green: '#a3be8c',
+  yellow: '#ebcb8b',
+  blue: '#81a1c1',
+  magenta: '#b48ead',
+  cyan: '#88c0d0',
+  white: '#e5e9f0',
+  brightBlack: '#4c566a',
+  brightRed: '#bf616a',
+  brightGreen: '#a3be8c',
+  brightYellow: '#ebcb8b',
+  brightBlue: '#81a1c1',
+  brightMagenta: '#b48ead',
+  brightCyan: '#8fbcbb',
+  brightWhite: '#eceff4',
+};
+
+export const TERMINAL_THEMES: Record<ThemeId, ITheme> = {
+  light: lightTheme,
+  dark: darkTheme,
+  'solarized-dark': solarizedDarkTheme,
+  nord: nordTheme,
+};

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,3 +1,5 @@
+export type ThemeId = 'light' | 'dark' | 'solarized-dark' | 'nord';
+
 export interface Project {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- Extends the binary light/dark theme system to support named themes via a central registry (`src/renderer/themes.ts`)
- Adds **Solarized Dark** and **Nord** as built-in themes, each with full CSS custom properties and matching xterm terminal colors
- Settings modal now shows a 2x2 theme picker grid; dark-toned themes retain the `dark` class so Tailwind `dark:` variants keep working

## Test plan
- [ ] `pnpm dev` — app starts without errors
- [ ] Open Settings → Appearance: 4 theme buttons visible in 2x2 grid
- [ ] Click each theme — UI colors change instantly, terminal colors update
- [ ] Close and reopen app — selected theme persists
- [ ] Create a new task with terminal, switch themes — terminal redraws correctly
- [ ] `pnpm type-check` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)