### PR TITLE
Remove extra spacing above terminal drawer

### DIFF
--- a/src/renderer/components/ShellDrawerWrapper.tsx
+++ b/src/renderer/components/ShellDrawerWrapper.tsx
@@ -43,10 +43,8 @@ export function ShellDrawerWrapper({
       <Panel minSize={20}>{children}</Panel>
       <PanelResizeHandle
         disabled={collapsed}
-        className="h-5 flex items-end"
-      >
-        <div className="h-[1px] w-full bg-border" />
-      </PanelResizeHandle>
+        className="h-[1px] bg-border"
+      />
       <Panel
         ref={panelRef}
         className={animating ? 'panel-transition' : ''}


### PR DESCRIPTION
## Summary
- Reduced the PanelResizeHandle from 20px (h-5) to 1px between the main terminal and the shell drawer
- Eliminates the dark gap that appeared above the `>_ TERMINAL` header

## Test plan
- [ ] Open a task with the terminal drawer visible
- [ ] Verify no black bar/spacing appears above the terminal drawer header


🤖 Generated with [Claude Code](https://claude.com/claude-code)