### PR TITLE
Fix scroll position desync when switching terminal sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ release/
 .env
 .env.local
 .claude/skills/steal
+claude.local.md

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -43,6 +43,7 @@ export class TerminalSessionManager {
   private lastPtyCols = 0;
   private lastPtyRows = 0;
   private writeScrollRafPending = false;
+  private savedViewportY: number | null = null;
   readonly shellOnly: boolean;
   private themeId: string;
   constructor(opts: {
@@ -402,6 +403,11 @@ export class TerminalSessionManager {
         this.fitAddon.fit();
         this.terminal.focus();
 
+        if (this.savedViewportY !== null) {
+          this.forceScrollToLine(this.savedViewportY);
+          this.savedViewportY = null;
+        }
+
         // Use fit() dedup logic — avoid redundant SIGWINCH that can cause
         // the shell to redraw while the user is already typing
         const dims = this.fitAddon.proposeDimensions();
@@ -420,6 +426,8 @@ export class TerminalSessionManager {
   }
 
   detach() {
+    this.savedViewportY = this.terminal.buffer.active.viewportY;
+
     // Save snapshot before detaching
     this.saveSnapshot();
 
@@ -760,6 +768,20 @@ export class TerminalSessionManager {
       // Best effort
     }
     return false;
+  }
+
+  /**
+   * scrollToLine(n) is a no-op when viewportY already equals n — xterm skips
+   * the scroll event so the Viewport never syncs the DOM scrollTop. After a
+   * DOM re-attach (appendChild), scrollTop resets to 0 but viewportY keeps its
+   * old value, leaving them desynced. Force the event by scrolling away first.
+   */
+  private forceScrollToLine(line: number) {
+    const buf = this.terminal.buffer.active;
+    if (buf.viewportY === line) {
+      this.terminal.scrollToLine(line > 0 ? line - 1 : line + 1);
+    }
+    this.terminal.scrollToLine(line);
   }
 
   private isAtBottom(): boolean {


### PR DESCRIPTION
## Summary
- After switching away from a terminal session and back, scrolling would jump the viewport to the top of scrollback before scrolling from there
- Root cause: `appendChild` resets DOM `scrollTop` to 0, but xterm's internal `viewportY` keeps its old value. `scrollToLine(n)` is a no-op when `viewportY` already equals `n`, so the Viewport class never syncs `scrollTop` back
- Fix: save `viewportY` on detach and restore via `forceScrollToLine()` on re-attach, which nudges to an adjacent line first to guarantee the scroll event fires

## Test plan
- [ ] Open app with an active session that has scrollback
- [ ] Switch to a different session
- [ ] Switch back to the original session
- [ ] Scroll down — viewport should scroll normally from its current position, not jump to top

🤖 Generated with [Claude Code](https://claude.com/claude-code) and Dash!