### PR TITLE
Add emdash acknowledgement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ All keybindings are customizable in Settings > Keybindings.
 - **Terminal snapshots**: `~/Library/Application Support/Dash/terminal-snapshots/`
 - **Worktrees**: `{project}/../worktrees/{task-slug}/`
 
+## Acknowledgements
+
+Inspired by [emdash](https://github.com/generalaction/emdash).
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Added acknowledgement section to README referencing the [emdash](https://github.com/generalaction/emdash) project as inspiration

## Test plan
- [x] Verify link renders correctly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)