### PR TITLE
Fix QR code not displaying in Remote Control modal

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:*">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws://localhost:*">
     <title>Dash</title>
   </head>
   <body class="bg-background text-foreground">


### PR DESCRIPTION
## Summary
- CSP `default-src 'self'` was blocking `data:` URLs for images, causing the QR code in the Remote Control modal to show a broken image icon
- Added `img-src 'self' data:` to the Content-Security-Policy to allow data URL images

## Test plan
- [ ] Open Remote Control modal and verify QR code renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)