### PR TITLE
Add permission prompt awareness via Notification hook

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -60,8 +60,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Activity monitor
   ptyGetAllActivity: () => ipcRenderer.invoke('pty:activity:getAll'),
-  onPtyActivity: (callback: (data: Record<string, 'busy' | 'idle'>) => void) => {
-    const handler = (_event: unknown, data: Record<string, 'busy' | 'idle'>) => callback(data);
+  onPtyActivity: (callback: (data: Record<string, 'busy' | 'idle' | 'waiting'>) => void) => {
+    const handler = (_event: unknown, data: Record<string, 'busy' | 'idle' | 'waiting'>) =>
+      callback(data);
     ipcRenderer.on('pty:activity', handler);
     return () => {
       ipcRenderer.removeListener('pty:activity', handler);

--- a/src/main/services/ActivityMonitor.ts
+++ b/src/main/services/ActivityMonitor.ts
@@ -4,7 +4,7 @@ import type { WebContents } from 'electron';
 
 const execFileAsync = promisify(execFile);
 
-type ActivityState = 'busy' | 'idle';
+type ActivityState = 'busy' | 'idle' | 'waiting';
 
 interface PtyActivity {
   pid: number;
@@ -47,6 +47,17 @@ class ActivityMonitorImpl {
     const activity = this.activities.get(ptyId);
     if (!activity || activity.state === 'busy') return;
     activity.state = 'busy';
+    this.emitAll();
+  }
+
+  /**
+   * Immediately transition a PTY to waiting (permission prompt).
+   * Called by HookServer when a Notification hook fires with permission_prompt.
+   */
+  setWaitingForPermission(ptyId: string): void {
+    const activity = this.activities.get(ptyId);
+    if (!activity || activity.state === 'waiting') return;
+    activity.state = 'waiting';
     this.emitAll();
   }
 

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -182,6 +182,17 @@ function writeHookSettings(cwd: string, ptyId: string): void {
     UserPromptSubmit: [
       { hooks: [{ type: 'command', command: `${curlBase}/hook/busy?ptyId=${ptyId}` }] },
     ],
+    Notification: [
+      {
+        matcher: 'permission_prompt',
+        hooks: [
+          {
+            type: 'command',
+            command: `curl -s --connect-timeout 2 -X POST -H "Content-Type: application/json" -d @- http://127.0.0.1:${port}/hook/notification?ptyId=${ptyId}`,
+          },
+        ],
+      },
+    ],
   };
 
   // Auto-detect task-context.json and inject SessionStart hook if it exists

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -88,7 +88,7 @@ export function App() {
   }, [commitAttribution]);
 
   // Activity state — keys are PTY IDs that have active sessions
-  const [taskActivity, setTaskActivity] = useState<Record<string, 'busy' | 'idle'>>({});
+  const [taskActivity, setTaskActivity] = useState<Record<string, 'busy' | 'idle' | 'waiting'>>({});
 
   const notificationSoundRef = useRef(notificationSound);
   useEffect(() => {
@@ -155,7 +155,7 @@ export function App() {
 
   // Activity monitor — subscribe first, then query to avoid race
   useEffect(() => {
-    const prevActivity: Record<string, 'busy' | 'idle'> = {};
+    const prevActivity: Record<string, 'busy' | 'idle' | 'waiting'> = {};
     // Track PTYs that have been idle at least once, so we skip the initial
     // busy→idle transition that fires when a direct-spawn PTY first registers.
     const hasBeenIdle = new Set<string>();
@@ -171,6 +171,7 @@ export function App() {
         }
       }
       // Detect any busy→idle transition (only for PTYs that completed a full work cycle)
+      // Skip transitions from 'waiting' — those are not task completions
       for (const [id, state] of Object.entries(newActivity)) {
         if (prevActivity[id] === 'busy' && state === 'idle' && hasBeenIdle.has(id)) {
           playNotificationSound(notificationSoundRef.current);

--- a/src/renderer/components/LeftSidebar.tsx
+++ b/src/renderer/components/LeftSidebar.tsx
@@ -33,7 +33,7 @@ interface LeftSidebarProps {
   onShowCommitGraph: (projectId: string) => void;
   collapsed: boolean;
   onToggleCollapse: () => void;
-  taskActivity: Record<string, 'busy' | 'idle'>;
+  taskActivity: Record<string, 'busy' | 'idle' | 'waiting'>;
 }
 
 export function LeftSidebar({
@@ -82,8 +82,9 @@ export function LeftSidebar({
     });
   }
 
-  function projectActivity(projectId: string): 'busy' | 'idle' | null {
+  function projectActivity(projectId: string): 'busy' | 'idle' | 'waiting' | null {
     const tasks = (tasksByProject[projectId] || []).filter((t) => !t.archivedAt);
+    if (tasks.some((t) => taskActivity[t.id] === 'waiting')) return 'waiting';
     if (tasks.some((t) => taskActivity[t.id] === 'busy')) return 'busy';
     if (tasks.some((t) => taskActivity[t.id] === 'idle')) return 'idle';
     return null;
@@ -135,7 +136,11 @@ export function LeftSidebar({
                 {activity && (
                   <div
                     className={`absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full border-2 border-[hsl(var(--surface-1))] ${
-                      activity === 'busy' ? 'bg-amber-400 status-pulse' : 'bg-emerald-400'
+                      activity === 'waiting'
+                        ? 'bg-orange-500'
+                        : activity === 'busy'
+                          ? 'bg-amber-400 status-pulse'
+                          : 'bg-emerald-400'
                     }`}
                   />
                 )}
@@ -163,14 +168,16 @@ export function LeftSidebar({
     <div className="h-full flex flex-col" style={{ background: 'hsl(var(--surface-1))' }}>
       {/* Header */}
       <div className="flex items-center justify-between px-4 pt-3 pb-1">
-        <span className="text-sm font-medium text-muted-foreground/50 select-none">
-          Projects
-        </span>
+        <span className="text-sm font-medium text-muted-foreground/50 select-none">Projects</span>
         <div className="flex items-center gap-1">
           <IconButton onClick={onOpenFolder} title="Add project" className="titlebar-no-drag">
             <FolderOpen size={15} strokeWidth={1.8} />
           </IconButton>
-          <IconButton onClick={onToggleCollapse} title="Collapse sidebar" className="titlebar-no-drag">
+          <IconButton
+            onClick={onToggleCollapse}
+            title="Collapse sidebar"
+            className="titlebar-no-drag"
+          >
             <PanelLeftClose size={15} strokeWidth={1.8} />
           </IconButton>
         </div>
@@ -311,7 +318,9 @@ export function LeftSidebar({
                             onClick={() => onSelectTask(project.id, task.id)}
                           >
                             {/* Status indicator */}
-                            {activity === 'busy' ? (
+                            {activity === 'waiting' ? (
+                              <div className="w-[6px] h-[6px] rounded-full bg-orange-500 flex-shrink-0" />
+                            ) : activity === 'busy' ? (
                               <div className="w-[6px] h-[6px] rounded-full bg-amber-400 status-pulse flex-shrink-0" />
                             ) : activity === 'idle' ? (
                               <div className="w-[6px] h-[6px] rounded-full bg-emerald-400 flex-shrink-0" />

--- a/src/renderer/components/MainContent.tsx
+++ b/src/renderer/components/MainContent.tsx
@@ -21,7 +21,7 @@ interface MainContentProps {
   sidebarCollapsed?: boolean;
   tasks?: Task[];
   activeTaskId?: string | null;
-  taskActivity?: Record<string, 'busy' | 'idle'>;
+  taskActivity?: Record<string, 'busy' | 'idle' | 'waiting'>;
   onSelectTask?: (id: string) => void;
 }
 
@@ -41,12 +41,8 @@ export function MainContent({
           <div className="w-14 h-14 rounded-2xl bg-accent/60 flex items-center justify-center mx-auto mb-4">
             <FolderOpen size={22} className="text-muted-foreground/40" strokeWidth={1.5} />
           </div>
-          <h2 className="text-[15px] font-semibold text-foreground/80 mb-1.5">
-            Dash
-          </h2>
-          <p className="text-[13px] text-muted-foreground/60">
-            Open a folder to get started
-          </p>
+          <h2 className="text-[15px] font-semibold text-foreground/80 mb-1.5">Dash</h2>
+          <p className="text-[13px] text-muted-foreground/60">Open a folder to get started</p>
         </div>
       </div>
     );
@@ -66,9 +62,13 @@ export function MainContent({
             Create a task to start a Claude session
           </p>
           <div className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-accent/40 text-[11px] text-muted-foreground/50">
-            <kbd className="px-1.5 py-0.5 rounded bg-accent text-[10px] font-mono font-medium">Cmd</kbd>
+            <kbd className="px-1.5 py-0.5 rounded bg-accent text-[10px] font-mono font-medium">
+              Cmd
+            </kbd>
             <span>+</span>
-            <kbd className="px-1.5 py-0.5 rounded bg-accent text-[10px] font-mono font-medium">N</kbd>
+            <kbd className="px-1.5 py-0.5 rounded bg-accent text-[10px] font-mono font-medium">
+              N
+            </kbd>
           </div>
         </div>
       </div>
@@ -76,7 +76,10 @@ export function MainContent({
   }
 
   const taskHeader = (
-    <div className="flex items-center gap-3 px-4 h-10 flex-shrink-0 border-b border-border/60" style={{ background: 'hsl(var(--surface-1))' }}>
+    <div
+      className="flex items-center gap-3 px-4 h-10 flex-shrink-0 border-b border-border/60"
+      style={{ background: 'hsl(var(--surface-1))' }}
+    >
       {sidebarCollapsed && tasks.length > 0 ? (
         <>
           <div className="flex items-center gap-0.5 overflow-x-auto scrollbar-none flex-1 min-w-0">
@@ -92,11 +95,13 @@ export function MainContent({
               >
                 <span
                   className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
-                    taskActivity[task.id] === 'busy'
-                      ? 'bg-amber-400 animate-pulse'
-                      : taskActivity[task.id] === 'idle'
-                        ? 'bg-green-400'
-                        : 'bg-muted-foreground/30'
+                    taskActivity[task.id] === 'waiting'
+                      ? 'bg-orange-500'
+                      : taskActivity[task.id] === 'busy'
+                        ? 'bg-amber-400 animate-pulse'
+                        : taskActivity[task.id] === 'idle'
+                          ? 'bg-green-400'
+                          : 'bg-muted-foreground/30'
                   }`}
                 />
                 <span className="truncate max-w-[140px]">{task.name}</span>

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -111,8 +111,10 @@ export interface ElectronAPI {
   ) => () => void;
 
   // Activity monitor
-  ptyGetAllActivity: () => Promise<IpcResponse<Record<string, 'busy' | 'idle'>>>;
-  onPtyActivity: (callback: (data: Record<string, 'busy' | 'idle'>) => void) => () => void;
+  ptyGetAllActivity: () => Promise<IpcResponse<Record<string, 'busy' | 'idle' | 'waiting'>>>;
+  onPtyActivity: (
+    callback: (data: Record<string, 'busy' | 'idle' | 'waiting'>) => void,
+  ) => () => void;
 
   // Snapshots
   ptyGetSnapshot: (id: string) => Promise<IpcResponse<TerminalSnapshot | null>>;


### PR DESCRIPTION
## Summary
- Registers a Claude Code `Notification` hook (matcher: `permission_prompt`) that POSTs stdin JSON to a new `/hook/notification` endpoint on HookServer
- Adds a `'waiting'` activity state alongside `'busy'` and `'idle'` — when Claude is blocked on a permission prompt, the task indicator turns static orange (`bg-orange-500`)
- Shows a desktop notification "{taskName} needs permission" with click-to-focus behavior
- State automatically clears when the user responds (UserPromptSubmit → busy) or Claude finishes (Stop → idle)

## Files changed
- `HookServer.ts` — new POST `/hook/notification` endpoint, parameterized `showDesktopNotification`, `getTaskName` helper
- `ActivityMonitor.ts` — `'waiting'` state + `setWaitingForPermission()` method
- `ptyManager.ts` — registers `Notification` hook in `writeHookSettings()`
- `preload.ts`, `electron-api.d.ts` — updated activity type to include `'waiting'`
- `App.tsx` — handles `'waiting'` in activity subscription (no sound on waiting)
- `LeftSidebar.tsx`, `MainContent.tsx` — orange indicator for waiting state

## Test plan
- [ ] Start a task in default mode (not yolo), ask Claude to do something requiring permission
- [ ] Verify sidebar indicator turns orange when permission prompt appears
- [ ] Verify desktop notification fires when Dash is not focused
- [ ] Verify clicking notification focuses Dash on the correct task
- [ ] Verify indicator returns to amber/green after granting permission
- [ ] Manual curl test: `curl -s -X POST -H "Content-Type: application/json" -d '{"notification_type":"permission_prompt"}' http://127.0.0.1:<PORT>/hook/notification?ptyId=<ID>`
- [ ] `pnpm type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)