### PR TITLE
fix: set SDKROOT before electron-rebuild on macOS 26 beta

### DIFF
--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -8,6 +8,7 @@ DEST="/Applications/$APP_NAME.app"
 
 echo "==> Rebuilding native modules for Electron..."
 cd "$ROOT"
+export SDKROOT="$(xcrun --show-sdk-path)"
 pnpm exec electron-rebuild -f -w better-sqlite3,node-pty
 
 echo "==> Building $APP_NAME..."


### PR DESCRIPTION
## Problem

`./scripts/build-local.sh` fails during `electron-rebuild` on macOS 26 beta (Darwin 25.x) with:

```
fatal error: 'functional' file not found
   14 | #include <functional>
```

## Root cause

On macOS 26 / CLT 17, Apple moved C++ standard library headers inside the SDK bundle. They are no longer present at the CLT top-level path:

```
/Library/Developer/CommandLineTools/usr/include/c++/v1/functional  ← missing
```

They now live inside the SDK:

```
/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/c++/v1/functional  ← exists
```

`node-gyp` doesn't set `SDKROOT` when invoking the compiler, so clang can't locate the headers.

## Fix

Export `SDKROOT` (via `xcrun`) before calling `electron-rebuild`:

```diff
 echo "==> Rebuilding native modules for Electron..."
 cd "$ROOT"
+export SDKROOT="$(xcrun --show-sdk-path)"
 pnpm exec electron-rebuild -f -w better-sqlite3,node-pty
```

`xcrun --show-sdk-path` returns the active SDK path on any macOS with CLT installed, so this should be safe on older versions — but I'm on macOS 26 beta and can't verify on 13/14/15. Happy for someone to confirm backwards compatibility before merging. Feel free to close if you'd prefer a different approach.