### PR TITLE
Fix terminal text clipping at panel edges

### DIFF
--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -114,12 +114,17 @@
 
 /* ── Terminal ─────────────────────────────────────────────── */
 
-.terminal-container {
-  padding: 0 16px;
-}
-
 .terminal-container .xterm {
   height: 100%;
+  padding: 0 8px;
+}
+
+/* Inset the absolutely-positioned viewport to match .xterm padding
+   so the canvas renders within the padded area. FitAddon reads .xterm
+   padding and subtracts it from available width automatically. */
+.terminal-container .xterm .xterm-viewport {
+  left: 8px;
+  right: 8px;
 }
 
 /* ── Scrollbar ────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Replace clunky 16px container padding with 8px padding on `.xterm` plus viewport inset overrides
- FitAddon reads `.xterm` padding and subtracts it from available width automatically
- Inset `.xterm-viewport` (`left: 8px; right: 8px`) so the absolutely-positioned viewport respects the same padding bounds

## Test plan
- [ ] Verify terminal text no longer clips at the right edge in both main terminal and shell drawer
- [ ] Resize panels and confirm text reflows correctly
- [ ] Check on Linux (CanvasAddon) and macOS (WebGL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)