### PR TITLE
Support for custom fonts

### DIFF
--- a/src/main/ipc/fontIpc.ts
+++ b/src/main/ipc/fontIpc.ts
@@ -24,38 +24,31 @@ set AppleScript's text item delimiters to "\\n"
 return monoFonts as text`;
 
 async function detectMonospaceFonts(): Promise<string[]> {
-  if (cachedFonts) return cachedFonts;
+  if (cachedFonts && cachedFonts.length > 0) return cachedFonts;
 
   try {
+    let stdout: string;
     if (process.platform === 'darwin') {
       // macOS: use NSFontManager via AppleScript to reliably detect fixed-pitch fonts
-      const { stdout } = await execFileAsync('osascript', ['-e', APPLESCRIPT_MONO_FONTS], {
+      ({ stdout } = await execFileAsync('/usr/bin/osascript', ['-e', APPLESCRIPT_MONO_FONTS], {
         timeout: 15000,
-      });
-      const families = new Set<string>();
-      for (const line of stdout.split('\n')) {
-        const name = line.trim();
-        if (name) families.add(name);
-      }
-      cachedFonts = [...families].sort((a, b) => a.localeCompare(b));
+      }));
     } else {
       // Linux: use fc-list to find monospace fonts
-      const { stdout } = await execFileAsync('fc-list', [
-        ':spacing=mono',
-        '--format=%{family[0]}\n',
-      ]);
-      const families = new Set<string>();
-      for (const line of stdout.split('\n')) {
-        const name = line.trim();
-        if (name) families.add(name);
-      }
-      cachedFonts = [...families].sort((a, b) => a.localeCompare(b));
+      ({ stdout } = await execFileAsync('fc-list', [':spacing=mono', '--format=%{family[0]}\n']));
     }
-  } catch {
-    cachedFonts = [];
+    const families = new Set<string>();
+    for (const line of stdout.split('\n')) {
+      const name = line.trim();
+      if (name) families.add(name);
+    }
+    cachedFonts = [...families].sort((a, b) => a.localeCompare(b));
+  } catch (err) {
+    console.error('[fontIpc] Failed to detect system fonts:', err);
+    cachedFonts = null;
   }
 
-  return cachedFonts;
+  return cachedFonts ?? [];
 }
 
 export function registerFontIpc(): void {

--- a/src/main/ipc/fontIpc.ts
+++ b/src/main/ipc/fontIpc.ts
@@ -1,0 +1,70 @@
+import { ipcMain } from 'electron';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+let cachedFonts: string[] | null = null;
+
+async function detectMonospaceFonts(): Promise<string[]> {
+  if (cachedFonts) return cachedFonts;
+
+  try {
+    if (process.platform === 'darwin') {
+      // macOS: use system_profiler to list all fonts, filter for monospace
+      const { stdout } = await execFileAsync('system_profiler', ['SPFontsDataType'], {
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      const families = new Set<string>();
+      let currentFamily = '';
+      for (const line of stdout.split('\n')) {
+        const familyMatch = line.match(/^\s+Family:\s+(.+)/);
+        if (familyMatch) {
+          currentFamily = familyMatch[1].trim();
+        }
+        // Look for monospace/fixed-width type indicators
+        if (
+          currentFamily &&
+          (line.includes('Style: Monospaced') ||
+            line.includes('Style: Fixed') ||
+            /\bMono\b/i.test(currentFamily) ||
+            /\bCode\b/i.test(currentFamily) ||
+            /\bConsolas\b/i.test(currentFamily) ||
+            /\bCourier\b/i.test(currentFamily) ||
+            /\bMenlo\b/i.test(currentFamily) ||
+            /\bMonaco\b/i.test(currentFamily))
+        ) {
+          families.add(currentFamily);
+        }
+      }
+      cachedFonts = [...families].sort((a, b) => a.localeCompare(b));
+    } else {
+      // Linux: use fc-list to find monospace fonts
+      const { stdout } = await execFileAsync('fc-list', [
+        ':spacing=mono',
+        '--format=%{family[0]}\n',
+      ]);
+      const families = new Set<string>();
+      for (const line of stdout.split('\n')) {
+        const name = line.trim();
+        if (name) families.add(name);
+      }
+      cachedFonts = [...families].sort((a, b) => a.localeCompare(b));
+    }
+  } catch {
+    cachedFonts = [];
+  }
+
+  return cachedFonts;
+}
+
+export function registerFontIpc(): void {
+  ipcMain.handle('font:getSystemFonts', async () => {
+    try {
+      const fonts = await detectMonospaceFonts();
+      return { success: true, data: fonts };
+    } catch (err) {
+      return { success: false, error: String(err) };
+    }
+  });
+}

--- a/src/main/ipc/fontIpc.ts
+++ b/src/main/ipc/fontIpc.ts
@@ -35,7 +35,10 @@ async function detectMonospaceFonts(): Promise<string[]> {
       }));
     } else {
       // Linux: use fc-list to find monospace fonts
-      ({ stdout } = await execFileAsync('fc-list', [':spacing=mono', '--format=%{family[0]}\n']));
+      ({ stdout } = await execFileAsync('/usr/bin/fc-list', [
+        ':spacing=mono',
+        '--format=%{family[0]}\n',
+      ]));
     }
     const families = new Set<string>();
     for (const line of stdout.split('\n')) {

--- a/src/main/ipc/fontIpc.ts
+++ b/src/main/ipc/fontIpc.ts
@@ -6,36 +6,36 @@ const execFileAsync = promisify(execFile);
 
 let cachedFonts: string[] | null = null;
 
+const APPLESCRIPT_MONO_FONTS = `
+use framework "AppKit"
+set fm to current application's NSFontManager's sharedFontManager()
+set fonts to fm's availableFontFamilies() as list
+set monoFonts to {}
+repeat with f in fonts
+  set members to fm's availableMembersOfFontFamily:(f as text)
+  if members is not missing value and (count of members) > 0 then
+    set traits to item 4 of item 1 of (members as list)
+    if (traits mod 2048) div 1024 = 1 then
+      set end of monoFonts to (f as text)
+    end if
+  end if
+end repeat
+set AppleScript's text item delimiters to "\\n"
+return monoFonts as text`;
+
 async function detectMonospaceFonts(): Promise<string[]> {
   if (cachedFonts) return cachedFonts;
 
   try {
     if (process.platform === 'darwin') {
-      // macOS: use system_profiler to list all fonts, filter for monospace
-      const { stdout } = await execFileAsync('system_profiler', ['SPFontsDataType'], {
-        maxBuffer: 10 * 1024 * 1024,
+      // macOS: use NSFontManager via AppleScript to reliably detect fixed-pitch fonts
+      const { stdout } = await execFileAsync('osascript', ['-e', APPLESCRIPT_MONO_FONTS], {
+        timeout: 15000,
       });
       const families = new Set<string>();
-      let currentFamily = '';
       for (const line of stdout.split('\n')) {
-        const familyMatch = line.match(/^\s+Family:\s+(.+)/);
-        if (familyMatch) {
-          currentFamily = familyMatch[1].trim();
-        }
-        // Look for monospace/fixed-width type indicators
-        if (
-          currentFamily &&
-          (line.includes('Style: Monospaced') ||
-            line.includes('Style: Fixed') ||
-            /\bMono\b/i.test(currentFamily) ||
-            /\bCode\b/i.test(currentFamily) ||
-            /\bConsolas\b/i.test(currentFamily) ||
-            /\bCourier\b/i.test(currentFamily) ||
-            /\bMenlo\b/i.test(currentFamily) ||
-            /\bMonaco\b/i.test(currentFamily))
-        ) {
-          families.add(currentFamily);
-        }
+        const name = line.trim();
+        if (name) families.add(name);
       }
       cachedFonts = [...families].sort((a, b) => a.localeCompare(b));
     } else {

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -8,6 +8,7 @@ import { registerAutoUpdateIpc } from './autoUpdateIpc';
 import { registerAzureDevOpsIpc } from './azureDevOpsIpc';
 import { registerPixelAgentsIpc } from './pixelAgentsIpc';
 import { registerTelemetryIpc } from './telemetryIpc';
+import { registerFontIpc } from './fontIpc';
 
 export function registerAllIpc(): void {
   registerAppIpc();
@@ -20,4 +21,5 @@ export function registerAllIpc(): void {
   registerAzureDevOpsIpc();
   registerPixelAgentsIpc();
   registerTelemetryIpc();
+  registerFontIpc();
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -13,6 +13,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   openInIDE: (args: { folderPath: string; ide?: 'cursor' | 'code' }) =>
     ipcRenderer.invoke('app:openInIDE', args),
   detectAvailableIDEs: () => ipcRenderer.invoke('app:detectAvailableIDEs'),
+  getSystemFonts: () => ipcRenderer.invoke('font:getSystemFonts'),
 
   // Database - Projects
   getProjects: () => ipcRenderer.invoke('db:getProjects'),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -98,6 +98,17 @@ export function App() {
   const [terminalTheme, setTerminalTheme] = useState(() => {
     return localStorage.getItem('terminalTheme') || 'default';
   });
+  const [terminalFontFamily, setTerminalFontFamily] = useState<string | null>(() => {
+    return localStorage.getItem('terminalFontFamily') || null;
+  });
+  const [terminalFontSize, setTerminalFontSize] = useState(() => {
+    const stored = localStorage.getItem('terminalFontSize');
+    return stored ? parseInt(stored, 10) : 13;
+  });
+  const [terminalLineHeight, setTerminalLineHeight] = useState(() => {
+    const stored = localStorage.getItem('terminalLineHeight');
+    return stored ? parseFloat(stored) : 1.2;
+  });
   const [preferredIDE, setPreferredIDE] = useState<'cursor' | 'code' | 'auto'>(() => {
     return (localStorage.getItem('preferredIDE') as 'cursor' | 'code' | 'auto') || 'auto';
   });
@@ -385,6 +396,11 @@ export function App() {
     document.documentElement.classList.toggle('light', theme === 'light');
     sessionRegistry.setAllTerminalThemes(terminalTheme, theme === 'dark');
   }, [theme, terminalTheme]);
+
+  // Terminal font
+  useEffect(() => {
+    sessionRegistry.setAllTerminalFont(terminalFontFamily, terminalFontSize, terminalLineHeight);
+  }, [terminalFontFamily, terminalFontSize, terminalLineHeight]);
 
   // Git: watch active task directory + poll
   useEffect(() => {
@@ -1384,6 +1400,25 @@ export function App() {
             setTerminalTheme(id);
             localStorage.setItem('terminalTheme', id);
             sessionRegistry.setAllTerminalThemes(id, theme === 'dark');
+          }}
+          terminalFontFamily={terminalFontFamily}
+          onTerminalFontFamilyChange={(f: string | null) => {
+            setTerminalFontFamily(f);
+            if (f) {
+              localStorage.setItem('terminalFontFamily', f);
+            } else {
+              localStorage.removeItem('terminalFontFamily');
+            }
+          }}
+          terminalFontSize={terminalFontSize}
+          onTerminalFontSizeChange={(s: number) => {
+            setTerminalFontSize(s);
+            localStorage.setItem('terminalFontSize', String(s));
+          }}
+          terminalLineHeight={terminalLineHeight}
+          onTerminalLineHeightChange={(h: number) => {
+            setTerminalLineHeight(h);
+            localStorage.setItem('terminalLineHeight', String(h));
           }}
           diffContextLines={diffContextLines}
           onDiffContextLinesChange={(v) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -98,17 +98,6 @@ export function App() {
   const [terminalTheme, setTerminalTheme] = useState(() => {
     return localStorage.getItem('terminalTheme') || 'default';
   });
-  const [terminalFontFamily, setTerminalFontFamily] = useState<string | null>(() => {
-    return localStorage.getItem('terminalFontFamily') || null;
-  });
-  const [terminalFontSize, setTerminalFontSize] = useState(() => {
-    const stored = localStorage.getItem('terminalFontSize');
-    return stored ? parseInt(stored, 10) : 13;
-  });
-  const [terminalLineHeight, setTerminalLineHeight] = useState(() => {
-    const stored = localStorage.getItem('terminalLineHeight');
-    return stored ? parseFloat(stored) : 1.2;
-  });
   const [preferredIDE, setPreferredIDE] = useState<'cursor' | 'code' | 'auto'>(() => {
     return (localStorage.getItem('preferredIDE') as 'cursor' | 'code' | 'auto') || 'auto';
   });
@@ -396,11 +385,6 @@ export function App() {
     document.documentElement.classList.toggle('light', theme === 'light');
     sessionRegistry.setAllTerminalThemes(terminalTheme, theme === 'dark');
   }, [theme, terminalTheme]);
-
-  // Terminal font
-  useEffect(() => {
-    sessionRegistry.setAllTerminalFont(terminalFontFamily, terminalFontSize, terminalLineHeight);
-  }, [terminalFontFamily, terminalFontSize, terminalLineHeight]);
 
   // Git: watch active task directory + poll
   useEffect(() => {
@@ -882,9 +866,7 @@ export function App() {
               prompt,
               meta: {
                 githubIssues:
-                  ghItems.length > 0
-                    ? ghItems.map((i) => ({ id: i.id, url: i.url }))
-                    : undefined,
+                  ghItems.length > 0 ? ghItems.map((i) => ({ id: i.id, url: i.url })) : undefined,
                 adoWorkItems:
                   adoItems.length > 0
                     ? adoItems.map((wi) => ({ id: wi.id, url: wi.url }))
@@ -1400,25 +1382,6 @@ export function App() {
             setTerminalTheme(id);
             localStorage.setItem('terminalTheme', id);
             sessionRegistry.setAllTerminalThemes(id, theme === 'dark');
-          }}
-          terminalFontFamily={terminalFontFamily}
-          onTerminalFontFamilyChange={(f: string | null) => {
-            setTerminalFontFamily(f);
-            if (f) {
-              localStorage.setItem('terminalFontFamily', f);
-            } else {
-              localStorage.removeItem('terminalFontFamily');
-            }
-          }}
-          terminalFontSize={terminalFontSize}
-          onTerminalFontSizeChange={(s: number) => {
-            setTerminalFontSize(s);
-            localStorage.setItem('terminalFontSize', String(s));
-          }}
-          terminalLineHeight={terminalLineHeight}
-          onTerminalLineHeightChange={(h: number) => {
-            setTerminalLineHeight(h);
-            localStorage.setItem('terminalLineHeight', String(h));
           }}
           diffContextLines={diffContextLines}
           onDiffContextLinesChange={(v) => {

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -30,6 +30,7 @@ import {
   LINE_HEIGHT_MIN,
   LINE_HEIGHT_MAX,
   LINE_HEIGHT_STEP,
+  detectInstalledFonts,
 } from '../terminal/terminalFonts';
 import type {
   PixelAgentsConfig,
@@ -584,19 +585,11 @@ export function SettingsModal({
   const [systemFonts, setSystemFonts] = useState<string[]>([]);
   const fontDropdownRef = useRef<HTMLDivElement>(null);
 
-  // Load system fonts when dropdown opens
+  // Detect installed system fonts when dropdown first opens
   useEffect(() => {
     if (fontDropdownOpen && systemFonts.length === 0) {
-      window.electronAPI
-        .getSystemFonts()
-        .then((resp) => {
-          if (resp.success && resp.data && resp.data.length > 0) {
-            setSystemFonts(resp.data);
-          }
-        })
-        .catch((err) => {
-          console.error('[SettingsModal] Failed to load system fonts:', err);
-        });
+      const detected = detectInstalledFonts();
+      if (detected.length > 0) setSystemFonts(detected);
     }
   }, [fontDropdownOpen, systemFonts.length]);
 

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -581,30 +581,20 @@ export function SettingsModal({
 
   const [fontDropdownOpen, setFontDropdownOpen] = useState(false);
   const [fontSearch, setFontSearch] = useState('');
-  const [showSystemFonts, setShowSystemFonts] = useState(false);
   const [systemFonts, setSystemFonts] = useState<string[]>([]);
-  const [systemFontsLoading, setSystemFontsLoading] = useState(false);
   const fontDropdownRef = useRef<HTMLDivElement>(null);
 
-  const loadSystemFonts = async () => {
-    if (systemFonts.length > 0) return;
-    setSystemFontsLoading(true);
-    try {
-      const resp = await window.electronAPI.getSystemFonts();
-      if (resp.success && resp.data) {
-        setSystemFonts(resp.data);
-      }
-    } catch {
-      // Silently fail — curated list still works
-    }
-    setSystemFontsLoading(false);
-  };
-
+  // Load system fonts when dropdown opens
   useEffect(() => {
-    if (showSystemFonts && systemFonts.length === 0) {
-      loadSystemFonts();
+    if (fontDropdownOpen && systemFonts.length === 0) {
+      window.electronAPI
+        .getSystemFonts()
+        .then((resp) => {
+          if (resp.success && resp.data) setSystemFonts(resp.data);
+        })
+        .catch(() => {});
     }
-  }, [showSystemFonts]);
+  }, [fontDropdownOpen]);
 
   // Close font dropdown on click outside
   useEffect(() => {
@@ -1217,9 +1207,7 @@ export function SettingsModal({
                               setFontSearch('');
                             }}
                             className={`w-full text-left px-3 py-1.5 text-[13px] hover:bg-surface-2 transition-colors ${
-                              terminalFontFamily === null
-                                ? 'text-primary'
-                                : 'text-foreground/80'
+                              terminalFontFamily === null ? 'text-primary' : 'text-foreground/80'
                             }`}
                           >
                             Default (monospace)
@@ -1256,23 +1244,19 @@ export function SettingsModal({
                             </button>
                           ))}
 
-                          {/* System fonts toggle + list */}
-                          <div className="border-t border-border/40 mt-1 pt-1">
-                            <button
-                              onClick={() => setShowSystemFonts(!showSystemFonts)}
-                              className="w-full text-left px-3 py-1.5 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
-                            >
-                              {showSystemFonts ? '▾' : '▸'} System fonts
-                              {systemFontsLoading && (
-                                <span className="ml-2 text-[10px] text-muted-foreground/50">
-                                  Loading...
-                                </span>
-                              )}
-                            </button>
-                            {showSystemFonts &&
-                              systemFonts
-                                .filter((f) =>
-                                  f.toLowerCase().includes(fontSearch.toLowerCase()),
+                          {/* System fonts — flat list, deduped against curated */}
+                          {systemFonts.length > 0 && (
+                            <>
+                              <div className="px-3 pt-2 pb-1 text-[10px] text-muted-foreground/60 uppercase tracking-wider border-t border-border/40 mt-1">
+                                System
+                              </div>
+                              {systemFonts
+                                .filter(
+                                  (f) =>
+                                    f.toLowerCase().includes(fontSearch.toLowerCase()) &&
+                                    !CURATED_FONTS.some(
+                                      (c) => c.name.toLowerCase() === f.toLowerCase(),
+                                    ),
                                 )
                                 .map((f) => {
                                   const family = `'${f}', monospace`;
@@ -1287,7 +1271,7 @@ export function SettingsModal({
                                       className={`w-full text-left px-3 py-1.5 text-[13px] hover:bg-surface-2 transition-colors ${
                                         terminalFontFamily === family
                                           ? 'text-primary'
-                                          : 'text-foreground/60'
+                                          : 'text-foreground/80'
                                       }`}
                                       style={{ fontFamily: family }}
                                     >
@@ -1300,7 +1284,8 @@ export function SettingsModal({
                                     </button>
                                   );
                                 })}
-                          </div>
+                            </>
+                          )}
                         </div>
                       </div>
                     )}
@@ -1384,8 +1369,7 @@ export function SettingsModal({
                       fontFamily: terminalFontFamily || 'monospace',
                       fontSize: `${terminalFontSize}px`,
                       lineHeight: terminalLineHeight,
-                      color:
-                        resolveTheme(terminalTheme, theme === 'dark').foreground || '#d4d4d4',
+                      color: resolveTheme(terminalTheme, theme === 'dark').foreground || '#d4d4d4',
                     }}
                   >
                     <div>

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -22,16 +22,8 @@ import {
 } from '../keybindings';
 import { NOTIFICATION_SOUNDS, SOUND_LABELS } from '../sounds';
 import type { NotificationSound } from '../sounds';
-import { TERMINAL_THEMES, resolveTheme } from '../terminal/terminalThemes';
-import {
-  CURATED_FONTS,
-  FONT_SIZE_MIN,
-  FONT_SIZE_MAX,
-  LINE_HEIGHT_MIN,
-  LINE_HEIGHT_MAX,
-  LINE_HEIGHT_STEP,
-  detectInstalledFonts,
-} from '../terminal/terminalFonts';
+import { TERMINAL_THEMES } from '../terminal/terminalThemes';
+import { TerminalFontSettings } from './TerminalFontSettings';
 import type {
   PixelAgentsConfig,
   PixelAgentsStatus,
@@ -60,12 +52,6 @@ interface SettingsModalProps {
   onShellDrawerPositionChange: (value: 'left' | 'main' | 'right') => void;
   terminalTheme: string;
   onTerminalThemeChange: (id: string) => void;
-  terminalFontFamily: string | null;
-  onTerminalFontFamilyChange: (family: string | null) => void;
-  terminalFontSize: number;
-  onTerminalFontSizeChange: (size: number) => void;
-  terminalLineHeight: number;
-  onTerminalLineHeightChange: (height: number) => void;
   preferredIDE: 'cursor' | 'code' | 'auto';
   onPreferredIDEChange: (value: 'cursor' | 'code' | 'auto') => void;
   commitAttribution: string | undefined;
@@ -542,12 +528,6 @@ export function SettingsModal({
   onShellDrawerPositionChange,
   terminalTheme,
   onTerminalThemeChange,
-  terminalFontFamily,
-  onTerminalFontFamilyChange,
-  terminalFontSize,
-  onTerminalFontSizeChange,
-  terminalLineHeight,
-  onTerminalLineHeightChange,
   preferredIDE,
   onPreferredIDEChange,
   commitAttribution,
@@ -579,32 +559,6 @@ export function SettingsModal({
   const [updateVersion, setUpdateVersion] = useState<string | null>(null);
   const [telemetryEnabled, setTelemetryEnabled] = useState(true);
   const [telemetryEnvDisabled, setTelemetryEnvDisabled] = useState(false);
-
-  const [fontDropdownOpen, setFontDropdownOpen] = useState(false);
-  const [fontSearch, setFontSearch] = useState('');
-  const [systemFonts, setSystemFonts] = useState<string[]>([]);
-  const fontDropdownRef = useRef<HTMLDivElement>(null);
-
-  // Detect installed system fonts when dropdown first opens
-  useEffect(() => {
-    if (fontDropdownOpen && systemFonts.length === 0) {
-      const detected = detectInstalledFonts();
-      if (detected.length > 0) setSystemFonts(detected);
-    }
-  }, [fontDropdownOpen, systemFonts.length]);
-
-  // Close font dropdown on click outside
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (fontDropdownRef.current && !fontDropdownRef.current.contains(e.target as Node)) {
-        setFontDropdownOpen(false);
-      }
-    };
-    if (fontDropdownOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => document.removeEventListener('mousedown', handleClickOutside);
-    }
-  }, [fontDropdownOpen]);
 
   useEffect(() => {
     const cleanups = [
@@ -1158,257 +1112,7 @@ export function SettingsModal({
                 </div>
               </div>
 
-              {/* Terminal Font */}
-              <div>
-                <label className="block text-[12px] font-medium text-foreground mb-3">
-                  Terminal Font
-                </label>
-
-                {/* Font Family Picker */}
-                <div className="mb-4">
-                  <div className="text-[11px] text-muted-foreground mb-1.5">Font Family</div>
-                  <div ref={fontDropdownRef} className="relative">
-                    <button
-                      onClick={() => setFontDropdownOpen(!fontDropdownOpen)}
-                      className="w-full flex items-center justify-between px-3 py-2 rounded-lg border border-border/60 bg-surface-0 text-[13px] text-foreground hover:border-border transition-colors"
-                    >
-                      <span style={{ fontFamily: terminalFontFamily || 'monospace' }}>
-                        {terminalFontFamily
-                          ? CURATED_FONTS.find((f) => f.family === terminalFontFamily)?.name ||
-                            terminalFontFamily.split(',')[0].replace(/'/g, '').trim()
-                          : 'Default (monospace)'}
-                      </span>
-                      <span className="text-muted-foreground text-[10px]">▼</span>
-                    </button>
-
-                    {fontDropdownOpen && (
-                      <div className="absolute z-50 top-full left-0 right-0 mt-1 rounded-lg border border-border/60 bg-surface-1 shadow-lg max-h-[280px] overflow-hidden flex flex-col">
-                        {/* Search */}
-                        <div className="p-2 border-b border-border/40">
-                          <input
-                            type="text"
-                            value={fontSearch}
-                            onChange={(e) => setFontSearch(e.target.value)}
-                            placeholder="Search fonts..."
-                            className="w-full px-2.5 py-1.5 rounded-md border border-border/60 bg-surface-0 text-[12px] text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:border-primary/40"
-                            autoFocus
-                          />
-                        </div>
-
-                        <div className="overflow-y-auto flex-1">
-                          {/* Default option */}
-                          <button
-                            onClick={() => {
-                              onTerminalFontFamilyChange(null);
-                              setFontDropdownOpen(false);
-                              setFontSearch('');
-                            }}
-                            className={`w-full text-left px-3 py-1.5 text-[13px] hover:bg-surface-2 transition-colors ${
-                              terminalFontFamily === null ? 'text-primary' : 'text-foreground/80'
-                            }`}
-                          >
-                            Default (monospace)
-                            {terminalFontFamily === null && (
-                              <span className="float-right text-primary text-[11px]">✓</span>
-                            )}
-                          </button>
-
-                          {/* Curated fonts */}
-                          <div className="px-3 pt-2 pb-1 text-[10px] text-muted-foreground/60 uppercase tracking-wider">
-                            Popular
-                          </div>
-                          {CURATED_FONTS.filter((f) =>
-                            f.name.toLowerCase().includes(fontSearch.toLowerCase()),
-                          ).map((f) => (
-                            <button
-                              key={f.family}
-                              onClick={() => {
-                                onTerminalFontFamilyChange(f.family);
-                                setFontDropdownOpen(false);
-                                setFontSearch('');
-                              }}
-                              className={`w-full text-left px-3 py-1.5 text-[13px] hover:bg-surface-2 transition-colors ${
-                                terminalFontFamily === f.family
-                                  ? 'text-primary'
-                                  : 'text-foreground/80'
-                              }`}
-                              style={{ fontFamily: f.family }}
-                            >
-                              {f.name}
-                              {terminalFontFamily === f.family && (
-                                <span className="float-right text-primary text-[11px]">✓</span>
-                              )}
-                            </button>
-                          ))}
-
-                          {/* System fonts — flat list, deduped against curated */}
-                          {systemFonts.length > 0 && (
-                            <>
-                              <div className="px-3 pt-2 pb-1 text-[10px] text-muted-foreground/60 uppercase tracking-wider border-t border-border/40 mt-1">
-                                System
-                              </div>
-                              {systemFonts
-                                .filter(
-                                  (f) =>
-                                    f.toLowerCase().includes(fontSearch.toLowerCase()) &&
-                                    !CURATED_FONTS.some(
-                                      (c) => c.name.toLowerCase() === f.toLowerCase(),
-                                    ),
-                                )
-                                .map((f) => {
-                                  const family = `'${f}', monospace`;
-                                  return (
-                                    <button
-                                      key={f}
-                                      onClick={() => {
-                                        onTerminalFontFamilyChange(family);
-                                        setFontDropdownOpen(false);
-                                        setFontSearch('');
-                                      }}
-                                      className={`w-full text-left px-3 py-1.5 text-[13px] hover:bg-surface-2 transition-colors ${
-                                        terminalFontFamily === family
-                                          ? 'text-primary'
-                                          : 'text-foreground/80'
-                                      }`}
-                                      style={{ fontFamily: family }}
-                                    >
-                                      {f}
-                                      {terminalFontFamily === family && (
-                                        <span className="float-right text-primary text-[11px]">
-                                          ✓
-                                        </span>
-                                      )}
-                                    </button>
-                                  );
-                                })}
-                            </>
-                          )}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                {/* Font Size */}
-                <div className="mb-4">
-                  <div className="text-[11px] text-muted-foreground mb-1.5">Font Size</div>
-                  <div className="flex items-center gap-3">
-                    <input
-                      type="range"
-                      min={FONT_SIZE_MIN}
-                      max={FONT_SIZE_MAX}
-                      step={1}
-                      value={terminalFontSize}
-                      onChange={(e) => onTerminalFontSizeChange(parseInt(e.target.value, 10))}
-                      className="flex-1 accent-primary"
-                    />
-                    <input
-                      type="number"
-                      min={FONT_SIZE_MIN}
-                      max={FONT_SIZE_MAX}
-                      step={1}
-                      value={terminalFontSize}
-                      onChange={(e) => {
-                        const v = parseInt(e.target.value, 10);
-                        if (v >= FONT_SIZE_MIN && v <= FONT_SIZE_MAX) {
-                          onTerminalFontSizeChange(v);
-                        }
-                      }}
-                      className="w-[50px] text-center px-1.5 py-1 rounded-md border border-border/60 bg-surface-0 text-[13px] text-foreground focus:outline-none focus:border-primary/40"
-                    />
-                    <span className="text-[11px] text-muted-foreground">px</span>
-                  </div>
-                </div>
-
-                {/* Line Height */}
-                <div className="mb-4">
-                  <div className="text-[11px] text-muted-foreground mb-1.5">Line Height</div>
-                  <div className="flex items-center gap-3">
-                    <input
-                      type="range"
-                      min={LINE_HEIGHT_MIN}
-                      max={LINE_HEIGHT_MAX}
-                      step={LINE_HEIGHT_STEP}
-                      value={terminalLineHeight}
-                      onChange={(e) => onTerminalLineHeightChange(parseFloat(e.target.value))}
-                      className="flex-1 accent-primary"
-                    />
-                    <input
-                      type="number"
-                      min={LINE_HEIGHT_MIN}
-                      max={LINE_HEIGHT_MAX}
-                      step={LINE_HEIGHT_STEP}
-                      value={terminalLineHeight}
-                      onChange={(e) => {
-                        const v = parseFloat(e.target.value);
-                        if (v >= LINE_HEIGHT_MIN && v <= LINE_HEIGHT_MAX) {
-                          onTerminalLineHeightChange(v);
-                        }
-                      }}
-                      className="w-[50px] text-center px-1.5 py-1 rounded-md border border-border/60 bg-surface-0 text-[13px] text-foreground focus:outline-none focus:border-primary/40"
-                    />
-                  </div>
-                </div>
-
-                {/* Live Preview */}
-                <div
-                  className="rounded-lg border border-border/60 p-3 overflow-hidden"
-                  style={{
-                    backgroundColor:
-                      resolveTheme(terminalTheme, theme === 'dark').background || '#1f1f1f',
-                  }}
-                >
-                  <div className="text-[10px] uppercase tracking-wider mb-2 opacity-40 font-sans text-foreground">
-                    Preview
-                  </div>
-                  <div
-                    style={{
-                      fontFamily: terminalFontFamily || 'monospace',
-                      fontSize: `${terminalFontSize}px`,
-                      lineHeight: terminalLineHeight,
-                      color: resolveTheme(terminalTheme, theme === 'dark').foreground || '#d4d4d4',
-                    }}
-                  >
-                    <div>
-                      <span
-                        style={{
-                          color: resolveTheme(terminalTheme, theme === 'dark').magenta || '#c678dd',
-                        }}
-                      >
-                        const
-                      </span>{' '}
-                      <span
-                        style={{
-                          color: resolveTheme(terminalTheme, theme === 'dark').yellow || '#e5c07b',
-                        }}
-                      >
-                        greeting
-                      </span>{' '}
-                      ={' '}
-                      <span
-                        style={{
-                          color: resolveTheme(terminalTheme, theme === 'dark').green || '#98c379',
-                        }}
-                      >
-                        &apos;Hello, World!&apos;
-                      </span>
-                      ;
-                    </div>
-                    <div
-                      style={{
-                        color:
-                          resolveTheme(terminalTheme, theme === 'dark').brightBlack || '#5c6370',
-                      }}
-                    >
-                      {'// 0O oO ilIL1| {} [] () <>'}
-                    </div>
-                  </div>
-                </div>
-
-                <div className="text-[10px] text-muted-foreground/50 mt-1.5">
-                  Applies to all Claude and shell terminals
-                </div>
-              </div>
+              <TerminalFontSettings terminalTheme={terminalTheme} theme={theme} />
 
               {/* Terminal Theme */}
               <div>

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -22,7 +22,15 @@ import {
 } from '../keybindings';
 import { NOTIFICATION_SOUNDS, SOUND_LABELS } from '../sounds';
 import type { NotificationSound } from '../sounds';
-import { TERMINAL_THEMES } from '../terminal/terminalThemes';
+import { TERMINAL_THEMES, resolveTheme } from '../terminal/terminalThemes';
+import {
+  CURATED_FONTS,
+  FONT_SIZE_MIN,
+  FONT_SIZE_MAX,
+  LINE_HEIGHT_MIN,
+  LINE_HEIGHT_MAX,
+  LINE_HEIGHT_STEP,
+} from '../terminal/terminalFonts';
 import type {
   PixelAgentsConfig,
   PixelAgentsStatus,
@@ -51,6 +59,12 @@ interface SettingsModalProps {
   onShellDrawerPositionChange: (value: 'left' | 'main' | 'right') => void;
   terminalTheme: string;
   onTerminalThemeChange: (id: string) => void;
+  terminalFontFamily: string | null;
+  onTerminalFontFamilyChange: (family: string | null) => void;
+  terminalFontSize: number;
+  onTerminalFontSizeChange: (size: number) => void;
+  terminalLineHeight: number;
+  onTerminalLineHeightChange: (height: number) => void;
   preferredIDE: 'cursor' | 'code' | 'auto';
   onPreferredIDEChange: (value: 'cursor' | 'code' | 'auto') => void;
   commitAttribution: string | undefined;
@@ -527,6 +541,12 @@ export function SettingsModal({
   onShellDrawerPositionChange,
   terminalTheme,
   onTerminalThemeChange,
+  terminalFontFamily,
+  onTerminalFontFamilyChange,
+  terminalFontSize,
+  onTerminalFontSizeChange,
+  terminalLineHeight,
+  onTerminalLineHeightChange,
   preferredIDE,
   onPreferredIDEChange,
   commitAttribution,
@@ -558,6 +578,46 @@ export function SettingsModal({
   const [updateVersion, setUpdateVersion] = useState<string | null>(null);
   const [telemetryEnabled, setTelemetryEnabled] = useState(true);
   const [telemetryEnvDisabled, setTelemetryEnvDisabled] = useState(false);
+
+  const [fontDropdownOpen, setFontDropdownOpen] = useState(false);
+  const [fontSearch, setFontSearch] = useState('');
+  const [showSystemFonts, setShowSystemFonts] = useState(false);
+  const [systemFonts, setSystemFonts] = useState<string[]>([]);
+  const [systemFontsLoading, setSystemFontsLoading] = useState(false);
+  const fontDropdownRef = useRef<HTMLDivElement>(null);
+
+  const loadSystemFonts = async () => {
+    if (systemFonts.length > 0) return;
+    setSystemFontsLoading(true);
+    try {
+      const resp = await window.electronAPI.getSystemFonts();
+      if (resp.success && resp.data) {
+        setSystemFonts(resp.data);
+      }
+    } catch {
+      // Silently fail — curated list still works
+    }
+    setSystemFontsLoading(false);
+  };
+
+  useEffect(() => {
+    if (showSystemFonts && systemFonts.length === 0) {
+      loadSystemFonts();
+    }
+  }, [showSystemFonts]);
+
+  // Close font dropdown on click outside
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (fontDropdownRef.current && !fontDropdownRef.current.contains(e.target as Node)) {
+        setFontDropdownOpen(false);
+      }
+    };
+    if (fontDropdownOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [fontDropdownOpen]);
 
   useEffect(() => {
     const cleanups = [
@@ -1108,6 +1168,264 @@ export function SettingsModal({
                     <Moon size={15} strokeWidth={1.8} />
                     Dark
                   </button>
+                </div>
+              </div>
+
+              {/* Terminal Font */}
+              <div>
+                <label className="block text-[12px] font-medium text-foreground mb-3">
+                  Terminal Font
+                </label>
+
+                {/* Font Family Picker */}
+                <div className="mb-4">
+                  <div className="text-[11px] text-muted-foreground mb-1.5">Font Family</div>
+                  <div ref={fontDropdownRef} className="relative">
+                    <button
+                      onClick={() => setFontDropdownOpen(!fontDropdownOpen)}
+                      className="w-full flex items-center justify-between px-3 py-2 rounded-lg border border-border/60 bg-surface-0 text-[13px] text-foreground hover:border-border transition-colors"
+                    >
+                      <span style={{ fontFamily: terminalFontFamily || 'monospace' }}>
+                        {terminalFontFamily
+                          ? CURATED_FONTS.find((f) => f.family === terminalFontFamily)?.name ||
+                            terminalFontFamily.split(',')[0].replace(/'/g, '').trim()
+                          : 'Default (monospace)'}
+                      </span>
+                      <span className="text-muted-foreground text-[10px]">▼</span>
+                    </button>
+
+                    {fontDropdownOpen && (
+                      <div className="absolute z-50 top-full left-0 right-0 mt-1 rounded-lg border border-border/60 bg-surface-1 shadow-lg max-h-[280px] overflow-hidden flex flex-col">
+                        {/* Search */}
+                        <div className="p-2 border-b border-border/40">
+                          <input
+                            type="text"
+                            value={fontSearch}
+                            onChange={(e) => setFontSearch(e.target.value)}
+                            placeholder="Search fonts..."
+                            className="w-full px-2.5 py-1.5 rounded-md border border-border/60 bg-surface-0 text-[12px] text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:border-primary/40"
+                            autoFocus
+                          />
+                        </div>
+
+                        <div className="overflow-y-auto flex-1">
+                          {/* Default option */}
+                          <button
+                            onClick={() => {
+                              onTerminalFontFamilyChange(null);
+                              setFontDropdownOpen(false);
+                              setFontSearch('');
+                            }}
+                            className={`w-full text-left px-3 py-1.5 text-[13px] hover:bg-surface-2 transition-colors ${
+                              terminalFontFamily === null
+                                ? 'text-primary'
+                                : 'text-foreground/80'
+                            }`}
+                          >
+                            Default (monospace)
+                            {terminalFontFamily === null && (
+                              <span className="float-right text-primary text-[11px]">✓</span>
+                            )}
+                          </button>
+
+                          {/* Curated fonts */}
+                          <div className="px-3 pt-2 pb-1 text-[10px] text-muted-foreground/60 uppercase tracking-wider">
+                            Popular
+                          </div>
+                          {CURATED_FONTS.filter((f) =>
+                            f.name.toLowerCase().includes(fontSearch.toLowerCase()),
+                          ).map((f) => (
+                            <button
+                              key={f.family}
+                              onClick={() => {
+                                onTerminalFontFamilyChange(f.family);
+                                setFontDropdownOpen(false);
+                                setFontSearch('');
+                              }}
+                              className={`w-full text-left px-3 py-1.5 text-[13px] hover:bg-surface-2 transition-colors ${
+                                terminalFontFamily === f.family
+                                  ? 'text-primary'
+                                  : 'text-foreground/80'
+                              }`}
+                              style={{ fontFamily: f.family }}
+                            >
+                              {f.name}
+                              {terminalFontFamily === f.family && (
+                                <span className="float-right text-primary text-[11px]">✓</span>
+                              )}
+                            </button>
+                          ))}
+
+                          {/* System fonts toggle + list */}
+                          <div className="border-t border-border/40 mt-1 pt-1">
+                            <button
+                              onClick={() => setShowSystemFonts(!showSystemFonts)}
+                              className="w-full text-left px-3 py-1.5 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+                            >
+                              {showSystemFonts ? '▾' : '▸'} System fonts
+                              {systemFontsLoading && (
+                                <span className="ml-2 text-[10px] text-muted-foreground/50">
+                                  Loading...
+                                </span>
+                              )}
+                            </button>
+                            {showSystemFonts &&
+                              systemFonts
+                                .filter((f) =>
+                                  f.toLowerCase().includes(fontSearch.toLowerCase()),
+                                )
+                                .map((f) => {
+                                  const family = `'${f}', monospace`;
+                                  return (
+                                    <button
+                                      key={f}
+                                      onClick={() => {
+                                        onTerminalFontFamilyChange(family);
+                                        setFontDropdownOpen(false);
+                                        setFontSearch('');
+                                      }}
+                                      className={`w-full text-left px-3 py-1.5 text-[13px] hover:bg-surface-2 transition-colors ${
+                                        terminalFontFamily === family
+                                          ? 'text-primary'
+                                          : 'text-foreground/60'
+                                      }`}
+                                      style={{ fontFamily: family }}
+                                    >
+                                      {f}
+                                      {terminalFontFamily === family && (
+                                        <span className="float-right text-primary text-[11px]">
+                                          ✓
+                                        </span>
+                                      )}
+                                    </button>
+                                  );
+                                })}
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Font Size */}
+                <div className="mb-4">
+                  <div className="text-[11px] text-muted-foreground mb-1.5">Font Size</div>
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="range"
+                      min={FONT_SIZE_MIN}
+                      max={FONT_SIZE_MAX}
+                      step={1}
+                      value={terminalFontSize}
+                      onChange={(e) => onTerminalFontSizeChange(parseInt(e.target.value, 10))}
+                      className="flex-1 accent-primary"
+                    />
+                    <input
+                      type="number"
+                      min={FONT_SIZE_MIN}
+                      max={FONT_SIZE_MAX}
+                      step={1}
+                      value={terminalFontSize}
+                      onChange={(e) => {
+                        const v = parseInt(e.target.value, 10);
+                        if (v >= FONT_SIZE_MIN && v <= FONT_SIZE_MAX) {
+                          onTerminalFontSizeChange(v);
+                        }
+                      }}
+                      className="w-[50px] text-center px-1.5 py-1 rounded-md border border-border/60 bg-surface-0 text-[13px] text-foreground focus:outline-none focus:border-primary/40"
+                    />
+                    <span className="text-[11px] text-muted-foreground">px</span>
+                  </div>
+                </div>
+
+                {/* Line Height */}
+                <div className="mb-4">
+                  <div className="text-[11px] text-muted-foreground mb-1.5">Line Height</div>
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="range"
+                      min={LINE_HEIGHT_MIN}
+                      max={LINE_HEIGHT_MAX}
+                      step={LINE_HEIGHT_STEP}
+                      value={terminalLineHeight}
+                      onChange={(e) => onTerminalLineHeightChange(parseFloat(e.target.value))}
+                      className="flex-1 accent-primary"
+                    />
+                    <input
+                      type="number"
+                      min={LINE_HEIGHT_MIN}
+                      max={LINE_HEIGHT_MAX}
+                      step={LINE_HEIGHT_STEP}
+                      value={terminalLineHeight}
+                      onChange={(e) => {
+                        const v = parseFloat(e.target.value);
+                        if (v >= LINE_HEIGHT_MIN && v <= LINE_HEIGHT_MAX) {
+                          onTerminalLineHeightChange(v);
+                        }
+                      }}
+                      className="w-[50px] text-center px-1.5 py-1 rounded-md border border-border/60 bg-surface-0 text-[13px] text-foreground focus:outline-none focus:border-primary/40"
+                    />
+                  </div>
+                </div>
+
+                {/* Live Preview */}
+                <div
+                  className="rounded-lg border border-border/60 p-3 overflow-hidden"
+                  style={{
+                    backgroundColor:
+                      resolveTheme(terminalTheme, theme === 'dark').background || '#1f1f1f',
+                  }}
+                >
+                  <div className="text-[10px] uppercase tracking-wider mb-2 opacity-40 font-sans text-foreground">
+                    Preview
+                  </div>
+                  <div
+                    style={{
+                      fontFamily: terminalFontFamily || 'monospace',
+                      fontSize: `${terminalFontSize}px`,
+                      lineHeight: terminalLineHeight,
+                      color:
+                        resolveTheme(terminalTheme, theme === 'dark').foreground || '#d4d4d4',
+                    }}
+                  >
+                    <div>
+                      <span
+                        style={{
+                          color: resolveTheme(terminalTheme, theme === 'dark').magenta || '#c678dd',
+                        }}
+                      >
+                        const
+                      </span>{' '}
+                      <span
+                        style={{
+                          color: resolveTheme(terminalTheme, theme === 'dark').yellow || '#e5c07b',
+                        }}
+                      >
+                        greeting
+                      </span>{' '}
+                      ={' '}
+                      <span
+                        style={{
+                          color: resolveTheme(terminalTheme, theme === 'dark').green || '#98c379',
+                        }}
+                      >
+                        &apos;Hello, World!&apos;
+                      </span>
+                      ;
+                    </div>
+                    <div
+                      style={{
+                        color:
+                          resolveTheme(terminalTheme, theme === 'dark').brightBlack || '#5c6370',
+                      }}
+                    >
+                      {'// 0O oO ilIL1| {} [] () <>'}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="text-[10px] text-muted-foreground/50 mt-1.5">
+                  Applies to all Claude and shell terminals
                 </div>
               </div>
 

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -590,11 +590,15 @@ export function SettingsModal({
       window.electronAPI
         .getSystemFonts()
         .then((resp) => {
-          if (resp.success && resp.data) setSystemFonts(resp.data);
+          if (resp.success && resp.data && resp.data.length > 0) {
+            setSystemFonts(resp.data);
+          }
         })
-        .catch(() => {});
+        .catch((err) => {
+          console.error('[SettingsModal] Failed to load system fonts:', err);
+        });
     }
-  }, [fontDropdownOpen]);
+  }, [fontDropdownOpen, systemFonts.length]);
 
   // Close font dropdown on click outside
   useEffect(() => {

--- a/src/renderer/components/TerminalFontSettings.tsx
+++ b/src/renderer/components/TerminalFontSettings.tsx
@@ -1,0 +1,328 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { ChevronDown, Check } from 'lucide-react';
+import { sessionRegistry } from '../terminal/SessionRegistry';
+import { resolveTheme } from '../terminal/terminalThemes';
+import {
+  CURATED_FONTS,
+  FONT_SIZE_MIN,
+  FONT_SIZE_MAX,
+  FONT_SIZE_DEFAULT,
+  LINE_HEIGHT_MIN,
+  LINE_HEIGHT_MAX,
+  LINE_HEIGHT_DEFAULT,
+  LINE_HEIGHT_STEP,
+} from '../terminal/terminalFonts';
+
+interface TerminalFontSettingsProps {
+  terminalTheme: string;
+  theme: 'light' | 'dark';
+}
+
+export function TerminalFontSettings({ terminalTheme, theme }: TerminalFontSettingsProps) {
+  const [fontFamily, setFontFamily] = useState<string | null>(() => {
+    return localStorage.getItem('terminalFontFamily') || null;
+  });
+  const [fontSize, setFontSize] = useState(() => {
+    const stored = localStorage.getItem('terminalFontSize');
+    return stored ? parseInt(stored, 10) : FONT_SIZE_DEFAULT;
+  });
+  const [lineHeight, setLineHeight] = useState(() => {
+    const stored = localStorage.getItem('terminalLineHeight');
+    return stored ? parseFloat(stored) : LINE_HEIGHT_DEFAULT;
+  });
+
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [systemFonts, setSystemFonts] = useState<string[]>([]);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Propagate font changes to all terminals
+  useEffect(() => {
+    sessionRegistry.setAllTerminalFont(fontFamily, fontSize, lineHeight);
+  }, [fontFamily, fontSize, lineHeight]);
+
+  // Load system fonts when dropdown opens
+  useEffect(() => {
+    if (dropdownOpen && systemFonts.length === 0) {
+      window.electronAPI
+        .getSystemFonts()
+        .then((resp) => {
+          if (resp.success && resp.data && resp.data.length > 0) {
+            setSystemFonts(resp.data);
+          }
+        })
+        .catch(() => {});
+    }
+  }, [dropdownOpen, systemFonts.length]);
+
+  // Close dropdown on click outside
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [dropdownOpen]);
+
+  const updateFontFamily = (f: string | null) => {
+    setFontFamily(f);
+    if (f) {
+      localStorage.setItem('terminalFontFamily', f);
+    } else {
+      localStorage.removeItem('terminalFontFamily');
+    }
+  };
+
+  const updateFontSize = (s: number) => {
+    setFontSize(s);
+    localStorage.setItem('terminalFontSize', String(s));
+  };
+
+  const updateLineHeight = (h: number) => {
+    setLineHeight(h);
+    localStorage.setItem('terminalLineHeight', String(h));
+  };
+
+  const curatedNames = new Set(CURATED_FONTS.map((c) => c.name.toLowerCase()));
+  const filteredSystemFonts = systemFonts.filter(
+    (f) => f.toLowerCase().includes(search.toLowerCase()) && !curatedNames.has(f.toLowerCase()),
+  );
+
+  const currentTheme = resolveTheme(terminalTheme, theme === 'dark');
+
+  return (
+    <div>
+      <label className="block text-[12px] font-medium text-foreground mb-3">Terminal Font</label>
+
+      {/* Font Family Picker */}
+      <div className="mb-4">
+        <div className="text-[11px] text-muted-foreground mb-1.5">Font Family</div>
+        <div ref={dropdownRef} className="relative">
+          <button
+            onClick={() => setDropdownOpen(!dropdownOpen)}
+            className="w-full flex items-center justify-between px-3 py-2 rounded-lg border border-border/60 text-[13px] text-foreground hover:border-border transition-colors"
+            style={{ background: 'hsl(var(--surface-0))' }}
+          >
+            <span style={{ fontFamily: fontFamily || 'monospace' }}>
+              {fontFamily
+                ? CURATED_FONTS.find((f) => f.family === fontFamily)?.name ||
+                  fontFamily.split(',')[0].replace(/'/g, '').trim()
+                : 'Default (monospace)'}
+            </span>
+            <ChevronDown size={14} strokeWidth={1.8} className="text-muted-foreground" />
+          </button>
+
+          {dropdownOpen && (
+            <div
+              className="absolute z-50 top-full left-0 right-0 mt-1 rounded-lg border border-border/60 shadow-lg max-h-[280px] overflow-hidden flex flex-col"
+              style={{ background: 'hsl(var(--surface-1))' }}
+            >
+              {/* Search */}
+              <div className="p-2 border-b border-border/40">
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search fonts..."
+                  className="w-full px-2.5 py-1.5 rounded-md border border-border/60 text-[12px] text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:border-primary/40"
+                  style={{ background: 'hsl(var(--surface-0))' }}
+                  autoFocus
+                />
+              </div>
+
+              <div className="overflow-y-auto flex-1">
+                {/* Default option */}
+                <button
+                  onClick={() => {
+                    updateFontFamily(null);
+                    setDropdownOpen(false);
+                    setSearch('');
+                  }}
+                  className={`w-full text-left px-3 py-1.5 text-[13px] transition-colors ${
+                    fontFamily === null ? 'text-primary' : 'text-foreground/80'
+                  }`}
+                  style={{ ['--tw-bg-opacity' as string]: 1 }}
+                  onMouseEnter={(e) => (e.currentTarget.style.background = 'hsl(var(--surface-2))')}
+                  onMouseLeave={(e) => (e.currentTarget.style.background = '')}
+                >
+                  Default (monospace)
+                  {fontFamily === null && (
+                    <Check size={12} strokeWidth={2} className="float-right text-primary mt-0.5" />
+                  )}
+                </button>
+
+                {/* Curated fonts */}
+                <div className="px-3 pt-2 pb-1 text-[10px] text-muted-foreground/60 uppercase tracking-wider">
+                  Popular
+                </div>
+                {CURATED_FONTS.filter((f) =>
+                  f.name.toLowerCase().includes(search.toLowerCase()),
+                ).map((f) => (
+                  <button
+                    key={f.family}
+                    onClick={() => {
+                      updateFontFamily(f.family);
+                      setDropdownOpen(false);
+                      setSearch('');
+                    }}
+                    className={`w-full text-left px-3 py-1.5 text-[13px] transition-colors ${
+                      fontFamily === f.family ? 'text-primary' : 'text-foreground/80'
+                    }`}
+                    style={{ fontFamily: f.family }}
+                    onMouseEnter={(e) =>
+                      (e.currentTarget.style.background = 'hsl(var(--surface-2))')
+                    }
+                    onMouseLeave={(e) => (e.currentTarget.style.background = '')}
+                  >
+                    {f.name}
+                    {fontFamily === f.family && (
+                      <Check
+                        size={12}
+                        strokeWidth={2}
+                        className="float-right text-primary mt-0.5"
+                      />
+                    )}
+                  </button>
+                ))}
+
+                {/* System fonts — flat list, deduped against curated */}
+                {filteredSystemFonts.length > 0 && (
+                  <>
+                    <div className="px-3 pt-2 pb-1 text-[10px] text-muted-foreground/60 uppercase tracking-wider border-t border-border/40 mt-1">
+                      System
+                    </div>
+                    {filteredSystemFonts.map((f) => {
+                      const family = `'${f}', monospace`;
+                      return (
+                        <button
+                          key={f}
+                          onClick={() => {
+                            updateFontFamily(family);
+                            setDropdownOpen(false);
+                            setSearch('');
+                          }}
+                          className={`w-full text-left px-3 py-1.5 text-[13px] transition-colors ${
+                            fontFamily === family ? 'text-primary' : 'text-foreground/80'
+                          }`}
+                          style={{ fontFamily: family }}
+                          onMouseEnter={(e) =>
+                            (e.currentTarget.style.background = 'hsl(var(--surface-2))')
+                          }
+                          onMouseLeave={(e) => (e.currentTarget.style.background = '')}
+                        >
+                          {f}
+                          {fontFamily === family && (
+                            <Check
+                              size={12}
+                              strokeWidth={2}
+                              className="float-right text-primary mt-0.5"
+                            />
+                          )}
+                        </button>
+                      );
+                    })}
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Font Size */}
+      <div className="mb-4">
+        <div className="text-[11px] text-muted-foreground mb-1.5">Font Size</div>
+        <div className="flex items-center gap-3">
+          <input
+            type="range"
+            min={FONT_SIZE_MIN}
+            max={FONT_SIZE_MAX}
+            step={1}
+            value={fontSize}
+            onChange={(e) => updateFontSize(parseInt(e.target.value, 10))}
+            className="flex-1 accent-primary"
+          />
+          <input
+            type="number"
+            min={FONT_SIZE_MIN}
+            max={FONT_SIZE_MAX}
+            step={1}
+            value={fontSize}
+            onChange={(e) => {
+              const v = parseInt(e.target.value, 10);
+              if (v >= FONT_SIZE_MIN && v <= FONT_SIZE_MAX) {
+                updateFontSize(v);
+              }
+            }}
+            className="w-[50px] text-center px-1.5 py-1 rounded-md border border-border/60 text-[13px] text-foreground focus:outline-none focus:border-primary/40"
+            style={{ background: 'hsl(var(--surface-0))' }}
+          />
+          <span className="text-[11px] text-muted-foreground">px</span>
+        </div>
+      </div>
+
+      {/* Line Height */}
+      <div className="mb-4">
+        <div className="text-[11px] text-muted-foreground mb-1.5">Line Height</div>
+        <div className="flex items-center gap-3">
+          <input
+            type="range"
+            min={LINE_HEIGHT_MIN}
+            max={LINE_HEIGHT_MAX}
+            step={LINE_HEIGHT_STEP}
+            value={lineHeight}
+            onChange={(e) => updateLineHeight(parseFloat(e.target.value))}
+            className="flex-1 accent-primary"
+          />
+          <input
+            type="number"
+            min={LINE_HEIGHT_MIN}
+            max={LINE_HEIGHT_MAX}
+            step={LINE_HEIGHT_STEP}
+            value={lineHeight}
+            onChange={(e) => {
+              const v = parseFloat(e.target.value);
+              if (v >= LINE_HEIGHT_MIN && v <= LINE_HEIGHT_MAX) {
+                updateLineHeight(v);
+              }
+            }}
+            className="w-[50px] text-center px-1.5 py-1 rounded-md border border-border/60 text-[13px] text-foreground focus:outline-none focus:border-primary/40"
+            style={{ background: 'hsl(var(--surface-0))' }}
+          />
+        </div>
+      </div>
+
+      {/* Live Preview */}
+      <div
+        className="rounded-lg border border-border/60 p-3 overflow-hidden"
+        style={{ backgroundColor: currentTheme.background }}
+      >
+        <div className="text-[10px] uppercase tracking-wider mb-2 opacity-40 font-sans text-foreground">
+          Preview
+        </div>
+        <div
+          style={{
+            fontFamily: fontFamily || 'monospace',
+            fontSize: `${fontSize}px`,
+            lineHeight: lineHeight,
+            color: currentTheme.foreground,
+          }}
+        >
+          <div>
+            <span style={{ color: currentTheme.magenta }}>const</span>{' '}
+            <span style={{ color: currentTheme.yellow }}>greeting</span> ={' '}
+            <span style={{ color: currentTheme.green }}>&apos;Hello, World!&apos;</span>;
+          </div>
+          <div style={{ color: currentTheme.brightBlack }}>{'// 0O oO ilIL1| {} [] () <>'}</div>
+        </div>
+      </div>
+
+      <div className="text-[10px] text-muted-foreground/50 mt-1.5">
+        Applies to all Claude and shell terminals
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/terminal/SessionRegistry.ts
+++ b/src/renderer/terminal/SessionRegistry.ts
@@ -1,4 +1,5 @@
 import { TerminalSessionManager } from './TerminalSessionManager';
+import { FONT_SIZE_DEFAULT, LINE_HEIGHT_DEFAULT } from './terminalFonts';
 
 interface AttachOptions {
   id: string;
@@ -13,6 +14,9 @@ class SessionRegistryImpl {
   private sessions = new Map<string, TerminalSessionManager>();
   private _isDark = true;
   private _themeId = 'default';
+  private _fontFamily: string | null = null;
+  private _fontSize: number = FONT_SIZE_DEFAULT;
+  private _lineHeight: number = LINE_HEIGHT_DEFAULT;
 
   getOrCreate(opts: Omit<AttachOptions, 'container'>): TerminalSessionManager {
     let session = this.sessions.get(opts.id);
@@ -24,6 +28,9 @@ class SessionRegistryImpl {
         isDark: this._isDark,
         shellOnly: opts.shellOnly,
         themeId: opts.themeId ?? this._themeId,
+        fontFamily: this._fontFamily,
+        fontSize: this._fontSize,
+        lineHeight: this._lineHeight,
       });
       this.sessions.set(opts.id, session);
     }
@@ -78,6 +85,15 @@ class SessionRegistryImpl {
     this._isDark = isDark;
     for (const session of this.sessions.values()) {
       session.setTerminalTheme(themeId, isDark);
+    }
+  }
+
+  setAllTerminalFont(fontFamily: string | null, fontSize: number, lineHeight: number): void {
+    this._fontFamily = fontFamily;
+    this._fontSize = fontSize;
+    this._lineHeight = lineHeight;
+    for (const session of this.sessions.values()) {
+      session.setTerminalFont(fontFamily, fontSize, lineHeight);
     }
   }
 

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -46,7 +46,6 @@ export class TerminalSessionManager {
   private savedViewportY: number | null = null;
   readonly shellOnly: boolean;
   private themeId: string;
-  private fontFamily: string | null;
   constructor(opts: {
     id: string;
     cwd: string;
@@ -65,7 +64,6 @@ export class TerminalSessionManager {
     this.isDark = opts.isDark ?? true;
     this.shellOnly = opts.shellOnly ?? false;
     this.themeId = opts.themeId ?? 'default';
-    this.fontFamily = opts.fontFamily ?? null;
 
     this.terminal = new Terminal({
       scrollback: 100_000,
@@ -638,7 +636,6 @@ export class TerminalSessionManager {
   }
 
   setTerminalFont(fontFamily: string | null, fontSize: number, lineHeight: number) {
-    this.fontFamily = fontFamily;
     try {
       if (fontFamily) {
         this.terminal.options.fontFamily = fontFamily;

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -46,6 +46,7 @@ export class TerminalSessionManager {
   private savedViewportY: number | null = null;
   readonly shellOnly: boolean;
   private themeId: string;
+  private fontFamily: string | null;
   constructor(opts: {
     id: string;
     cwd: string;
@@ -53,6 +54,9 @@ export class TerminalSessionManager {
     isDark?: boolean;
     shellOnly?: boolean;
     themeId?: string;
+    fontFamily?: string | null;
+    fontSize?: number;
+    lineHeight?: number;
   }) {
     this.id = opts.id;
     this.cwd = opts.cwd;
@@ -61,11 +65,13 @@ export class TerminalSessionManager {
     this.isDark = opts.isDark ?? true;
     this.shellOnly = opts.shellOnly ?? false;
     this.themeId = opts.themeId ?? 'default';
+    this.fontFamily = opts.fontFamily ?? null;
 
     this.terminal = new Terminal({
       scrollback: 100_000,
-      fontSize: 13,
-      lineHeight: 1.2,
+      fontSize: opts.fontSize ?? 13,
+      lineHeight: opts.lineHeight ?? 1.2,
+      fontFamily: opts.fontFamily ?? undefined,
       allowProposedApi: true,
       theme: resolveTheme(this.themeId, this.isDark),
       cursorBlink: true,
@@ -628,6 +634,27 @@ export class TerminalSessionManager {
           window.electronAPI.ptyResize({ id: this.id, cols, rows: dims.rows });
         }, 50);
       }
+    }
+  }
+
+  setTerminalFont(fontFamily: string | null, fontSize: number, lineHeight: number) {
+    this.fontFamily = fontFamily;
+    try {
+      if (fontFamily) {
+        this.terminal.options.fontFamily = fontFamily;
+      } else {
+        // Reset to xterm.js default
+        this.terminal.options.fontFamily = undefined;
+      }
+      this.terminal.options.fontSize = fontSize;
+      this.terminal.options.lineHeight = lineHeight;
+    } catch {
+      // WebGL addon may crash if GPU context is lost
+    }
+
+    // Refit terminal since character dimensions changed
+    if (this.opened) {
+      this.fit();
     }
   }
 

--- a/src/renderer/terminal/terminalFonts.ts
+++ b/src/renderer/terminal/terminalFonts.ts
@@ -1,0 +1,42 @@
+export interface TerminalFontConfig {
+  fontFamily: string | null;
+  fontSize: number;
+  lineHeight: number;
+}
+
+export const FONT_SIZE_MIN = 10;
+export const FONT_SIZE_MAX = 24;
+export const FONT_SIZE_DEFAULT = 13;
+
+export const LINE_HEIGHT_MIN = 1.0;
+export const LINE_HEIGHT_MAX = 2.0;
+export const LINE_HEIGHT_DEFAULT = 1.2;
+export const LINE_HEIGHT_STEP = 0.1;
+
+export interface CuratedFont {
+  name: string;
+  family: string; // CSS font-family value (with fallbacks)
+}
+
+export const CURATED_FONTS: CuratedFont[] = [
+  { name: 'JetBrains Mono', family: "'JetBrains Mono', monospace" },
+  { name: 'Fira Code', family: "'Fira Code', monospace" },
+  { name: 'SF Mono', family: "'SF Mono', monospace" },
+  { name: 'Menlo', family: "'Menlo', monospace" },
+  { name: 'Cascadia Code', family: "'Cascadia Code', monospace" },
+  { name: 'Source Code Pro', family: "'Source Code Pro', monospace" },
+  { name: 'Hack', family: "'Hack', monospace" },
+  { name: 'IBM Plex Mono', family: "'IBM Plex Mono', monospace" },
+  { name: 'Inconsolata', family: "'Inconsolata', monospace" },
+  { name: 'Ubuntu Mono', family: "'Ubuntu Mono', monospace" },
+  { name: 'Roboto Mono', family: "'Roboto Mono', monospace" },
+  { name: 'Monaco', family: "'Monaco', monospace" },
+];
+
+export function defaultFontConfig(): TerminalFontConfig {
+  return {
+    fontFamily: null,
+    fontSize: FONT_SIZE_DEFAULT,
+    lineHeight: LINE_HEIGHT_DEFAULT,
+  };
+}

--- a/src/renderer/terminal/terminalFonts.ts
+++ b/src/renderer/terminal/terminalFonts.ts
@@ -21,8 +21,6 @@ export interface CuratedFont {
 export const CURATED_FONTS: CuratedFont[] = [
   { name: 'JetBrains Mono', family: "'JetBrains Mono', monospace" },
   { name: 'Fira Code', family: "'Fira Code', monospace" },
-  { name: 'SF Mono', family: "'SF Mono', monospace" },
-  { name: 'Menlo', family: "'Menlo', monospace" },
   { name: 'Cascadia Code', family: "'Cascadia Code', monospace" },
   { name: 'Source Code Pro', family: "'Source Code Pro', monospace" },
   { name: 'Hack', family: "'Hack', monospace" },
@@ -30,7 +28,6 @@ export const CURATED_FONTS: CuratedFont[] = [
   { name: 'Inconsolata', family: "'Inconsolata', monospace" },
   { name: 'Ubuntu Mono', family: "'Ubuntu Mono', monospace" },
   { name: 'Roboto Mono', family: "'Roboto Mono', monospace" },
-  { name: 'Monaco', family: "'Monaco', monospace" },
 ];
 
 export function defaultFontConfig(): TerminalFontConfig {
@@ -39,110 +36,4 @@ export function defaultFontConfig(): TerminalFontConfig {
     fontSize: FONT_SIZE_DEFAULT,
     lineHeight: LINE_HEIGHT_DEFAULT,
   };
-}
-
-/**
- * Known monospace font families to probe for on the system.
- * We test each against the generic 'monospace' fallback using canvas measurement.
- * Excludes names already in CURATED_FONTS to avoid duplicates.
- */
-const SYSTEM_FONT_CANDIDATES: string[] = [
-  // macOS
-  'Andale Mono',
-  'Courier New',
-  'Monaco',
-  'PT Mono',
-  'SF Mono',
-  'Menlo',
-  // Nerd Font variants (common with terminal users)
-  'MesloLGS Nerd Font Mono',
-  'MesloLGM Nerd Font Mono',
-  'MesloLGL Nerd Font Mono',
-  'MesloLGSDZ Nerd Font Mono',
-  'MesloLGMDZ Nerd Font Mono',
-  'MesloLGLDZ Nerd Font Mono',
-  'MesloLGS Nerd Font',
-  'MesloLGM Nerd Font',
-  'MesloLGL Nerd Font',
-  'FiraCode Nerd Font Mono',
-  'FiraCode Nerd Font',
-  'Hack Nerd Font Mono',
-  'Hack Nerd Font',
-  'JetBrainsMono Nerd Font Mono',
-  'JetBrainsMono Nerd Font',
-  'Symbols Nerd Font Mono',
-  'Symbols Nerd Font',
-  // Popular coding fonts
-  'Maple Mono',
-  'Maple Mono NF',
-  'Maple Mono Normal NF',
-  'Cascadia Mono',
-  'Cascadia Code',
-  'Consolas',
-  'Courier',
-  'DejaVu Sans Mono',
-  'Droid Sans Mono',
-  'Fantasque Sans Mono',
-  'Iosevka',
-  'Iosevka Term',
-  'Liberation Mono',
-  'Noto Sans Mono',
-  'Operator Mono',
-  'Input Mono',
-  'Victor Mono',
-  'Anonymous Pro',
-  'Bitstream Vera Sans Mono',
-  'Oxygen Mono',
-  'Overpass Mono',
-  'Space Mono',
-  'Azeret Mono',
-  'Red Hat Mono',
-  'Geist Mono',
-  'Monaspace Neon',
-  'Monaspace Argon',
-  'Monaspace Xenon',
-  'Monaspace Radon',
-  'Monaspace Krypton',
-  'Berkeley Mono',
-  'Comic Mono',
-  'Commit Mono',
-  'Intel One Mono',
-  // Linux
-  'FreeMono',
-  'Nimbus Mono L',
-  'Tlwg Mono',
-  'Noto Mono',
-];
-
-/**
- * Detect which fonts from SYSTEM_FONT_CANDIDATES are actually installed,
- * using canvas text measurement. Returns font names not already in CURATED_FONTS.
- */
-export function detectInstalledFonts(): string[] {
-  const canvas = document.createElement('canvas');
-  const ctx = canvas.getContext('2d');
-  if (!ctx) return [];
-
-  const testString = 'mmmmmmmmmmlli1|WW@@';
-  const size = '72px';
-  const fallback = 'monospace';
-
-  // Measure with just the fallback
-  ctx.font = `${size} ${fallback}`;
-  const fallbackWidth = ctx.measureText(testString).width;
-
-  const curatedNames = new Set(CURATED_FONTS.map((f) => f.name.toLowerCase()));
-
-  const installed: string[] = [];
-  for (const font of SYSTEM_FONT_CANDIDATES) {
-    if (curatedNames.has(font.toLowerCase())) continue;
-
-    ctx.font = `${size} '${font}', ${fallback}`;
-    const width = ctx.measureText(testString).width;
-    if (width !== fallbackWidth) {
-      installed.push(font);
-    }
-  }
-
-  return installed.sort((a, b) => a.localeCompare(b));
 }

--- a/src/renderer/terminal/terminalFonts.ts
+++ b/src/renderer/terminal/terminalFonts.ts
@@ -40,3 +40,109 @@ export function defaultFontConfig(): TerminalFontConfig {
     lineHeight: LINE_HEIGHT_DEFAULT,
   };
 }
+
+/**
+ * Known monospace font families to probe for on the system.
+ * We test each against the generic 'monospace' fallback using canvas measurement.
+ * Excludes names already in CURATED_FONTS to avoid duplicates.
+ */
+const SYSTEM_FONT_CANDIDATES: string[] = [
+  // macOS
+  'Andale Mono',
+  'Courier New',
+  'Monaco',
+  'PT Mono',
+  'SF Mono',
+  'Menlo',
+  // Nerd Font variants (common with terminal users)
+  'MesloLGS Nerd Font Mono',
+  'MesloLGM Nerd Font Mono',
+  'MesloLGL Nerd Font Mono',
+  'MesloLGSDZ Nerd Font Mono',
+  'MesloLGMDZ Nerd Font Mono',
+  'MesloLGLDZ Nerd Font Mono',
+  'MesloLGS Nerd Font',
+  'MesloLGM Nerd Font',
+  'MesloLGL Nerd Font',
+  'FiraCode Nerd Font Mono',
+  'FiraCode Nerd Font',
+  'Hack Nerd Font Mono',
+  'Hack Nerd Font',
+  'JetBrainsMono Nerd Font Mono',
+  'JetBrainsMono Nerd Font',
+  'Symbols Nerd Font Mono',
+  'Symbols Nerd Font',
+  // Popular coding fonts
+  'Maple Mono',
+  'Maple Mono NF',
+  'Maple Mono Normal NF',
+  'Cascadia Mono',
+  'Cascadia Code',
+  'Consolas',
+  'Courier',
+  'DejaVu Sans Mono',
+  'Droid Sans Mono',
+  'Fantasque Sans Mono',
+  'Iosevka',
+  'Iosevka Term',
+  'Liberation Mono',
+  'Noto Sans Mono',
+  'Operator Mono',
+  'Input Mono',
+  'Victor Mono',
+  'Anonymous Pro',
+  'Bitstream Vera Sans Mono',
+  'Oxygen Mono',
+  'Overpass Mono',
+  'Space Mono',
+  'Azeret Mono',
+  'Red Hat Mono',
+  'Geist Mono',
+  'Monaspace Neon',
+  'Monaspace Argon',
+  'Monaspace Xenon',
+  'Monaspace Radon',
+  'Monaspace Krypton',
+  'Berkeley Mono',
+  'Comic Mono',
+  'Commit Mono',
+  'Intel One Mono',
+  // Linux
+  'FreeMono',
+  'Nimbus Mono L',
+  'Tlwg Mono',
+  'Noto Mono',
+];
+
+/**
+ * Detect which fonts from SYSTEM_FONT_CANDIDATES are actually installed,
+ * using canvas text measurement. Returns font names not already in CURATED_FONTS.
+ */
+export function detectInstalledFonts(): string[] {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return [];
+
+  const testString = 'mmmmmmmmmmlli1|WW@@';
+  const size = '72px';
+  const fallback = 'monospace';
+
+  // Measure with just the fallback
+  ctx.font = `${size} ${fallback}`;
+  const fallbackWidth = ctx.measureText(testString).width;
+
+  const curatedNames = new Set(CURATED_FONTS.map((f) => f.name.toLowerCase()));
+
+  const installed: string[] = [];
+  for (const font of SYSTEM_FONT_CANDIDATES) {
+    if (curatedNames.has(font.toLowerCase())) continue;
+
+    ctx.font = `${size} '${font}', ${fallback}`;
+    const width = ctx.measureText(testString).width;
+    if (width !== fallbackWidth) {
+      installed.push(font);
+    }
+  }
+
+  return installed.sort((a, b) => a.localeCompare(b));
+}

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -36,6 +36,7 @@ export interface ElectronAPI {
   }) => Promise<IpcResponse<null>>;
   openInIDE: (args: { folderPath: string; ide?: 'cursor' | 'code' }) => Promise<IpcResponse<null>>;
   detectAvailableIDEs: () => Promise<IpcResponse<string[]>>;
+  getSystemFonts: () => Promise<IpcResponse<string[]>>;
 
   // Database - Projects
   getProjects: () => Promise<IpcResponse<Project[]>>;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,6 +34,10 @@ module.exports = {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
+        'surface-0': 'hsl(var(--surface-0))',
+        'surface-1': 'hsl(var(--surface-1))',
+        'surface-2': 'hsl(var(--surface-2))',
+        'surface-3': 'hsl(var(--surface-3))',
       },
       borderRadius: {
         lg: 'var(--radius)',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,10 +34,6 @@ module.exports = {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
-        'surface-0': 'hsl(var(--surface-0))',
-        'surface-1': 'hsl(var(--surface-1))',
-        'surface-2': 'hsl(var(--surface-2))',
-        'surface-3': 'hsl(var(--surface-3))',
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
  ## Summary

  - Add terminal font family, font size, and line height settings to Settings → Appearance
  - Searchable font picker with curated popular fonts + detected system monospace fonts
  - Live preview with syntax highlighting that updates as you change settings
  - Settings persist via localStorage and apply instantly to all open terminals

  ## Details

  New **Terminal Font** section in the Appearance tab (between App Theme and Terminal Theme):

  - **Font family**: Searchable dropdown with 12 curated popular monospace fonts plus system-installed monospace fonts detected via canvas
  text measurement
  - **Font size**: Slider + numeric input (10–24px, default 13px)
  - **Line height**: Slider + numeric input (1.0–2.0, default 1.2)
  - **Live preview**: Syntax-highlighted code sample using current terminal theme colors