### PR TITLE
Disable focus reporting before focusing terminal on re-attach

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -399,6 +399,11 @@ export class TerminalSessionManager {
 
       requestAnimationFrame(() => {
         if (gen !== this.attachGeneration) return;
+        // Disable focus reporting before focusing — a restored snapshot or
+        // previous Ink process may have left it enabled, and the focus event
+        // would send \x1b[I as PTY input before the new Ink process is ready,
+        // causing stray "O"/"I" chars in the input field.
+        this.terminal.write('\x1b[?1004l');
         this.fitAddon.fit();
         this.terminal.focus();
 


### PR DESCRIPTION
## Summary
- A restored snapshot or previous Ink process may leave focus reporting (DECSET 1004) enabled
- When `terminal.focus()` is called, the browser sends `\x1b[I` as PTY input before the new process is ready, causing stray "O"/"I" characters in the input field
- Fix: write `\x1b[?1004l` (DECRST 1004) before focusing to prevent this

## Test plan
- [ ] Open app, switch between sessions repeatedly
- [ ] Verify no stray "O" or "I" characters appear in the terminal input

🤖 Generated with [Claude Code](https://claude.com/claude-code)