### PR TITLE
Fix CI: fail on duplicate version tags, bump to 0.1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,13 +137,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if git ls-remote --tags origin "${{ steps.version.outputs.version }}" | grep -q .; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Version ${{ steps.version.outputs.version }} already released. Bump the version in package.json before merging."
+            exit 1
           fi
 
       - name: Create tagged release
-        if: steps.tag_check.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -151,12 +149,3 @@ jobs:
             --title "${{ steps.version.outputs.version }}" \
             --generate-notes \
             artifacts/*
-
-      - name: Update existing release artifacts
-        if: steps.tag_check.outputs.exists == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Upload latest artifacts to existing release (overwrites)
-          gh release upload "${{ steps.version.outputs.version }}" \
-            artifacts/* --clobber

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen",


### PR DESCRIPTION
## Summary
- Release job now **fails** instead of silently re-uploading to an existing release when the version isn't bumped
- Removes the "update existing release" fallback path that masked missing version bumps
- Bumps version `0.1.1` → `0.1.2` (no new release was created since PR #35)

## Test plan
- [ ] `version-check` job passes on this PR (version differs from main)
- [ ] After merge, `build-mac` and `release` jobs run and create a `v0.1.2` release

🤖 Generated with [Claude Code](https://claude.com/claude-code)