### PR TITLE
Add merge-to-main button for worktree task branches

### DIFF
--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -182,12 +182,25 @@ export function registerGitIpc(): void {
   );
 
   // Get detailed info for a single commit
+  ipcMain.handle('git:getCommitDetail', async (_event, args: { cwd: string; hash: string }) => {
+    try {
+      const data = await GitService.getCommitDetail(args.cwd, args.hash);
+      return { success: true, data };
+    } catch (error) {
+      return { success: false, error: String(error) };
+    }
+  });
+
+  // Merge a task branch into main
   ipcMain.handle(
-    'git:getCommitDetail',
-    async (_event, args: { cwd: string; hash: string }) => {
+    'git:mergeToMain',
+    async (_event, args: { projectPath: string; taskBranch: string; taskPath: string }) => {
       try {
-        const data = await GitService.getCommitDetail(args.cwd, args.hash);
-        return { success: true, data };
+        const result = await GitService.mergeTaskToMain(args);
+        if (!result.success) {
+          return { success: false, error: result.error, data: { conflicts: result.conflicts } };
+        }
+        return { success: true };
       } catch (error) {
         return { success: false, error: String(error) };
       }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -162,6 +162,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   gitCommit: (args: { cwd: string; message: string }) => ipcRenderer.invoke('git:commit', args),
   gitPush: (cwd: string) => ipcRenderer.invoke('git:push', cwd),
 
+  // Merge to main
+  gitMergeToMain: (args: { projectPath: string; taskBranch: string; taskPath: string }) =>
+    ipcRenderer.invoke('git:mergeToMain', args),
+
   // Branch listing
   gitListBranches: (cwd: string) => ipcRenderer.invoke('git:listBranches', cwd),
 

--- a/src/main/services/GitService.ts
+++ b/src/main/services/GitService.ts
@@ -386,6 +386,41 @@ export class GitService {
     await git(cwd, ['push']);
   }
 
+  /**
+   * Merge a task branch into main in the main project repo.
+   */
+  static async mergeTaskToMain(args: {
+    projectPath: string;
+    taskBranch: string;
+    taskPath: string;
+  }): Promise<{ success: boolean; error?: string; conflicts?: string[] }> {
+    const { projectPath, taskBranch } = args;
+    try {
+      await git(projectPath, ['merge', taskBranch, '--no-ff', '-m', `Merge ${taskBranch}`]);
+      return { success: true };
+    } catch (err: unknown) {
+      const error = err as { stderr?: string; stdout?: string };
+      const msg = String(error.stderr || error.stdout || err);
+
+      // Check for merge conflicts
+      if (/conflict/i.test(msg) || /automatic merge failed/i.test(msg)) {
+        // Get list of conflicted files
+        try {
+          const statusOut = await git(projectPath, ['diff', '--name-only', '--diff-filter=U']);
+          const conflicts = statusOut
+            .split('\n')
+            .map((l) => l.trim())
+            .filter(Boolean);
+          return { success: false, error: 'Merge conflicts', conflicts };
+        } catch {
+          return { success: false, error: 'Merge conflicts', conflicts: [] };
+        }
+      }
+
+      return { success: false, error: msg.split('\n')[0].trim() };
+    }
+  }
+
   // ── Commit Graph ────────────────────────────────────────
 
   static async getCommitGraph(cwd: string, limit = 150, skip = 0): Promise<CommitGraphData> {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -833,6 +833,23 @@ export function App() {
     refreshGitStatus(activeTask.path);
   }
 
+  async function handleMergeToMain() {
+    if (!activeTask || !activeProject) return;
+    const res = await window.electronAPI.gitMergeToMain({
+      projectPath: activeProject.path,
+      taskBranch: activeTask.branch,
+      taskPath: activeTask.path,
+    });
+    if (!res.success) {
+      const conflicts = res.data?.conflicts;
+      if (conflicts && conflicts.length > 0) {
+        throw new Error(`Merge conflicts in: ${conflicts.join(', ')}`);
+      }
+      throw new Error(res.error || 'Merge failed');
+    }
+    refreshGitStatus(activeTask.path);
+  }
+
   async function handleDiscardFile(filePath: string) {
     if (!activeTask) return;
     await window.electronAPI.gitDiscardFile({ cwd: activeTask.path, filePath });
@@ -1047,6 +1064,9 @@ export function App() {
                   collapsed={changesPanelCollapsed}
                   onToggleCollapse={toggleChangesPanel}
                   onShowCommitGraph={() => setShowCommitGraph(true)}
+                  onMergeToMain={handleMergeToMain}
+                  activeTaskBranch={activeTask?.branch}
+                  activeTaskUseWorktree={activeTask?.useWorktree}
                 />
               </ShellDrawerWrapper>
             </Panel>

--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -16,6 +16,7 @@ import {
   PanelRightOpen,
   PanelRightClose,
   GitBranch,
+  GitMerge,
 } from 'lucide-react';
 import type { FileChange, FileChangeStatus, GitStatus } from '../../shared/types';
 
@@ -33,6 +34,9 @@ interface FileChangesPanelProps {
   collapsed?: boolean;
   onToggleCollapse?: () => void;
   onShowCommitGraph?: () => void;
+  onMergeToMain?: () => Promise<void>;
+  activeTaskBranch?: string | null;
+  activeTaskUseWorktree?: boolean;
 }
 
 const STATUS_COLORS: Record<FileChangeStatus, string> = {
@@ -123,9 +127,7 @@ function FileItem({
 
       <span className="truncate flex-1 min-w-0" title={file.path}>
         <span className="text-foreground/90">{fileName}</span>
-        {dirPath && (
-          <span className="text-muted-foreground/40 ml-1">{dirPath}/</span>
-        )}
+        {dirPath && <span className="text-muted-foreground/40 ml-1">{dirPath}/</span>}
       </span>
 
       {/* Stat badge */}
@@ -141,7 +143,9 @@ function FileItem({
       )}
 
       {/* Status badge */}
-      <span className={`w-[18px] h-[16px] rounded flex items-center justify-center text-[9px] font-bold flex-shrink-0 ${STATUS_BADGE_COLORS[file.status]}`}>
+      <span
+        className={`w-[18px] h-[16px] rounded flex items-center justify-center text-[9px] font-bold flex-shrink-0 ${STATUS_BADGE_COLORS[file.status]}`}
+      >
         {STATUS_LABELS[file.status]}
       </span>
 
@@ -149,7 +153,10 @@ function FileItem({
       {!file.staged && (
         <div className="opacity-0 group-hover:opacity-100 flex gap-px flex-shrink-0 transition-all duration-150">
           <button
-            onClick={(e) => { e.stopPropagation(); onDiscard(); }}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDiscard();
+            }}
             className="p-[3px] rounded hover:bg-destructive/15 text-muted-foreground/50 hover:text-destructive"
             title="Discard changes"
           >
@@ -175,10 +182,15 @@ export function FileChangesPanel({
   collapsed,
   onToggleCollapse,
   onShowCommitGraph,
+  onMergeToMain,
+  activeTaskBranch,
+  activeTaskUseWorktree,
 }: FileChangesPanelProps) {
   const [commitMsg, setCommitMsg] = useState('');
   const [committing, setCommitting] = useState(false);
   const [pushing, setPushing] = useState(false);
+  const [merging, setMerging] = useState(false);
+  const [showMergeConfirm, setShowMergeConfirm] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Track previous file keys to detect newly added files
@@ -232,7 +244,10 @@ export function FileChangesPanel({
 
   if (!gitStatus) {
     return (
-      <div className="h-full flex items-center justify-center" style={{ background: 'hsl(var(--surface-1))' }}>
+      <div
+        className="h-full flex items-center justify-center"
+        style={{ background: 'hsl(var(--surface-1))' }}
+      >
         <p className="text-[11px] text-muted-foreground/40">
           {loading ? 'Loading...' : 'No task selected'}
         </p>
@@ -271,8 +286,33 @@ export function FileChangesPanel({
     }
   }
 
+  async function handleMergeToMain() {
+    if (!onMergeToMain) return;
+    setMerging(true);
+    setError(null);
+    setShowMergeConfirm(false);
+    try {
+      await onMergeToMain();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setMerging(false);
+    }
+  }
+
+  const showMergeButton =
+    onMergeToMain &&
+    activeTaskUseWorktree &&
+    activeTaskBranch &&
+    activeTaskBranch !== 'main' &&
+    activeTaskBranch !== 'master';
+  const hasUncommittedChanges = (gitStatus?.files.length ?? 0) > 0;
+
   return (
-    <div className="h-full flex flex-col overflow-hidden" style={{ background: 'hsl(var(--surface-1))' }}>
+    <div
+      className="h-full flex flex-col overflow-hidden"
+      style={{ background: 'hsl(var(--surface-1))' }}
+    >
       {/* Header */}
       <div className="flex items-center justify-between px-3 h-10 flex-shrink-0 border-b border-border/60">
         <div className="flex items-center gap-2">
@@ -308,12 +348,14 @@ export function FileChangesPanel({
             <div className="flex items-center gap-1 text-muted-foreground/40 mr-1">
               {gitStatus.ahead > 0 && (
                 <span className="flex items-center gap-0.5 text-[9px] text-[hsl(var(--git-added))]">
-                  <ArrowUp size={8} strokeWidth={2.5} />{gitStatus.ahead}
+                  <ArrowUp size={8} strokeWidth={2.5} />
+                  {gitStatus.ahead}
                 </span>
               )}
               {gitStatus.behind > 0 && (
                 <span className="flex items-center gap-0.5 text-[9px] text-[hsl(var(--git-deleted))]">
-                  <ArrowDown size={8} strokeWidth={2.5} />{gitStatus.behind}
+                  <ArrowDown size={8} strokeWidth={2.5} />
+                  {gitStatus.behind}
                 </span>
               )}
             </div>
@@ -394,7 +436,10 @@ export function FileChangesPanel({
           )}
           <textarea
             value={commitMsg}
-            onChange={(e) => { setCommitMsg(e.target.value); setError(null); }}
+            onChange={(e) => {
+              setCommitMsg(e.target.value);
+              setError(null);
+            }}
             onKeyDown={(e) => {
               if (e.key === 'Enter' && e.metaKey) {
                 e.preventDefault();
@@ -426,6 +471,58 @@ export function FileChangesPanel({
               </button>
             )}
           </div>
+        </div>
+      )}
+
+      {/* Merge to main */}
+      {showMergeButton && (
+        <div className="flex-shrink-0 border-t border-border/60 p-2">
+          {error && totalChanges === 0 && (
+            <p className="text-[11px] text-destructive bg-destructive/10 rounded px-2 py-1 break-words mb-1.5">
+              {error}
+            </p>
+          )}
+          {showMergeConfirm ? (
+            <div className="flex flex-col gap-1.5">
+              <p className="text-[11px] text-foreground/70">
+                Merge <span className="font-medium text-foreground">{activeTaskBranch}</span> into
+                main?
+              </p>
+              <div className="flex gap-1.5">
+                <button
+                  onClick={handleMergeToMain}
+                  disabled={merging}
+                  className="flex-1 flex items-center justify-center gap-1.5 text-[12px] px-3 py-1.5 rounded-lg bg-emerald-500/15 text-emerald-400 hover:bg-emerald-500/25 border border-emerald-500/20 font-medium transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                >
+                  <GitMerge size={12} strokeWidth={1.8} />
+                  {merging ? 'Merging...' : 'Confirm'}
+                </button>
+                <button
+                  onClick={() => setShowMergeConfirm(false)}
+                  className="flex items-center justify-center px-3 py-1.5 rounded-lg text-[12px] bg-accent hover:bg-accent/80 text-foreground/60 transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={() => {
+                setError(null);
+                setShowMergeConfirm(true);
+              }}
+              disabled={hasUncommittedChanges || merging}
+              title={
+                hasUncommittedChanges
+                  ? 'Commit or stash changes before merging'
+                  : `Merge ${activeTaskBranch} into main`
+              }
+              className="w-full flex items-center justify-center gap-1.5 text-[12px] px-3 py-1.5 rounded-lg bg-emerald-500/15 text-emerald-400 hover:bg-emerald-500/25 border border-emerald-500/20 font-medium transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <GitMerge size={12} strokeWidth={1.8} />
+              Merge to main
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -196,6 +196,13 @@ export interface ElectronAPI {
   gitCommit: (args: { cwd: string; message: string }) => Promise<IpcResponse<void>>;
   gitPush: (cwd: string) => Promise<IpcResponse<void>>;
 
+  // Merge to main
+  gitMergeToMain: (args: {
+    projectPath: string;
+    taskBranch: string;
+    taskPath: string;
+  }) => Promise<IpcResponse<{ conflicts?: string[] }>>;
+
   // Commit graph
   gitGetCommitGraph: (args: {
     cwd: string;


### PR DESCRIPTION
## Summary
- Adds a "Merge to main" button in the FileChangesPanel for tasks using worktrees
- Runs `git merge --no-ff` in the main project repo with confirmation step
- Disables when uncommitted changes exist, detects and reports merge conflicts

## Test plan
- [ ] Create a worktree task, make commits, verify merge button appears
- [ ] Verify button is disabled when there are uncommitted changes
- [ ] Confirm merge works and git status refreshes afterward
- [ ] Verify button does not appear for non-worktree tasks or main branch
- [ ] Test merge conflict scenario shows conflicted file list