### PR TITLE
Reload GPU addon on WebGL context loss

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -187,6 +187,7 @@ export class TerminalSessionManager {
         const webgl = new WebglAddon();
         webgl.onContextLoss(() => {
           webgl.dispose();
+          this.loadGpuAddon();
         });
         this.terminal.loadAddon(webgl);
         return;


### PR DESCRIPTION
## Summary
- When a WebGL context is lost, the terminal now reloads the GPU addon instead of just disposing it
- Falls back to Canvas addon, then software renderer if WebGL can't be reacquired
- Prevents terminals from going blank after prolonged use (browsers cap WebGL contexts at ~8-16 per page)

## Test plan
- [ ] Open 8+ task sessions, switching between them to force WebGL context pressure
- [ ] Verify terminals continue rendering correctly after extended use
- [ ] Check DevTools console for WebGL context loss/restore messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)