### PR TITLE
feat: add Windows support with WSL backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,21 @@ This builds the app, ad-hoc signs it, and copies `Dash.app` to `/Applications`.
 
 ## Prerequisites
 
+### All platforms
+
 - Node.js 22+
 - [pnpm](https://pnpm.io/)
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (`npm install -g @anthropic-ai/claude-code`)
 - Git
+
+### macOS
+
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (`npm install -g @anthropic-ai/claude-code`)
+
+### Windows (experimental)
+
+- [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install) with a Linux distribution
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed inside WSL
+- [Git for Windows](https://git-scm.com/download/win)
 
 ## Setup
 
@@ -53,6 +64,8 @@ pnpm rebuild  # rebuilds native modules (node-pty, better-sqlite3)
 ```
 
 ## Development
+
+### macOS
 
 ```bash
 pnpm dev
@@ -66,6 +79,16 @@ To just rebuild and launch the main process:
 pnpm build:main
 npx electron dist/main/main/entry.js --dev
 ```
+
+### Windows (experimental)
+
+Windows support is experimental. Dash runs as a native Windows Electron app but spawns Claude Code inside WSL.
+
+```bash
+pnpm dev
+```
+
+The app detects Windows and spawns terminal sessions via `wsl.exe`. Projects use Windows paths (e.g., `C:\Users\you\project`) which are translated to WSL paths (`/mnt/c/Users/you/project`) when spawning Claude. Git operations use Git for Windows; Claude CLI runs inside your default WSL distribution.
 
 ## Build
 
@@ -126,34 +149,34 @@ src/
 
 ## Default keybindings
 
-| Shortcut | Action |
-|----------|--------|
-| `Cmd+N` | New task |
-| `Cmd+Shift+K` | Next task |
-| `Cmd+Shift+J` | Previous task |
-| `Cmd+Shift+A` | Stage all |
-| `Cmd+Shift+U` | Unstage all |
-| `Cmd+,` | Settings |
-| `Cmd+O` | Open folder |
-| `Cmd+`` ` `` | Focus terminal |
-| `Esc` | Close overlay |
+| Shortcut      | Action         |
+| ------------- | -------------- |
+| `Cmd+N`       | New task       |
+| `Cmd+Shift+K` | Next task      |
+| `Cmd+Shift+J` | Previous task  |
+| `Cmd+Shift+A` | Stage all      |
+| `Cmd+Shift+U` | Unstage all    |
+| `Cmd+,`       | Settings       |
+| `Cmd+O`       | Open folder    |
+| `Cmd+`` ` ``  | Focus terminal |
+| `Esc`         | Close overlay  |
 
 All keybindings are customizable in Settings > Keybindings.
 
 ## Tech stack
 
-| | |
-|---|---|
-| Shell | Electron 30 |
-| UI | React 18, TypeScript, Tailwind CSS 3 |
-| Build | Vite 5, pnpm |
-| Terminal | xterm.js + node-pty |
+|          |                                       |
+| -------- | ------------------------------------- |
+| Shell    | Electron 30                           |
+| UI       | React 18, TypeScript, Tailwind CSS 3  |
+| Build    | Vite 5, pnpm                          |
+| Terminal | xterm.js + node-pty                   |
 | Database | SQLite (better-sqlite3) + Drizzle ORM |
-| Package | electron-builder |
+| Package  | electron-builder                      |
 
 ## Data storage
 
-- **Database**: `~/Library/Application Support/Dash/app.db` (macOS)
+- **Database**: `~/Library/Application Support/Dash/app.db`
 - **Terminal snapshots**: `~/Library/Application Support/Dash/terminal-snapshots/`
 - **Worktrees**: `{project}/../worktrees/{task-slug}/`
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "build:renderer": "vite build",
     "rebuild": "electron-rebuild -f -w node-pty,better-sqlite3",
     "package:mac": "pnpm build && electron-builder --mac",
+    "package:win": "pnpm build && electron-builder --win",
+    "package:all": "pnpm build && electron-builder --mac --win",
     "type-check": "tsc --noEmit && tsc -p tsconfig.main.json --noEmit",
     "drizzle:generate": "drizzle-kit generate",
     "prepare": "husky"
@@ -51,6 +53,33 @@
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "artifactName": "${productName}-${version}-${os}-${arch}.${ext}"
+    },
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "x64"
+          ]
+        }
+      ],
+      "icon": "build/icon.ico",
+      "artifactName": "${productName}-${version}-${os}-${arch}.${ext}"
+    },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true,
+      "installerIcon": "build/icon.ico",
+      "uninstallerIcon": "build/icon.ico",
+      "installerHeaderIcon": "build/icon.ico",
+      "createDesktopShortcut": true,
+      "createStartMenuShortcut": true
     }
   },
   "pnpm": {

--- a/src/main/services/GitService.ts
+++ b/src/main/services/GitService.ts
@@ -21,6 +21,7 @@ import type {
 const execFileAsync = promisify(execFile);
 
 const MAX_DIFF_SIZE = 1024 * 1024; // 1MB max diff output
+const NULL_DEVICE = process.platform === 'win32' ? 'NUL' : '/dev/null';
 
 async function git(cwd: string, args: string[]): Promise<string> {
   const { stdout } = await execFileAsync('git', args, {
@@ -316,7 +317,7 @@ export class GitService {
         '--no-index',
         `--unified=${ctx}`,
         '--',
-        '/dev/null',
+        NULL_DEVICE,
         filePath,
       ]);
       return this.parseDiff(out, filePath);

--- a/src/main/services/HookServer.ts
+++ b/src/main/services/HookServer.ts
@@ -136,11 +136,14 @@ class HookServerImpl {
         res.end();
       });
 
-      this.server.listen(0, '127.0.0.1', () => {
+      // On Windows, bind to 0.0.0.0 so WSL can reach the hook server via the host gateway IP.
+      // On macOS/Linux, bind to 127.0.0.1 to avoid exposing the server on the network.
+      const bindAddr = process.platform === 'win32' ? '0.0.0.0' : '127.0.0.1';
+      this.server.listen(0, bindAddr, () => {
         const addr = this.server!.address();
         if (addr && typeof addr === 'object') {
           this._port = addr.port;
-          console.error(`[HookServer] Listening on 127.0.0.1:${this._port}`);
+          console.error(`[HookServer] Listening on ${bindAddr}:${this._port}`);
           resolve(this._port);
         } else {
           reject(new Error('Failed to get hook server address'));

--- a/src/main/services/WslService.ts
+++ b/src/main/services/WslService.ts
@@ -1,0 +1,192 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * WSL distribution information
+ */
+export interface WslDistribution {
+  name: string;
+  isDefault: boolean;
+  state: 'Running' | 'Stopped';
+  version: 1 | 2;
+}
+
+/**
+ * Module-level variable to store the user-selected WSL distribution.
+ * Will be wired up to electron-store or settings later.
+ */
+let selectedDistribution: string = '';
+
+/**
+ * Service for Windows/WSL integration in Dash.
+ * Detects WSL availability, lists distributions, and detects Claude CLI within WSL.
+ */
+export class WslService {
+  /**
+   * Check if WSL is available on this system.
+   * @returns True if WSL is installed and available, false otherwise
+   */
+  static async isWslAvailable(): Promise<boolean> {
+    try {
+      await execFileAsync('wsl.exe', ['--status'], { timeout: 10000 });
+      return true;
+    } catch (err) {
+      console.error('[WslService.isWslAvailable] WSL not available:', err);
+      return false;
+    }
+  }
+
+  /**
+   * List all WSL distributions installed on the system.
+   * Parses output from `wsl.exe --list --verbose`.
+   *
+   * Output format example:
+   * ```
+   *   NAME      STATE           VERSION
+   * * Ubuntu    Running         2
+   *   Debian    Stopped         2
+   * ```
+   *
+   * @returns Array of WslDistribution objects
+   */
+  static async listDistributions(): Promise<WslDistribution[]> {
+    try {
+      const { stdout } = await execFileAsync('wsl.exe', ['--list', '--verbose'], {
+        timeout: 10000,
+        encoding: 'utf16le', // WSL output is typically UTF-16LE on Windows
+      });
+
+      const lines = stdout.split('\n').map((line) => line.trim());
+      const distributions: WslDistribution[] = [];
+
+      // Skip header line (first non-empty line)
+      let startIndex = 0;
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].length > 0) {
+          startIndex = i + 1;
+          break;
+        }
+      }
+
+      // Parse each distribution line
+      for (let i = startIndex; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line || line.length === 0) continue;
+
+        // Check if this is the default distribution (marked with *)
+        const isDefault = line.startsWith('*');
+        const cleanLine = line.replace(/^\*\s*/, '').trim();
+
+        // Split by whitespace (multiple spaces/tabs)
+        const parts = cleanLine.split(/\s+/).filter((p) => p.length > 0);
+        if (parts.length < 3) continue;
+
+        const [name, state, versionStr] = parts;
+
+        // Parse state
+        const normalizedState = state.toLowerCase();
+        let distroState: 'Running' | 'Stopped';
+        if (normalizedState.includes('running')) {
+          distroState = 'Running';
+        } else if (normalizedState.includes('stopped')) {
+          distroState = 'Stopped';
+        } else {
+          // Default to Stopped for unknown states
+          distroState = 'Stopped';
+        }
+
+        // Parse version
+        const version = versionStr === '1' ? 1 : 2;
+
+        distributions.push({
+          name,
+          isDefault,
+          state: distroState,
+          version,
+        });
+      }
+
+      return distributions;
+    } catch (err) {
+      console.error('[WslService.listDistributions] Failed to list distributions:', err);
+      return [];
+    }
+  }
+
+  /**
+   * Resolve which WSL distribution to use: user-selected, default, or first available.
+   * @returns The distribution name, or undefined if none found
+   */
+  static async resolveDistribution(): Promise<string | undefined> {
+    const selected = WslService.getSelectedDistribution();
+    if (selected) return selected;
+    const distros = await WslService.listDistributions();
+    const defaultDistro = distros.find((d) => d.isDefault);
+    return defaultDistro?.name || distros[0]?.name;
+  }
+
+  /**
+   * Get the user-configured WSL distribution.
+   * @returns The selected distribution name, or empty string if none set
+   */
+  static getSelectedDistribution(): string {
+    return selectedDistribution;
+  }
+
+  /**
+   * Set the user-configured WSL distribution.
+   * @param name The distribution name to use
+   */
+  static setSelectedDistribution(name: string): void {
+    selectedDistribution = name;
+  }
+
+  /**
+   * Detect if Claude CLI is installed in the specified WSL distribution.
+   * @param distro The WSL distribution name to check
+   * @returns Detection result with installation status, version, and path
+   */
+  static async detectClaudeCli(
+    distro: string,
+  ): Promise<{ installed: boolean; version: string | null; path: string | null }> {
+    try {
+      // First, try to find the Claude CLI path using 'which'
+      // Use bash -l -c to run as a login shell, ensuring PATH is set correctly
+      const { stdout: whichOutput } = await execFileAsync(
+        'wsl.exe',
+        ['-d', distro, '--', 'bash', '-l', '-c', 'which claude'],
+        { timeout: 15000 },
+      );
+
+      const claudePath = whichOutput.trim();
+      if (!claudePath) {
+        return { installed: false, version: null, path: null };
+      }
+
+      // Found the path, now get the version
+      try {
+        const { stdout: versionOutput } = await execFileAsync(
+          'wsl.exe',
+          ['-d', distro, '--', 'bash', '-l', '-c', 'claude --version'],
+          { timeout: 15000 },
+        );
+
+        const version = versionOutput.trim();
+        return { installed: true, version, path: claudePath };
+      } catch (versionErr) {
+        console.error(
+          `[WslService.detectClaudeCli] Found Claude CLI at ${claudePath} but could not get version:`,
+          versionErr,
+        );
+        // Still report as installed even if version check fails
+        return { installed: true, version: null, path: claudePath };
+      }
+    } catch (err) {
+      // 'which' command failed, Claude CLI not found
+      console.error('[WslService.detectClaudeCli] Claude CLI not found in distribution:', err);
+      return { installed: false, version: null, path: null };
+    }
+  }
+}

--- a/src/main/utils/pathTranslation.ts
+++ b/src/main/utils/pathTranslation.ts
@@ -1,0 +1,72 @@
+/**
+ * Path translation utilities for Windows/WSL path conversion
+ */
+
+/**
+ * Checks if a path is a Windows-style path (e.g., C:\Users\mike\project)
+ * @param path - The path to check
+ * @returns true if the path matches Windows format
+ */
+export function isWindowsPath(path: string): boolean {
+  // Windows paths typically start with a drive letter followed by a colon and backslash
+  // e.g., C:\, D:\, etc.
+  return /^[a-zA-Z]:\\/.test(path);
+}
+
+/**
+ * Checks if a path is a WSL /mnt/ path (e.g., /mnt/c/Users/mike/project)
+ * @param path - The path to check
+ * @returns true if the path matches WSL /mnt/ format
+ */
+export function isWslPath(path: string): boolean {
+  // WSL paths start with /mnt/ followed by a single letter (drive) and forward slash
+  return /^\/mnt\/[a-zA-Z]\//.test(path);
+}
+
+/**
+ * Converts a Windows path to WSL format
+ * @param windowsPath - The Windows path to convert (e.g., C:\Users\mike\project)
+ * @returns The WSL-formatted path (e.g., /mnt/c/Users/mike/project)
+ */
+export function toWslPath(windowsPath: string): string {
+  // If it's not a Windows path, return as-is (could be relative or already Unix format)
+  if (!isWindowsPath(windowsPath)) {
+    return windowsPath;
+  }
+
+  // Extract drive letter (e.g., "C" from "C:\")
+  const driveLetter = windowsPath.charAt(0).toLowerCase();
+
+  // Remove drive letter and colon (e.g., "C:" from "C:\Users\mike\project")
+  const pathWithoutDrive = windowsPath.substring(2);
+
+  // Convert backslashes to forward slashes
+  const unixStylePath = pathWithoutDrive.replace(/\\/g, '/');
+
+  // Construct WSL path: /mnt/{drive}/{rest of path}
+  return `/mnt/${driveLetter}${unixStylePath}`;
+}
+
+/**
+ * Converts a WSL /mnt/ path back to Windows format
+ * @param wslPath - The WSL path to convert (e.g., /mnt/c/Users/mike/project)
+ * @returns The Windows-formatted path (e.g., C:\Users\mike\project)
+ */
+export function toWindowsPath(wslPath: string): string {
+  // If it's not a WSL /mnt/ path, return as-is
+  if (!isWslPath(wslPath)) {
+    return wslPath;
+  }
+
+  // Extract drive letter (e.g., "c" from "/mnt/c/Users/mike/project")
+  const driveLetter = wslPath.charAt(5).toUpperCase();
+
+  // Remove /mnt/{drive} prefix (e.g., "/mnt/c" from "/mnt/c/Users/mike/project")
+  const pathWithoutMnt = wslPath.substring(6);
+
+  // Convert forward slashes to backslashes
+  const windowsStylePath = pathWithoutMnt.replace(/\//g, '\\');
+
+  // Construct Windows path: {Drive}:\{rest of path}
+  return `${driveLetter}:${windowsStylePath}`;
+}


### PR DESCRIPTION
## Summary
- Adds Windows/WSL support: Dash runs as a native Windows Electron app, spawning Claude Code CLI inside WSL
- Includes path translation utilities, WSL distribution detection, and hook server accessibility from WSL
- Cherry-picked from #50 with fixes for path translation off-by-one, hook server reachability, env var passthrough, WSL hook command paths, type safety, and code dedup

## Fixes applied to original PR
- **`toWindowsPath` off-by-one** — `substring(7)` → `substring(6)` (was producing `C:Users` instead of `C:\Users`)
- **Hook server unreachable from WSL** — bind `0.0.0.0` on Windows; resolve host IP dynamically inside WSL
- **WSL hook command paths** — translate `contextPath` with `toWslPath()` for `cat` commands running inside WSL
- **Env var passthrough** — replaced broken `WSLENV` mechanism with `env VAR=value` prefix args in `wsl.exe` command line
- **Type regression** — replaced `proc: any` with `IPty` from node-pty
- **Code dedup** — extracted `WslService.resolveDistribution()` to replace 3 duplicated resolution patterns
- **Dynamic imports** — `WslService` imported dynamically inside platform-guarded paths (consistent with `main.ts`)

## Test plan
- [x] Verify `pnpm type-check` passes
- [ ] Test on macOS — no regressions in terminal spawning, hooks, or activity detection
- [ ] Test on Windows with WSL — Claude CLI spawns correctly, hooks fire, env vars reach WSL

🤖 Generated with [Claude Code](https://claude.com/claude-code)