### PR TITLE
Fix remote control reliability

### DIFF
--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -565,7 +565,10 @@ export async function startPty(options: {
  */
 export function sendRemoteControl(id: string): void {
   remoteControlService.startWatching(id);
-  writePty(id, '/rc\r');
+  // Write command text first, then send Enter separately so Claude Code's
+  // input handler processes the keystroke as a distinct event.
+  writePty(id, '/rc');
+  setTimeout(() => writePty(id, '\r'), 100);
 }
 
 /**

--- a/src/renderer/components/RemoteControlModal.tsx
+++ b/src/renderer/components/RemoteControlModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { X, Globe, Copy, Check, Loader2 } from 'lucide-react';
 import QRCode from 'qrcode';
 import type { RemoteControlState } from '../../shared/types';
@@ -13,14 +13,16 @@ export function RemoteControlModal({ ptyId, state, onClose }: RemoteControlModal
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [enabling, setEnabling] = useState(false);
+  const enabledRef = useRef(false);
 
   // Send /rc when modal opens if no active state
   useEffect(() => {
-    if (!state) {
+    if (!state && !enabledRef.current) {
+      enabledRef.current = true;
       setEnabling(true);
       window.electronAPI.ptyRemoteControlEnable(ptyId);
     }
-  }, []);
+  }, [ptyId, state]);
 
   // Update enabling state when we get a URL
   useEffect(() => {
@@ -32,6 +34,7 @@ export function RemoteControlModal({ ptyId, state, onClose }: RemoteControlModal
   // Generate QR code when URL arrives
   useEffect(() => {
     if (!state?.url) return;
+    console.log('[RemoteControl] QR code URL:', state.url);
     QRCode.toDataURL(state.url, {
       width: 200,
       margin: 2,


### PR DESCRIPTION
## Summary
- Split `/rc` PTY write into text + Enter with a 100ms delay so Claude Code processes the command correctly
- Add `useRef` guard in `RemoteControlModal` to prevent the enable effect from double-firing on re-renders
- Add debug logging for QR code URL generation

## Test plan
- [ ] Open Remote Control modal and verify QR code appears
- [ ] Close and reopen the modal — should not send `/rc` twice

🤖 Generated with [Claude Code](https://claude.com/claude-code)