### PR TITLE
Add remote control with QR code sharing

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,10 +62,12 @@
     ]
   },
   "dependencies": {
+    "@types/qrcode": "^1.5.6",
     "better-sqlite3": "^11.7.0",
     "drizzle-orm": "^0.32.0",
     "electron-log": "^5.1.0",
     "node-pty": "^1.0.0",
+    "qrcode": "^1.5.4",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "sonner": "^2.0.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       better-sqlite3:
         specifier: ^11.7.0
         version: 11.10.0
@@ -20,6 +23,9 @@ importers:
       node-pty:
         specifier: ^1.0.0
         version: 1.1.0
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       react:
         specifier: ^18.3.0
         version: 18.3.1
@@ -1003,6 +1009,9 @@ packages:
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
+
   '@types/react-dom@18.3.7':
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
@@ -1336,6 +1345,10 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
   caniuse-lite@1.0.30001769:
     resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
 
@@ -1387,6 +1400,9 @@ packages:
   cli-truncate@5.1.1:
     resolution: {integrity: sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==}
     engines: {node: '>=20'}
+
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1494,6 +1510,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -1536,6 +1556,9 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   dir-compare@3.3.0:
     resolution: {integrity: sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg==}
@@ -1842,6 +1865,10 @@ packages:
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
   find-up@5.0.0:
@@ -2208,6 +2235,10 @@ packages:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2467,9 +2498,17 @@ packages:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -2478,6 +2517,10 @@ packages:
   p-map@4.0.0:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -2539,6 +2582,10 @@ packages:
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
+
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -2631,6 +2678,11 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -2720,6 +2772,9 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
 
@@ -2808,6 +2863,9 @@ packages:
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3135,6 +3193,9 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3143,6 +3204,10 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -3167,6 +3232,9 @@ packages:
     resolution: {integrity: sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==}
     deprecated: This package is now deprecated. Move to @xterm/xterm instead.
 
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -3182,9 +3250,17 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -4048,6 +4124,10 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 22.19.10
+
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
       '@types/react': 18.3.28
@@ -4484,6 +4564,8 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
+  camelcase@5.3.1: {}
+
   caniuse-lite@1.0.30001769: {}
 
   chalk@4.1.2:
@@ -4537,6 +4619,12 @@ snapshots:
     dependencies:
       slice-ansi: 7.1.2
       string-width: 8.1.1
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
 
   cliui@8.0.1:
     dependencies:
@@ -4635,6 +4723,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -4673,6 +4763,8 @@ snapshots:
     optional: true
 
   didyoumean@1.2.2: {}
+
+  dijkstrajs@1.0.3: {}
 
   dir-compare@3.3.0:
     dependencies:
@@ -4984,6 +5076,11 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
 
   find-up@5.0.0:
     dependencies:
@@ -5368,6 +5465,10 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -5615,9 +5716,17 @@ snapshots:
 
   p-cancelable@2.1.1: {}
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
 
   p-locate@5.0.0:
     dependencies:
@@ -5626,6 +5735,8 @@ snapshots:
   p-map@4.0.0:
     dependencies:
       aggregate-error: 3.1.0
+
+  p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -5667,6 +5778,8 @@ snapshots:
       '@xmldom/xmldom': 0.8.11
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
+
+  pngjs@5.0.0: {}
 
   postcss-import@15.1.0(postcss@8.5.6):
     dependencies:
@@ -5744,6 +5857,12 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
 
   queue-microtask@1.2.3: {}
 
@@ -5844,6 +5963,8 @@ snapshots:
       picomatch: 2.3.1
 
   require-directory@2.1.1: {}
+
+  require-main-filename@2.0.0: {}
 
   resolve-alpn@1.2.1: {}
 
@@ -5955,6 +6076,8 @@ snapshots:
     dependencies:
       type-fest: 0.13.1
     optional: true
+
+  set-blocking@2.0.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -6281,11 +6404,19 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  which-module@2.0.1: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -6311,6 +6442,8 @@ snapshots:
 
   xterm@5.3.0: {}
 
+  y18n@4.0.3: {}
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
@@ -6319,7 +6452,26 @@ snapshots:
 
   yaml@2.8.2: {}
 
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@21.1.1: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@17.7.2:
     dependencies:

--- a/src/main/ipc/ptyIpc.ts
+++ b/src/main/ipc/ptyIpc.ts
@@ -11,9 +11,11 @@ import {
   killPty,
   killByOwner,
   writeTaskContext,
+  sendRemoteControl,
 } from '../services/ptyManager';
 import { terminalSnapshotService } from '../services/TerminalSnapshotService';
 import { activityMonitor } from '../services/ActivityMonitor';
+import { remoteControlService } from '../services/remoteControlService';
 
 export function registerPtyIpc(): void {
   ipcMain.handle(
@@ -129,6 +131,20 @@ export function registerPtyIpc(): void {
   // Activity monitor
   ipcMain.handle('pty:activity:getAll', () => {
     return { success: true, data: activityMonitor.getAll() };
+  });
+
+  // Remote control
+  ipcMain.handle('pty:remoteControl:enable', (_event, ptyId: string) => {
+    try {
+      sendRemoteControl(ptyId);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle('pty:remoteControl:getAllStates', () => {
+    return { success: true, data: remoteControlService.getAllStates() };
   });
 }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -98,6 +98,10 @@ app.whenReady().then(async () => {
   const { activityMonitor } = await import('./services/ActivityMonitor');
   activityMonitor.start(mainWindow.webContents);
 
+  // Remote control service needs a sender for state change events
+  const { remoteControlService } = await import('./services/remoteControlService');
+  remoteControlService.setSender(mainWindow.webContents);
+
   // Cleanup orphaned reserve worktrees (background, non-blocking)
   setTimeout(async () => {
     try {
@@ -154,6 +158,8 @@ app.on('activate', async () => {
     mainWindow = createWindow();
     const { activityMonitor } = await import('./services/ActivityMonitor');
     activityMonitor.start(mainWindow.webContents);
+    const { remoteControlService } = await import('./services/remoteControlService');
+    remoteControlService.setSender(mainWindow.webContents);
   }
 });
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -69,6 +69,23 @@ contextBridge.exposeInMainWorld('electronAPI', {
     };
   },
 
+  // Remote control
+  ptyRemoteControlEnable: (ptyId: string) =>
+    ipcRenderer.invoke('pty:remoteControl:enable', ptyId),
+  ptyRemoteControlGetAllStates: () => ipcRenderer.invoke('pty:remoteControl:getAllStates'),
+  onRemoteControlStateChanged: (
+    callback: (data: { ptyId: string; state: { url: string; active: boolean } | null }) => void,
+  ) => {
+    const handler = (
+      _event: unknown,
+      data: { ptyId: string; state: { url: string; active: boolean } | null },
+    ) => callback(data);
+    ipcRenderer.on('rc:stateChanged', handler);
+    return () => {
+      ipcRenderer.removeListener('rc:stateChanged', handler);
+    };
+  },
+
   // Snapshots
   ptyGetSnapshot: (id: string) => ipcRenderer.invoke('pty:snapshot:get', id),
   ptySaveSnapshot: (id: string, payload: unknown) =>

--- a/src/main/services/remoteControlService.ts
+++ b/src/main/services/remoteControlService.ts
@@ -1,0 +1,95 @@
+import type { WebContents } from 'electron';
+import type { RemoteControlState } from '@shared/types';
+
+const MAX_BUFFER = 8 * 1024;
+const WATCH_TIMEOUT = 15_000;
+
+const URL_REGEX = /https:\/\/claude\.ai\/code\/[a-zA-Z0-9_-]+/;
+
+// Strip ANSI escape sequences so they don't break URL matching
+const ANSI_RE = /\x1b\[[0-9;]*[a-zA-Z]|\x1b\].*?(?:\x07|\x1b\\)/g;
+
+interface Watcher {
+  buffer: string;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+class RemoteControlServiceImpl {
+  private states = new Map<string, RemoteControlState>();
+  private watchers = new Map<string, Watcher>();
+  private sender: WebContents | null = null;
+
+  setSender(sender: WebContents): void {
+    this.sender = sender;
+  }
+
+  startWatching(ptyId: string): void {
+    // Clear any existing watcher
+    this.stopWatching(ptyId);
+
+    const timer = setTimeout(() => {
+      this.stopWatching(ptyId);
+      // Emit null state so the modal can show a timeout/error
+      this.states.delete(ptyId);
+      this.emit(ptyId, null);
+    }, WATCH_TIMEOUT);
+
+    this.watchers.set(ptyId, { buffer: '', timer });
+  }
+
+  onPtyData(ptyId: string, data: string): void {
+    const watcher = this.watchers.get(ptyId);
+    if (!watcher) return;
+
+    watcher.buffer += data;
+    // Trim buffer if it gets too large
+    if (watcher.buffer.length > MAX_BUFFER) {
+      watcher.buffer = watcher.buffer.slice(-MAX_BUFFER);
+    }
+
+    const clean = watcher.buffer.replace(ANSI_RE, '');
+    const match = clean.match(URL_REGEX);
+    if (match) {
+      const url = match[0];
+      const state: RemoteControlState = { url, active: true };
+      this.states.set(ptyId, state);
+      this.stopWatching(ptyId);
+      this.emit(ptyId, state);
+    }
+  }
+
+  unregister(ptyId: string): void {
+    this.stopWatching(ptyId);
+    if (this.states.delete(ptyId)) {
+      this.emit(ptyId, null);
+    }
+  }
+
+  getState(ptyId: string): RemoteControlState | null {
+    return this.states.get(ptyId) ?? null;
+  }
+
+  getAllStates(): Record<string, RemoteControlState> {
+    const result: Record<string, RemoteControlState> = {};
+    for (const [id, state] of this.states) {
+      result[id] = state;
+    }
+    return result;
+  }
+
+  private stopWatching(ptyId: string): void {
+    const watcher = this.watchers.get(ptyId);
+    if (watcher) {
+      clearTimeout(watcher.timer);
+      this.watchers.delete(ptyId);
+    }
+  }
+
+  private emit(ptyId: string, state: RemoteControlState | null): void {
+    if (this.sender && !this.sender.isDestroyed()) {
+      this.sender.send('rc:stateChanged', { ptyId, state });
+    }
+  }
+}
+
+export const remoteControlService = new RemoteControlServiceImpl();

--- a/src/renderer/components/LeftSidebar.tsx
+++ b/src/renderer/components/LeftSidebar.tsx
@@ -8,12 +8,13 @@ import {
   Settings,
   GitBranch,
   GitGraph,
+  Globe,
   ChevronRight,
   ChevronDown,
   PanelLeftClose,
   PanelLeftOpen,
 } from 'lucide-react';
-import type { Project, Task } from '../../shared/types';
+import type { Project, Task, RemoteControlState } from '../../shared/types';
 import { IconButton } from './ui/IconButton';
 
 interface LeftSidebarProps {
@@ -34,6 +35,7 @@ interface LeftSidebarProps {
   collapsed: boolean;
   onToggleCollapse: () => void;
   taskActivity: Record<string, 'busy' | 'idle' | 'waiting'>;
+  remoteControlStates?: Record<string, RemoteControlState>;
 }
 
 export function LeftSidebar({
@@ -54,6 +56,7 @@ export function LeftSidebar({
   collapsed,
   onToggleCollapse,
   taskActivity,
+  remoteControlStates = {},
 }: LeftSidebarProps) {
   const [collapsedProjects, setCollapsedProjects] = useState<Set<string>>(new Set());
   const [collapsedArchived, setCollapsedArchived] = useState<Set<string>>(new Set());
@@ -325,6 +328,13 @@ export function LeftSidebar({
                             ) : activity === 'idle' ? (
                               <div className="w-[6px] h-[6px] rounded-full bg-emerald-400 flex-shrink-0" />
                             ) : null}
+                            {remoteControlStates[task.id] && (
+                              <Globe
+                                size={10}
+                                strokeWidth={2}
+                                className="text-primary flex-shrink-0 -ml-0.5"
+                              />
+                            )}
 
                             <span className="truncate flex-1">{task.name}</span>
 

--- a/src/renderer/components/MainContent.tsx
+++ b/src/renderer/components/MainContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TerminalPane } from './TerminalPane';
-import { Terminal, FolderOpen, GitBranch } from 'lucide-react';
-import type { Project, Task } from '../../shared/types';
+import { Terminal, FolderOpen, GitBranch, Globe } from 'lucide-react';
+import type { Project, Task, RemoteControlState } from '../../shared/types';
 
 /** Convert a git remote URL (SSH or HTTPS) to a GitHub issues base URL */
 function issueUrl(remote: string | null, num: number): string | null {
@@ -22,7 +22,9 @@ interface MainContentProps {
   tasks?: Task[];
   activeTaskId?: string | null;
   taskActivity?: Record<string, 'busy' | 'idle' | 'waiting'>;
+  remoteControlStates?: Record<string, RemoteControlState>;
   onSelectTask?: (id: string) => void;
+  onEnableRemoteControl?: (taskId: string) => void;
 }
 
 export function MainContent({
@@ -32,7 +34,9 @@ export function MainContent({
   tasks = [],
   activeTaskId,
   taskActivity = {},
+  remoteControlStates = {},
   onSelectTask,
+  onEnableRemoteControl,
 }: MainContentProps) {
   if (!activeProject) {
     return (
@@ -134,7 +138,7 @@ export function MainContent({
             <span className="text-[11px] font-mono">{activeTask.branch}</span>
           </div>
           {activeTask.linkedIssues && activeTask.linkedIssues.length > 0 && (
-            <div className="ml-auto flex items-center gap-1">
+            <div className="flex items-center gap-1">
               {activeTask.linkedIssues.map((num) => {
                 const url = issueUrl(activeProject?.gitRemote ?? null, num);
                 return url ? (
@@ -157,6 +161,19 @@ export function MainContent({
                 );
               })}
             </div>
+          )}
+          {taskActivity[activeTask.id] && (
+            <button
+              onClick={() => onEnableRemoteControl?.(activeTask.id)}
+              className={`ml-auto p-1 rounded-md transition-colors ${
+                remoteControlStates[activeTask.id]
+                  ? 'text-primary hover:bg-primary/10'
+                  : 'text-muted-foreground/50 hover:text-foreground hover:bg-accent/60'
+              }`}
+              title="Remote control"
+            >
+              <Globe size={14} strokeWidth={1.8} />
+            </button>
           )}
         </>
       )}

--- a/src/renderer/components/RemoteControlModal.tsx
+++ b/src/renderer/components/RemoteControlModal.tsx
@@ -1,0 +1,127 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { X, Globe, Copy, Check, Loader2 } from 'lucide-react';
+import QRCode from 'qrcode';
+import type { RemoteControlState } from '../../shared/types';
+
+interface RemoteControlModalProps {
+  ptyId: string;
+  state: RemoteControlState | null;
+  onClose: () => void;
+}
+
+export function RemoteControlModal({ ptyId, state, onClose }: RemoteControlModalProps) {
+  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [enabling, setEnabling] = useState(false);
+
+  // Send /rc when modal opens if no active state
+  useEffect(() => {
+    if (!state) {
+      setEnabling(true);
+      window.electronAPI.ptyRemoteControlEnable(ptyId);
+    }
+  }, []);
+
+  // Update enabling state when we get a URL
+  useEffect(() => {
+    if (state?.url) {
+      setEnabling(false);
+    }
+  }, [state?.url]);
+
+  // Generate QR code when URL arrives
+  useEffect(() => {
+    if (!state?.url) return;
+    QRCode.toDataURL(state.url, {
+      width: 200,
+      margin: 2,
+      color: { dark: '#000000', light: '#ffffff' },
+    }).then(setQrDataUrl);
+  }, [state?.url]);
+
+  const handleCopy = useCallback(() => {
+    if (!state?.url) return;
+    navigator.clipboard.writeText(state.url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [state?.url]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop animate-fade-in"
+      onClick={onClose}
+    >
+      <div
+        className="bg-card border border-border/60 rounded-xl shadow-2xl shadow-black/40 w-[380px] animate-slide-up overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div
+          className="flex items-center justify-between px-5 h-12 border-b border-border/60"
+          style={{ background: 'hsl(var(--surface-2))' }}
+        >
+          <div className="flex items-center gap-2">
+            <Globe size={14} strokeWidth={1.8} className="text-primary" />
+            <h2 className="text-[14px] font-semibold text-foreground">Remote Control</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground/50 hover:text-foreground transition-all duration-150"
+          >
+            <X size={14} strokeWidth={2} />
+          </button>
+        </div>
+
+        <div className="p-5 flex flex-col items-center gap-4">
+          {enabling && !state?.url ? (
+            <>
+              <div className="w-[200px] h-[200px] rounded-lg bg-accent/30 flex items-center justify-center">
+                <Loader2 size={24} className="text-muted-foreground animate-spin" />
+              </div>
+              <p className="text-[13px] text-muted-foreground">Enabling remote access...</p>
+            </>
+          ) : state?.url ? (
+            <>
+              {qrDataUrl && (
+                <img
+                  src={qrDataUrl}
+                  alt="Remote control QR code"
+                  className="w-[200px] h-[200px] rounded-lg"
+                />
+              )}
+              <p className="text-[12px] text-muted-foreground text-center max-w-[280px]">
+                Scan with your phone or open the link to continue this session remotely
+              </p>
+              <button
+                onClick={handleCopy}
+                className="flex items-center gap-2 px-4 py-2 rounded-full text-[13px] font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors w-full justify-center"
+              >
+                {copied ? (
+                  <>
+                    <Check size={13} strokeWidth={2} />
+                    Copied
+                  </>
+                ) : (
+                  <>
+                    <Copy size={13} strokeWidth={2} />
+                    Copy link
+                  </>
+                )}
+              </button>
+            </>
+          ) : (
+            <>
+              <div className="w-[200px] h-[200px] rounded-lg bg-accent/30 flex items-center justify-center">
+                <X size={24} className="text-muted-foreground/40" />
+              </div>
+              <p className="text-[13px] text-muted-foreground text-center max-w-[280px]">
+                Could not enable remote access. Make sure you have a Claude Pro plan and are signed
+                in.
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -195,3 +195,10 @@ export interface GithubIssue {
   url: string;
   assignees?: string[];
 }
+
+// ── Remote Control Types ────────────────────────────────────
+
+export interface RemoteControlState {
+  url: string;
+  active: boolean;
+}

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -11,6 +11,7 @@ import type {
   GithubIssue,
   CommitGraphData,
   CommitDetail,
+  RemoteControlState,
 } from '../shared/types';
 
 export interface ElectronAPI {
@@ -114,6 +115,15 @@ export interface ElectronAPI {
   ptyGetAllActivity: () => Promise<IpcResponse<Record<string, 'busy' | 'idle' | 'waiting'>>>;
   onPtyActivity: (
     callback: (data: Record<string, 'busy' | 'idle' | 'waiting'>) => void,
+  ) => () => void;
+
+  // Remote control
+  ptyRemoteControlEnable: (ptyId: string) => Promise<IpcResponse<void>>;
+  ptyRemoteControlGetAllStates: () => Promise<
+    IpcResponse<Record<string, RemoteControlState>>
+  >;
+  onRemoteControlStateChanged: (
+    callback: (data: { ptyId: string; state: RemoteControlState | null }) => void,
   ) => () => void;
 
   // Snapshots


### PR DESCRIPTION
## Summary
- Adds a Globe button in the task header that sends `/rc` to running Claude sessions
- Captures the remote control URL from PTY output and displays it as a QR code in a modal
- Shows a globe indicator in the sidebar for tasks with active remote control
- Includes copy-to-clipboard for the remote URL

## Test plan
- [ ] Start a task, wait for Claude session to initialize
- [ ] Click the Globe button in the task header
- [ ] Verify modal shows "Enabling remote access..." then QR code + URL
- [ ] Scan QR code with Claude mobile app — confirm session connects
- [ ] Verify sidebar shows globe indicator for the shared task
- [ ] Kill the task — verify remote indicator clears
- [ ] Test with non-Pro account — verify graceful timeout/error

🤖 Generated with [Claude Code](https://claude.com/claude-code)