### PR TITLE
Add optional Chat UI mode alongside native terminal view

### DIFF
--- a/src/main/ipc/ptyIpc.ts
+++ b/src/main/ipc/ptyIpc.ts
@@ -30,6 +30,7 @@ export function registerPtyIpc(): void {
         autoApprove?: boolean;
         resume?: boolean;
         isDark?: boolean;
+        chatMode?: boolean;
       },
     ) => {
       try {

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -297,6 +297,7 @@ export async function startDirectPty(options: {
   autoApprove?: boolean;
   resume?: boolean;
   isDark?: boolean;
+  chatMode?: boolean;
   sender?: WebContents;
 }): Promise<{
   reattached: boolean;
@@ -327,6 +328,9 @@ export async function startDirectPty(options: {
   }
 
   const args: string[] = [];
+  if (options.chatMode) {
+    args.push('--output-format', 'stream-json');
+  }
   if (options.resume) {
     args.push('-c', '-r');
   }

--- a/src/renderer/chat/ChatStreamParser.ts
+++ b/src/renderer/chat/ChatStreamParser.ts
@@ -1,0 +1,156 @@
+import type { ChatMessage, ChatContentBlock, StreamJsonEvent } from '../../shared/types';
+
+/**
+ * Parses Claude CLI `--output-format stream-json` JSONL output into ChatMessage objects.
+ *
+ * The stream produces newline-delimited JSON events. Each event has a `type` field:
+ * - system: init/error events
+ * - assistant: assistant message with content blocks
+ * - user: echoed user input
+ * - result: turn completion with cost/duration
+ */
+export class ChatStreamParser {
+  private buffer = '';
+  private messages: ChatMessage[] = [];
+  private messageCounter = 0;
+  private listeners: Set<() => void> = new Set();
+  private _sessionId: string | null = null;
+  private _isWaiting = false;
+  private _waitingListeners: Set<(waiting: boolean) => void> = new Set();
+
+  get sessionId(): string | null {
+    return this._sessionId;
+  }
+
+  get isWaiting(): boolean {
+    return this._isWaiting;
+  }
+
+  getMessages(): ChatMessage[] {
+    return this.messages;
+  }
+
+  /** Subscribe to message list changes. Returns unsubscribe function. */
+  onChange(fn: () => void): () => void {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  }
+
+  /** Subscribe to waiting state changes. */
+  onWaitingChange(fn: (waiting: boolean) => void): () => void {
+    this._waitingListeners.add(fn);
+    return () => this._waitingListeners.delete(fn);
+  }
+
+  /** Feed raw PTY data (may contain partial lines). */
+  feed(data: string): void {
+    this.buffer += data;
+    const lines = this.buffer.split('\n');
+    // Keep the last (possibly incomplete) line in the buffer
+    this.buffer = lines.pop() || '';
+
+    let changed = false;
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const event = JSON.parse(trimmed) as StreamJsonEvent;
+        if (this.processEvent(event)) {
+          changed = true;
+        }
+      } catch {
+        // Not valid JSON — could be raw CLI output (banners, prompts).
+        // Ignore gracefully.
+      }
+    }
+
+    if (changed) {
+      this.notify();
+    }
+  }
+
+  /** Reset parser state. */
+  reset(): void {
+    this.buffer = '';
+    this.messages = [];
+    this.messageCounter = 0;
+    this._sessionId = null;
+    this._isWaiting = false;
+    this.notify();
+  }
+
+  private processEvent(event: StreamJsonEvent): boolean {
+    switch (event.type) {
+      case 'system': {
+        if (event.subtype === 'init' && event.session_id) {
+          this._sessionId = event.session_id;
+        }
+        if (event.subtype === 'error' && event.message) {
+          this.messages.push({
+            id: `sys-${this.messageCounter++}`,
+            role: 'system',
+            content: [{ type: 'text', text: event.message }],
+            timestamp: Date.now(),
+          });
+          return true;
+        }
+        return false;
+      }
+
+      case 'assistant': {
+        this.setWaiting(false);
+        const msg = event.message;
+        this.messages.push({
+          id: msg.id || `asst-${this.messageCounter++}`,
+          role: 'assistant',
+          content: msg.content as ChatContentBlock[],
+          timestamp: Date.now(),
+          model: msg.model,
+        });
+        return true;
+      }
+
+      case 'user': {
+        this.setWaiting(false);
+        const content: ChatContentBlock[] = event.message.content || [];
+        this.messages.push({
+          id: `user-${this.messageCounter++}`,
+          role: 'user',
+          content,
+          timestamp: Date.now(),
+        });
+        return true;
+      }
+
+      case 'result': {
+        this.setWaiting(true);
+        // Attach cost to the last assistant message if available
+        if (event.cost_usd && this.messages.length > 0) {
+          const last = this.messages[this.messages.length - 1];
+          if (last.role === 'assistant') {
+            last.costUsd = event.cost_usd;
+          }
+        }
+        return true;
+      }
+
+      default:
+        return false;
+    }
+  }
+
+  private setWaiting(waiting: boolean): void {
+    if (this._isWaiting !== waiting) {
+      this._isWaiting = waiting;
+      for (const fn of this._waitingListeners) {
+        fn(waiting);
+      }
+    }
+  }
+
+  private notify(): void {
+    for (const fn of this.listeners) {
+      fn();
+    }
+  }
+}

--- a/src/renderer/components/ChatPane.tsx
+++ b/src/renderer/components/ChatPane.tsx
@@ -1,0 +1,181 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import { ArrowDown, Loader2 } from 'lucide-react';
+import { ChatStreamParser } from '../chat/ChatStreamParser';
+import { MessageBubble } from './chat/MessageBubble';
+import { ComposeBox } from './chat/ComposeBox';
+import { Tooltip } from './ui/Tooltip';
+import type { ChatMessage } from '../../shared/types';
+
+interface ChatPaneProps {
+  id: string;
+  cwd: string;
+  autoApprove?: boolean;
+}
+
+export function ChatPane({ id, cwd, autoApprove }: ChatPaneProps) {
+  const parserRef = useRef<ChatStreamParser | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isWaiting, setIsWaiting] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
+  const [isAtBottom, setIsAtBottom] = useState(true);
+  const [connected, setConnected] = useState(false);
+
+  // Initialize parser and PTY connection
+  useEffect(() => {
+    const parser = new ChatStreamParser();
+    parserRef.current = parser;
+
+    const unsubMessages = parser.onChange(() => {
+      setMessages([...parser.getMessages()]);
+    });
+
+    const unsubWaiting = parser.onWaitingChange(setIsWaiting);
+
+    // Connect to PTY
+    const unsubData = window.electronAPI.onPtyData(id, (data: string) => {
+      parser.feed(data);
+      setIsBusy(true);
+    });
+
+    const unsubExit = window.electronAPI.onPtyExit(id, () => {
+      setIsBusy(false);
+      setConnected(false);
+    });
+
+    // Start PTY in chat mode
+    (async () => {
+      try {
+        const isDark = document.documentElement.classList.contains('dark');
+        const result = await window.electronAPI.ptyStartDirect({
+          id,
+          cwd,
+          cols: 120,
+          rows: 40,
+          autoApprove,
+          resume: true,
+          isDark,
+          chatMode: true,
+        });
+
+        if (result.success) {
+          setConnected(true);
+          if (result.data?.reattached) {
+            // Reattached to existing PTY — messages will flow via onPtyData
+            setIsBusy(true);
+          }
+        }
+      } catch (err) {
+        console.error('[ChatPane] Failed to start PTY:', err);
+      }
+    })();
+
+    return () => {
+      unsubMessages();
+      unsubWaiting();
+      unsubData();
+      unsubExit();
+      // Don't kill PTY on unmount — mode switch preserves it, kill is explicit
+    };
+  }, [id, cwd, autoApprove]);
+
+  // Auto-scroll to bottom when new messages arrive
+  useEffect(() => {
+    if (isAtBottom && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages, isAtBottom]);
+
+  // Track scroll position
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+    setIsAtBottom(atBottom);
+  }, []);
+
+  const scrollToBottom = useCallback(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+      setIsAtBottom(true);
+    }
+  }, []);
+
+  // Send user message via PTY stdin
+  const handleSend = useCallback(
+    (text: string) => {
+      window.electronAPI.ptyInput({ id, data: text + '\n' });
+      setIsBusy(true);
+      setIsWaiting(false);
+    },
+    [id],
+  );
+
+  return (
+    <div className="w-full h-full flex flex-col bg-background relative">
+      {/* Message list */}
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto overflow-x-hidden"
+      >
+        {messages.length === 0 && connected && (
+          <div className="flex items-center justify-center h-full">
+            <div className="text-center">
+              <div className="text-[13px] text-muted-foreground/60 mb-1">
+                {isBusy ? 'Waiting for response...' : 'Chat mode active'}
+              </div>
+              <div className="text-[11px] text-muted-foreground/40">
+                Messages will appear here as Claude responds
+              </div>
+            </div>
+          </div>
+        )}
+
+        {messages.length === 0 && !connected && (
+          <div className="flex items-center justify-center h-full">
+            <div className="text-center">
+              <Loader2 size={20} className="animate-spin text-muted-foreground/40 mx-auto mb-2" />
+              <div className="text-[13px] text-muted-foreground/60">Connecting...</div>
+            </div>
+          </div>
+        )}
+
+        {messages.map((msg) => (
+          <MessageBubble key={msg.id} message={msg} allMessages={messages} />
+        ))}
+
+        {/* Busy indicator */}
+        {isBusy && !isWaiting && messages.length > 0 && (
+          <div className="flex items-center gap-2 px-4 py-3">
+            <div className="w-6 h-6 rounded-full bg-accent/80 flex items-center justify-center">
+              <Loader2 size={12} strokeWidth={2} className="animate-spin text-muted-foreground" />
+            </div>
+            <span className="text-[12px] text-muted-foreground animate-pulse">
+              Claude is thinking...
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Scroll to bottom button */}
+      {!isAtBottom && (
+        <Tooltip content="Scroll to bottom">
+          <button
+            onClick={scrollToBottom}
+            className="absolute bottom-[100px] right-4 z-10 w-8 h-8 rounded-full bg-accent/80 hover:bg-accent text-foreground/70 hover:text-foreground flex items-center justify-center shadow-md backdrop-blur-sm transition-all duration-150 hover:scale-105"
+          >
+            <ArrowDown size={16} strokeWidth={2} />
+          </button>
+        </Tooltip>
+      )}
+
+      {/* Compose box */}
+      <ComposeBox
+        onSend={handleSend}
+        disabled={!connected}
+        placeholder={isWaiting ? 'Send a message...' : 'Waiting for Claude to finish...'}
+      />
+    </div>
+  );
+}

--- a/src/renderer/components/MainContent.tsx
+++ b/src/renderer/components/MainContent.tsx
@@ -1,10 +1,20 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { TerminalPane } from './TerminalPane';
+import { ChatPane } from './ChatPane';
 import { ProjectOverview } from './ProjectOverview';
-import { FolderOpen, GitBranch, Globe, GitPullRequest, Code2 } from 'lucide-react';
-import type { Project, Task, RemoteControlState, PullRequestInfo } from '../../shared/types';
+import {
+  FolderOpen,
+  GitBranch,
+  Globe,
+  GitPullRequest,
+  Code2,
+  Terminal,
+  MessageSquare,
+} from 'lucide-react';
+import type { Project, Task, RemoteControlState, PullRequestInfo, ViewMode } from '../../shared/types';
 import { linkedItemUrl, isAdoRemote } from '../../shared/urls';
 import { Tooltip } from './ui/Tooltip';
+import { sessionRegistry } from '../terminal/SessionRegistry';
 
 interface MainContentProps {
   activeTask: Task | null;
@@ -46,6 +56,38 @@ export function MainContent({
   onRestoreTask,
 }: MainContentProps) {
   const [prInfo, setPrInfo] = useState<PullRequestInfo | null>(null);
+
+  // Per-task view mode persisted in localStorage
+  const viewModeKey = activeTask ? `viewMode:${activeTask.id}` : null;
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    if (!viewModeKey) return 'terminal';
+    return (localStorage.getItem(viewModeKey) as ViewMode) || 'terminal';
+  });
+
+  // Reset view mode when task changes
+  useEffect(() => {
+    if (viewModeKey) {
+      const stored = localStorage.getItem(viewModeKey) as ViewMode;
+      setViewMode(stored || 'terminal');
+    }
+  }, [viewModeKey]);
+
+  const handleToggleViewMode = useCallback(() => {
+    if (!activeTask || !viewModeKey) return;
+
+    const newMode: ViewMode = viewMode === 'terminal' ? 'chat' : 'terminal';
+
+    // Kill the current PTY so the new mode can spawn its own
+    window.electronAPI.ptyKill(activeTask.id);
+
+    // If switching away from terminal, detach and dispose the xterm session
+    if (viewMode === 'terminal') {
+      sessionRegistry.dispose(activeTask.id);
+    }
+
+    localStorage.setItem(viewModeKey, newMode);
+    setViewMode(newMode);
+  }, [activeTask, viewModeKey, viewMode]);
 
   useEffect(() => {
     setPrInfo(null);
@@ -158,9 +200,31 @@ export function MainContent({
               </button>
             ))}
           </div>
-          <div className="flex items-center gap-1.5 text-foreground/60 flex-shrink-0">
-            <GitBranch size={11} strokeWidth={2} />
-            <span className="text-[11px] font-mono">{activeTask.branch}</span>
+          <div className="flex items-center gap-1 flex-shrink-0">
+            <div className="flex items-center rounded-md border border-border/60 overflow-hidden mr-1.5">
+              <button
+                onClick={() => viewMode !== 'terminal' && handleToggleViewMode()}
+                className={`p-0.5 transition-colors ${
+                  viewMode === 'terminal'
+                    ? 'bg-primary/15 text-primary'
+                    : 'text-muted-foreground/50 hover:text-foreground hover:bg-accent/60'
+                }`}
+              >
+                <Terminal size={11} strokeWidth={1.8} />
+              </button>
+              <button
+                onClick={() => viewMode !== 'chat' && handleToggleViewMode()}
+                className={`p-0.5 transition-colors ${
+                  viewMode === 'chat'
+                    ? 'bg-primary/15 text-primary'
+                    : 'text-muted-foreground/50 hover:text-foreground hover:bg-accent/60'
+                }`}
+              >
+                <MessageSquare size={11} strokeWidth={1.8} />
+              </button>
+            </div>
+            <GitBranch size={11} strokeWidth={2} className="text-foreground/60" />
+            <span className="text-[11px] font-mono text-foreground/60">{activeTask.branch}</span>
           </div>
         </>
       ) : (
@@ -206,6 +270,33 @@ export function MainContent({
             </div>
           ) : null}
           <div className="ml-auto flex items-center gap-1.5">
+            {/* View mode toggle */}
+            <div className="flex items-center rounded-md border border-border/60 overflow-hidden">
+              <Tooltip content="Terminal view">
+                <button
+                  onClick={() => viewMode !== 'terminal' && handleToggleViewMode()}
+                  className={`p-1 transition-colors ${
+                    viewMode === 'terminal'
+                      ? 'bg-primary/15 text-primary'
+                      : 'text-muted-foreground/50 hover:text-foreground hover:bg-accent/60'
+                  }`}
+                >
+                  <Terminal size={13} strokeWidth={1.8} />
+                </button>
+              </Tooltip>
+              <Tooltip content="Chat view">
+                <button
+                  onClick={() => viewMode !== 'chat' && handleToggleViewMode()}
+                  className={`p-1 transition-colors ${
+                    viewMode === 'chat'
+                      ? 'bg-primary/15 text-primary'
+                      : 'text-muted-foreground/50 hover:text-foreground hover:bg-accent/60'
+                  }`}
+                >
+                  <MessageSquare size={13} strokeWidth={1.8} />
+                </button>
+              </Tooltip>
+            </div>
             {taskActivity[activeTask.id] && (
               <Tooltip content="Remote control">
                 <button
@@ -255,12 +346,21 @@ export function MainContent({
     <div className="h-full flex flex-col bg-background">
       {taskHeader}
       <div className="flex-1 min-h-0">
-        <TerminalPane
-          key={activeTask.id}
-          id={activeTask.id}
-          cwd={activeTask.path}
-          autoApprove={activeTask.autoApprove}
-        />
+        {viewMode === 'chat' ? (
+          <ChatPane
+            key={`chat-${activeTask.id}`}
+            id={activeTask.id}
+            cwd={activeTask.path}
+            autoApprove={activeTask.autoApprove}
+          />
+        ) : (
+          <TerminalPane
+            key={activeTask.id}
+            id={activeTask.id}
+            cwd={activeTask.path}
+            autoApprove={activeTask.autoApprove}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/renderer/components/chat/ComposeBox.tsx
+++ b/src/renderer/components/chat/ComposeBox.tsx
@@ -1,0 +1,73 @@
+import React, { useRef, useCallback, useState } from 'react';
+import { SendHorizonal } from 'lucide-react';
+
+interface ComposeBoxProps {
+  onSend: (text: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+export function ComposeBox({
+  onSend,
+  disabled = false,
+  placeholder = 'Send a message...',
+}: ComposeBoxProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [value, setValue] = useState('');
+
+  const handleSend = useCallback(() => {
+    const text = value.trim();
+    if (!text || disabled) return;
+    onSend(text);
+    setValue('');
+    // Reset textarea height
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+    }
+  }, [value, disabled, onSend]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+      }
+    },
+    [handleSend],
+  );
+
+  const handleInput = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(e.target.value);
+    // Auto-resize textarea
+    const el = e.target;
+    el.style.height = 'auto';
+    el.style.height = Math.min(el.scrollHeight, 200) + 'px';
+  }, []);
+
+  return (
+    <div className="border-t border-border/60 p-3" style={{ background: 'hsl(var(--surface-1))' }}>
+      <div className="flex items-end gap-2 rounded-lg border border-border/80 bg-background px-3 py-2 focus-within:border-primary/50 transition-colors">
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={handleInput}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={1}
+          className="flex-1 resize-none bg-transparent text-[13px] text-foreground placeholder:text-muted-foreground/50 focus:outline-none leading-relaxed max-h-[200px]"
+        />
+        <button
+          onClick={handleSend}
+          disabled={disabled || !value.trim()}
+          className="p-1 rounded-md text-primary hover:bg-primary/10 disabled:opacity-30 disabled:cursor-not-allowed transition-colors shrink-0"
+        >
+          <SendHorizonal size={16} strokeWidth={2} />
+        </button>
+      </div>
+      <div className="mt-1.5 text-[10px] text-muted-foreground/50 text-center">
+        Enter to send, Shift+Enter for new line
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -1,0 +1,222 @@
+import React from 'react';
+
+interface MarkdownRendererProps {
+  content: string;
+}
+
+/**
+ * Lightweight markdown renderer for chat messages.
+ * Handles: fenced code blocks, inline code, bold, italic, links, lists, headings.
+ */
+export function MarkdownRenderer({ content }: MarkdownRendererProps) {
+  const blocks = parseBlocks(content);
+  return <div className="markdown-content">{blocks.map((block, i) => renderBlock(block, i))}</div>;
+}
+
+type Block =
+  | { type: 'code'; lang: string; code: string }
+  | { type: 'paragraph'; text: string }
+  | { type: 'heading'; level: number; text: string }
+  | { type: 'list'; ordered: boolean; items: string[] };
+
+function parseBlocks(text: string): Block[] {
+  const blocks: Block[] = [];
+  const lines = text.split('\n');
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Fenced code block
+    const fenceMatch = line.match(/^```(\w*)/);
+    if (fenceMatch) {
+      const lang = fenceMatch[1] || '';
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith('```')) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      i++; // skip closing ```
+      blocks.push({ type: 'code', lang, code: codeLines.join('\n') });
+      continue;
+    }
+
+    // Heading
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)/);
+    if (headingMatch) {
+      blocks.push({ type: 'heading', level: headingMatch[1].length, text: headingMatch[2] });
+      i++;
+      continue;
+    }
+
+    // Unordered list
+    if (line.match(/^\s*[-*]\s+/)) {
+      const items: string[] = [];
+      while (i < lines.length && lines[i].match(/^\s*[-*]\s+/)) {
+        items.push(lines[i].replace(/^\s*[-*]\s+/, ''));
+        i++;
+      }
+      blocks.push({ type: 'list', ordered: false, items });
+      continue;
+    }
+
+    // Ordered list
+    if (line.match(/^\s*\d+\.\s+/)) {
+      const items: string[] = [];
+      while (i < lines.length && lines[i].match(/^\s*\d+\.\s+/)) {
+        items.push(lines[i].replace(/^\s*\d+\.\s+/, ''));
+        i++;
+      }
+      blocks.push({ type: 'list', ordered: true, items });
+      continue;
+    }
+
+    // Empty line
+    if (line.trim() === '') {
+      i++;
+      continue;
+    }
+
+    // Paragraph: collect consecutive non-empty, non-special lines
+    const paraLines: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== '' &&
+      !lines[i].match(/^```/) &&
+      !lines[i].match(/^#{1,6}\s+/) &&
+      !lines[i].match(/^\s*[-*]\s+/) &&
+      !lines[i].match(/^\s*\d+\.\s+/)
+    ) {
+      paraLines.push(lines[i]);
+      i++;
+    }
+    if (paraLines.length > 0) {
+      blocks.push({ type: 'paragraph', text: paraLines.join('\n') });
+    }
+  }
+
+  return blocks;
+}
+
+function renderBlock(block: Block, key: number): React.ReactNode {
+  switch (block.type) {
+    case 'code':
+      return (
+        <div key={key} className="my-2 rounded-md overflow-hidden border border-border/60">
+          {block.lang && (
+            <div className="px-3 py-1 text-[10px] font-mono text-muted-foreground bg-surface-1 border-b border-border/40">
+              {block.lang}
+            </div>
+          )}
+          <pre className="p-3 text-[12px] font-mono leading-relaxed overflow-x-auto bg-surface-0">
+            <code>{block.code}</code>
+          </pre>
+        </div>
+      );
+
+    case 'heading': {
+      const sizes = [
+        'text-lg font-bold',
+        'text-base font-bold',
+        'text-sm font-semibold',
+        'text-sm font-semibold',
+        'text-xs font-semibold',
+        'text-xs font-semibold',
+      ];
+      return (
+        <div key={key} className={`${sizes[block.level - 1]} mt-3 mb-1 text-foreground`}>
+          {renderInline(block.text)}
+        </div>
+      );
+    }
+
+    case 'list': {
+      const Tag = block.ordered ? 'ol' : 'ul';
+      return (
+        <Tag
+          key={key}
+          className={`my-1.5 pl-5 text-[13px] leading-relaxed ${block.ordered ? 'list-decimal' : 'list-disc'}`}
+        >
+          {block.items.map((item, j) => (
+            <li key={j} className="text-foreground/90">
+              {renderInline(item)}
+            </li>
+          ))}
+        </Tag>
+      );
+    }
+
+    case 'paragraph':
+      return (
+        <p key={key} className="my-1.5 text-[13px] leading-relaxed text-foreground/90">
+          {renderInline(block.text)}
+        </p>
+      );
+  }
+}
+
+/** Render inline markdown: bold, italic, inline code, links. */
+function renderInline(text: string): React.ReactNode {
+  // Split on inline patterns, preserving delimiters
+  const parts: React.ReactNode[] = [];
+  // Regex for: `code`, **bold**, *italic*, [text](url)
+  const regex = /(`[^`]+`|\*\*[^*]+\*\*|\*[^*]+\*|\[[^\]]+\]\([^)]+\))/g;
+  let lastIndex = 0;
+  let match;
+
+  while ((match = regex.exec(text)) !== null) {
+    // Add preceding text
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+
+    const token = match[0];
+    if (token.startsWith('`')) {
+      parts.push(
+        <code
+          key={match.index}
+          className="px-1 py-0.5 rounded bg-surface-1 text-[12px] font-mono text-foreground/80"
+        >
+          {token.slice(1, -1)}
+        </code>,
+      );
+    } else if (token.startsWith('**')) {
+      parts.push(
+        <strong key={match.index} className="font-semibold">
+          {token.slice(2, -2)}
+        </strong>,
+      );
+    } else if (token.startsWith('*')) {
+      parts.push(
+        <em key={match.index} className="italic">
+          {token.slice(1, -1)}
+        </em>,
+      );
+    } else if (token.startsWith('[')) {
+      const linkMatch = token.match(/\[([^\]]+)\]\(([^)]+)\)/);
+      if (linkMatch) {
+        parts.push(
+          <a
+            key={match.index}
+            href={linkMatch[2]}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+          >
+            {linkMatch[1]}
+          </a>,
+        );
+      }
+    }
+
+    lastIndex = match.index + token.length;
+  }
+
+  // Add remaining text
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  return parts.length === 1 ? parts[0] : <>{parts}</>;
+}

--- a/src/renderer/components/chat/MessageBubble.tsx
+++ b/src/renderer/components/chat/MessageBubble.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { User, Bot, AlertTriangle } from 'lucide-react';
+import type { ChatMessage, ChatContentBlock } from '../../../shared/types';
+import { MarkdownRenderer } from './MarkdownRenderer';
+import { ToolUseBlock } from './ToolUseBlock';
+
+interface MessageBubbleProps {
+  message: ChatMessage;
+  /** All messages in the conversation, for finding tool results. */
+  allMessages: ChatMessage[];
+}
+
+export function MessageBubble({ message, allMessages }: MessageBubbleProps) {
+  if (message.role === 'system') {
+    return (
+      <div className="flex items-start gap-2 px-4 py-2">
+        <AlertTriangle size={14} strokeWidth={1.8} className="text-orange-500 mt-0.5 shrink-0" />
+        <div className="text-[12px] text-orange-600 dark:text-orange-400">
+          {getTextContent(message.content)}
+        </div>
+      </div>
+    );
+  }
+
+  const isUser = message.role === 'user';
+
+  return (
+    <div className={`flex gap-3 px-4 py-3 ${isUser ? '' : 'bg-surface-0/50'}`}>
+      {/* Avatar */}
+      <div
+        className={`w-6 h-6 rounded-full flex items-center justify-center shrink-0 mt-0.5 ${
+          isUser
+            ? 'bg-primary/10 text-primary'
+            : 'bg-accent/80 text-muted-foreground'
+        }`}
+      >
+        {isUser ? (
+          <User size={13} strokeWidth={2} />
+        ) : (
+          <Bot size={13} strokeWidth={2} />
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="text-[12px] font-semibold text-foreground">
+            {isUser ? 'You' : 'Claude'}
+          </span>
+          {message.model && (
+            <span className="text-[10px] text-muted-foreground font-mono">{message.model}</span>
+          )}
+          {message.costUsd !== undefined && (
+            <span className="text-[10px] text-muted-foreground">
+              ${message.costUsd.toFixed(4)}
+            </span>
+          )}
+        </div>
+
+        <div className="space-y-1">
+          {message.content.map((block, i) => renderContentBlock(block, i, allMessages))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function renderContentBlock(
+  block: ChatContentBlock,
+  key: number,
+  allMessages: ChatMessage[],
+): React.ReactNode {
+  switch (block.type) {
+    case 'text':
+      return <MarkdownRenderer key={key} content={block.text} />;
+
+    case 'tool_use': {
+      // Find the corresponding tool_result in subsequent messages
+      const result = findToolResult(block.id, allMessages);
+      return <ToolUseBlock key={key} block={block} result={result} />;
+    }
+
+    case 'tool_result':
+      // Tool results are rendered inline with their tool_use blocks, skip standalone
+      return null;
+
+    default:
+      return null;
+  }
+}
+
+function findToolResult(
+  toolUseId: string,
+  allMessages: ChatMessage[],
+): (ChatContentBlock & { type: 'tool_result' }) | null {
+  for (const msg of allMessages) {
+    for (const block of msg.content) {
+      if (block.type === 'tool_result' && block.tool_use_id === toolUseId) {
+        return block;
+      }
+    }
+  }
+  return null;
+}
+
+function getTextContent(blocks: ChatContentBlock[]): string {
+  return blocks
+    .filter((b): b is ChatContentBlock & { type: 'text' } => b.type === 'text')
+    .map((b) => b.text)
+    .join('\n');
+}

--- a/src/renderer/components/chat/ToolUseBlock.tsx
+++ b/src/renderer/components/chat/ToolUseBlock.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { ChevronRight, Wrench, AlertCircle } from 'lucide-react';
+import type { ChatContentBlock } from '../../../shared/types';
+
+interface ToolUseBlockProps {
+  block: ChatContentBlock & { type: 'tool_use' };
+  result?: (ChatContentBlock & { type: 'tool_result' }) | null;
+}
+
+export function ToolUseBlock({ block, result }: ToolUseBlockProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="my-1.5 rounded-md border border-border/60 overflow-hidden">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-accent/30 transition-colors"
+        style={{ background: 'hsl(var(--surface-1))' }}
+      >
+        <ChevronRight
+          size={12}
+          strokeWidth={2}
+          className={`text-muted-foreground transition-transform duration-150 ${expanded ? 'rotate-90' : ''}`}
+        />
+        <Wrench size={12} strokeWidth={1.8} className="text-muted-foreground" />
+        <span className="text-[12px] font-mono font-medium text-foreground/80">{block.name}</span>
+        {result?.is_error && (
+          <AlertCircle size={12} strokeWidth={2} className="text-destructive ml-auto" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="border-t border-border/40">
+          {/* Input */}
+          <div className="px-3 py-2" style={{ background: 'hsl(var(--surface-0))' }}>
+            <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide mb-1">
+              Input
+            </div>
+            <pre className="text-[11px] font-mono text-foreground/70 whitespace-pre-wrap break-all overflow-x-auto max-h-[200px] overflow-y-auto">
+              {formatJson(block.input)}
+            </pre>
+          </div>
+
+          {/* Result */}
+          {result && (
+            <div
+              className="px-3 py-2 border-t border-border/40"
+              style={{ background: 'hsl(var(--surface-0))' }}
+            >
+              <div
+                className={`text-[10px] font-medium uppercase tracking-wide mb-1 ${
+                  result.is_error ? 'text-destructive' : 'text-muted-foreground'
+                }`}
+              >
+                {result.is_error ? 'Error' : 'Output'}
+              </div>
+              <pre
+                className={`text-[11px] font-mono whitespace-pre-wrap break-all overflow-x-auto max-h-[200px] overflow-y-auto ${
+                  result.is_error ? 'text-destructive/80' : 'text-foreground/70'
+                }`}
+              >
+                {result.content}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatJson(obj: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(obj, null, 2);
+  } catch {
+    return String(obj);
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -272,6 +272,63 @@ export interface PullRequestInfo {
   provider: 'github' | 'ado';
 }
 
+// ── Chat UI Types ───────────────────────────────────────────
+
+export type ViewMode = 'terminal' | 'chat';
+
+/** A single content block inside an assistant message. */
+export type ChatContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+  | { type: 'tool_result'; tool_use_id: string; content: string; is_error?: boolean };
+
+/** Parsed chat message for display. */
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: ChatContentBlock[];
+  timestamp: number;
+  /** Cost in USD for this turn (from result events). */
+  costUsd?: number;
+  /** Model that produced this message. */
+  model?: string;
+}
+
+/** Raw stream-json event from Claude CLI. */
+export type StreamJsonEvent =
+  | {
+      type: 'system';
+      subtype: 'init' | 'error';
+      session_id?: string;
+      message?: string;
+      tools?: unknown[];
+    }
+  | {
+      type: 'assistant';
+      message: {
+        id: string;
+        role: 'assistant';
+        content: ChatContentBlock[];
+        model?: string;
+        stop_reason?: string;
+      };
+    }
+  | {
+      type: 'user';
+      message: {
+        role: 'user';
+        content: ChatContentBlock[];
+      };
+    }
+  | {
+      type: 'result';
+      subtype: 'success' | 'error';
+      cost_usd?: number;
+      duration_ms?: number;
+      session_id?: string;
+      is_error?: boolean;
+    };
+
 // ── Remote Control Types ────────────────────────────────────
 
 export interface RemoteControlState {

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -96,6 +96,7 @@ export interface ElectronAPI {
     autoApprove?: boolean;
     resume?: boolean;
     isDark?: boolean;
+    chatMode?: boolean;
   }) => Promise<
     IpcResponse<{
       reattached: boolean;


### PR DESCRIPTION
Implements per-task toggle between terminal (xterm.js) and chat UI modes.
Both modes share the same Claude session via --session-id, allowing
instant switching without losing context.

Chat mode spawns Claude CLI with --output-format stream-json and renders
structured output as a conversation UI with:
- Parsed markdown in assistant responses
- Collapsible tool use sections with input/output
- Multiline compose box for user input
- Auto-scroll with manual scroll-back support

Terminal remains the ground truth fallback — if chat parsing breaks,
users can flip back to terminal instantly with no data loss.

Closes #78

https://claude.ai/code/session_01SBVie3jQcvT4bGkUknDRiR