### PR TITLE
Fix remote control /rc command not submitting

### DIFF
--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -565,7 +565,7 @@ export async function startPty(options: {
  */
 export function sendRemoteControl(id: string): void {
   remoteControlService.startWatching(id);
-  writePty(id, '/rc\n');
+  writePty(id, '/rc\r');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix `/rc` slash command not being executed when enabling remote control
- Changed `\n` (line feed) to `\r` (carriage return) in PTY write — `\n` maps to Shift+Enter in Claude Code which inserts a newline instead of submitting

## Test plan
- [ ] Click the Globe button on a running task
- [ ] Verify the `/rc` command is submitted and a remote URL is returned
- [ ] Verify the QR code modal displays the URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)