### PR TITLE
Fix version extraction in release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,9 @@ jobs:
 
       - name: Get version from package.json
         id: version
-        run: echo "version=v$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION=$(node -p 'require("./package.json").version')
+          echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen",


### PR DESCRIPTION
## Summary
- Fix broken `node -p` command in the release job's version extraction step
- The `\"` YAML escaping in a plain scalar was passed literally to bash single quotes, causing a Node.js `SyntaxError`
- This made the version resolve to empty — releases were tagged `v` instead of `v0.1.2`
- Switch to a YAML block scalar (`|`) so quotes are preserved correctly
- Bump version to 0.1.3

This is the root cause of why releases weren't being created properly. PR #60 added the duplicate-tag guard, this PR fixes the version parsing that was broken all along.

## Test plan
- [ ] `version-check` passes (0.1.3 != 0.1.2)
- [ ] After merge, release job creates `v0.1.3` release

🤖 Generated with [Claude Code](https://claude.com/claude-code)