### PR TITLE
Fix hook server cleanup and session isolation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/main/db/migrate.ts
+++ b/src/main/db/migrate.ts
@@ -118,6 +118,12 @@ export function runMigrations(): void {
     /* already exists */
   }
 
+  try {
+    rawDb.exec(`ALTER TABLE tasks ADD COLUMN context_prompt TEXT`);
+  } catch {
+    /* already exists */
+  }
+
   // Backfill: sync is_git_repo with actual filesystem state
   try {
     const allProjects = rawDb.prepare(`SELECT id, path FROM projects`).all() as {

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -34,6 +34,7 @@ export const tasks = sqliteTable(
     useWorktree: integer('use_worktree', { mode: 'boolean' }).default(true),
     autoApprove: integer('auto_approve', { mode: 'boolean' }).default(false),
     linkedItems: text('linked_items'),
+    contextPrompt: text('context_prompt'),
     branchCreatedByDash: integer('branch_created_by_dash', { mode: 'boolean' }).default(false),
     archivedAt: text('archived_at'),
     createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`),

--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -119,8 +119,11 @@ export function registerAppIpc(): void {
             body: 'Notifications enabled!',
           });
           n.show();
-        } catch {
-          // Ignore — user may have denied permission
+        } catch (err) {
+          console.error(
+            '[app:setDesktopNotification] Test notification failed (permission denied?):',
+            err,
+          );
         }
       }
     } catch (err) {
@@ -155,7 +158,8 @@ export function registerAppIpc(): void {
 
         // No custom attribution configured — Claude uses its built-in default
         return { success: true, data: null };
-      } catch {
+      } catch (err) {
+        console.error('[app:getClaudeAttribution] Failed to read settings:', err);
         return { success: true, data: null };
       }
     },
@@ -194,8 +198,10 @@ export function registerAppIpc(): void {
       const { claudeCliCache } = await import('../main');
       return { success: true, data: claudeCliCache };
     } catch (error) {
+      console.error('[app:detectClaude] Failed to import main module:', error);
       return {
-        success: true,
+        success: false,
+        error: String(error),
         data: { installed: false, version: null, path: null },
       };
     }

--- a/src/main/ipc/dbIpc.ts
+++ b/src/main/ipc/dbIpc.ts
@@ -1,4 +1,6 @@
 import { ipcMain } from 'electron';
+import fs from 'fs';
+import path from 'path';
 import { DatabaseService } from '../services/DatabaseService';
 import { TelemetryService } from '../services/TelemetryService';
 
@@ -59,6 +61,17 @@ export function registerDbIpc(): void {
 
   ipcMain.handle('db:deleteTask', (_event, id: string) => {
     try {
+      // Fetch task before deleting so we can clean up task-context.json
+      const task = DatabaseService.getTask(id);
+      if (task && !task.useWorktree) {
+        const contextPath = path.join(task.path, '.claude', 'task-context.json');
+        try {
+          if (fs.existsSync(contextPath)) fs.unlinkSync(contextPath);
+        } catch {
+          // Best effort — file may already be gone
+        }
+      }
+
       DatabaseService.deleteTask(id);
       TelemetryService.capture('task_deleted');
       return { success: true };

--- a/src/main/ipc/dbIpc.ts
+++ b/src/main/ipc/dbIpc.ts
@@ -1,6 +1,4 @@
 import { ipcMain } from 'electron';
-import fs from 'fs';
-import path from 'path';
 import { DatabaseService } from '../services/DatabaseService';
 import { TelemetryService } from '../services/TelemetryService';
 
@@ -61,17 +59,6 @@ export function registerDbIpc(): void {
 
   ipcMain.handle('db:deleteTask', (_event, id: string) => {
     try {
-      // Fetch task before deleting so we can clean up task-context.json
-      const task = DatabaseService.getTask(id);
-      if (task && !task.useWorktree) {
-        const contextPath = path.join(task.path, '.claude', 'task-context.json');
-        try {
-          if (fs.existsSync(contextPath)) fs.unlinkSync(contextPath);
-        } catch {
-          // Best effort — file may already be gone
-        }
-      }
-
       DatabaseService.deleteTask(id);
       TelemetryService.capture('task_deleted');
       return { success: true };

--- a/src/main/ipc/ptyIpc.ts
+++ b/src/main/ipc/ptyIpc.ts
@@ -10,9 +10,9 @@ import {
   resizePty,
   killPty,
   killByOwner,
-  writeTaskContext,
   sendRemoteControl,
 } from '../services/ptyManager';
+import { DatabaseService } from '../services/DatabaseService';
 import { terminalSnapshotService } from '../services/TerminalSnapshotService';
 import { activityMonitor } from '../services/ActivityMonitor';
 import { remoteControlService } from '../services/remoteControlService';
@@ -110,25 +110,15 @@ export function registerPtyIpc(): void {
     }
   });
 
-  // Write task context for SessionStart hook
-  ipcMain.handle(
-    'pty:writeTaskContext',
-    (
-      _event,
-      args: {
-        cwd: string;
-        prompt: string;
-        meta?: import('@shared/types').TaskContextMeta;
-      },
-    ) => {
-      try {
-        writeTaskContext(args.cwd, args.prompt, args.meta);
-        return { success: true };
-      } catch (error) {
-        return { success: false, error: String(error) };
-      }
-    },
-  );
+  // Store task context prompt in DB for SessionStart hook injection
+  ipcMain.handle('pty:writeTaskContext', (_event, args: { taskId: string; prompt: string }) => {
+    try {
+      DatabaseService.setTaskContextPrompt(args.taskId, args.prompt);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: String(error) };
+    }
+  });
 
   // Activity monitor
   ipcMain.handle('pty:activity:getAll', () => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -98,7 +98,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   ptyHasClaudeSession: (cwd: string) => ipcRenderer.invoke('pty:hasClaudeSession', cwd),
 
   // Task context for SessionStart hook
-  ptyWriteTaskContext: (args: { cwd: string; prompt: string; meta?: unknown }) =>
+  ptyWriteTaskContext: (args: { taskId: string; prompt: string }) =>
     ipcRenderer.invoke('pty:writeTaskContext', args),
 
   // App lifecycle

--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -120,6 +120,12 @@ export class DatabaseService {
     return this.mapTask(rows[0]);
   }
 
+  static getTask(id: string): Task | undefined {
+    const db = getDb();
+    const row = db.select().from(tasks).where(eq(tasks.id, id)).get();
+    return row ? this.mapTask(row) : undefined;
+  }
+
   static deleteTask(id: string): void {
     const db = getDb();
     db.delete(tasks).where(eq(tasks.id, id)).run();

--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -126,6 +126,14 @@ export class DatabaseService {
     return row ? this.mapTask(row) : undefined;
   }
 
+  static setTaskContextPrompt(id: string, prompt: string): void {
+    const db = getDb();
+    db.update(tasks)
+      .set({ contextPrompt: prompt, updatedAt: new Date().toISOString() })
+      .where(eq(tasks.id, id))
+      .run();
+  }
+
   static deleteTask(id: string): void {
     const db = getDb();
     db.delete(tasks).where(eq(tasks.id, id)).run();
@@ -222,6 +230,7 @@ export class DatabaseService {
       autoApprove: row.autoApprove ?? false,
       branchCreatedByDash: row.branchCreatedByDash ?? false,
       linkedItems,
+      contextPrompt: row.contextPrompt ?? null,
       archivedAt: row.archivedAt,
       createdAt: row.createdAt ?? '',
       updatedAt: row.updatedAt ?? '',

--- a/src/main/services/HookServer.ts
+++ b/src/main/services/HookServer.ts
@@ -34,8 +34,8 @@ class HookServerImpl {
           if (task?.name) {
             body = `${task.name} finished`;
           }
-        } catch {
-          // DB lookup failed — use fallback
+        } catch (err) {
+          console.error('[HookServer] DB lookup for notification body failed:', err);
         }
       }
       const n = new Notification({
@@ -60,7 +60,8 @@ class HookServerImpl {
       const db = getDb();
       const task = db.select({ name: tasks.name }).from(tasks).where(eq(tasks.id, ptyId)).get();
       return task?.name || 'A task';
-    } catch {
+    } catch (err) {
+      console.error('[HookServer] getTaskName failed for ptyId', ptyId, err);
       return 'A task';
     }
   }
@@ -75,7 +76,13 @@ class HookServerImpl {
       req.on('end', () => {
         try {
           resolve(JSON.parse(body));
-        } catch {
+        } catch (err) {
+          console.error(
+            '[HookServer] Failed to parse POST body:',
+            err,
+            '| raw:',
+            body.slice(0, 200),
+          );
           resolve({});
         }
       });

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -10,6 +10,39 @@ import type { TaskContextMeta } from '@shared/types';
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * Locate the Claude projects directory for a given cwd.
+ * Claude stores sessions under ~/.claude/projects/<encoded-cwd>/.
+ */
+function findClaudeProjectDir(cwd: string): string | null {
+  try {
+    const projectsDir = path.join(os.homedir(), '.claude', 'projects');
+    if (!fs.existsSync(projectsDir)) return null;
+
+    // Path-based: slashes → hyphens (the primary naming scheme)
+    const pathBased = path.join(projectsDir, cwd.replace(/\//g, '-'));
+    if (fs.existsSync(pathBased)) return pathBased;
+
+    // Partial match: last 3 path segments
+    const parts = cwd.split('/').filter((p) => p.length > 0);
+    const suffix = parts.slice(-3).join('-');
+    const dirs = fs.readdirSync(projectsDir);
+    const match = dirs.find((d) => d.includes(suffix));
+    if (match) return path.join(projectsDir, match);
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Check whether Claude has a session file for the given UUID in this cwd. */
+function hasSessionForId(cwd: string, sessionId: string): boolean {
+  const projDir = findClaudeProjectDir(cwd);
+  if (!projDir) return false;
+  return fs.existsSync(path.join(projDir, `${sessionId}.jsonl`));
+}
+
 interface PtyRecord {
   proc: any; // IPty from node-pty
   cwd: string;
@@ -284,19 +317,22 @@ function writeHookSettings(cwd: string, ptyId: string): void {
     ],
   };
 
-  // Auto-detect task-context.json and inject SessionStart hook if it exists
+  // Inject task context via SessionStart hook. Fires on startup (new session),
+  // and re-injects after compact/clear so Claude retains issue awareness.
   const contextPath = path.join(claudeDir, 'task-context.json');
   if (fs.existsSync(contextPath)) {
+    const sessionStartHook = {
+      hooks: [
+        {
+          type: 'command',
+          command: `cat "${contextPath}"`,
+        },
+      ],
+    };
     hookSettings.SessionStart = [
-      {
-        matcher: 'startup',
-        hooks: [
-          {
-            type: 'command',
-            command: `cat "${contextPath}"`,
-          },
-        ],
-      },
+      { matcher: 'startup', ...sessionStartHook },
+      { matcher: 'compact', ...sessionStartHook },
+      { matcher: 'clear', ...sessionStartHook },
     ];
   }
 
@@ -398,8 +434,6 @@ export async function startDirectPty(options: {
 }): Promise<{
   reattached: boolean;
   isDirectSpawn: boolean;
-  hasTaskContext: boolean;
-  taskContextMeta: TaskContextMeta | null;
 }> {
   // Re-attach to existing PTY (e.g., after renderer reload)
   const existing = ptys.get(options.id);
@@ -413,7 +447,7 @@ export async function startDirectPty(options: {
     ptys.delete(options.id);
   } else if (existing) {
     existing.owner = options.sender || null;
-    return { reattached: true, isDirectSpawn: true, hasTaskContext: false, taskContextMeta: null };
+    return { reattached: true, isDirectSpawn: true };
   }
 
   const claudePath = await findClaudePath();
@@ -423,9 +457,20 @@ export async function startDirectPty(options: {
   }
 
   const args: string[] = [];
-  if (options.resume) {
+
+  // Pin each task to its own Claude session so tasks sharing the same cwd
+  // (e.g. multiple tasks in the main worktree) never resume each other.
+  if (options.resume && hasSessionForId(options.cwd, options.id)) {
+    // Session was created with --session-id; resume it by ID.
+    args.push('-r', options.id);
+  } else if (options.resume) {
+    // Legacy task created before session pinning — fall back to most recent.
     args.push('-c', '-r');
+  } else {
+    // New session: create with deterministic UUID tied to this task.
+    args.push('--session-id', options.id);
   }
+
   if (options.autoApprove) {
     args.push('--dangerously-skip-permissions');
   }
@@ -476,21 +521,9 @@ export async function startDirectPty(options: {
     ptys.delete(options.id);
   });
 
-  const contextPath = path.join(options.cwd, '.claude', 'task-context.json');
-  let taskContextMeta: TaskContextMeta | null = null;
-  try {
-    if (fs.existsSync(contextPath)) {
-      const parsed = JSON.parse(fs.readFileSync(contextPath, 'utf-8'));
-      taskContextMeta = parsed.meta ?? null;
-    }
-  } catch {
-    // Best effort
-  }
   return {
     reattached: false,
     isDirectSpawn: true,
-    hasTaskContext: !!taskContextMeta,
-    taskContextMeta,
   };
 }
 

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -6,7 +6,7 @@ import { promisify } from 'util';
 import { type WebContents, app } from 'electron';
 import { activityMonitor } from './ActivityMonitor';
 import { hookServer } from './HookServer';
-import type { TaskContextMeta } from '@shared/types';
+import { DatabaseService } from './DatabaseService';
 
 const execFileAsync = promisify(execFile);
 
@@ -228,31 +228,13 @@ function buildDirectEnv(isDark: boolean): Record<string, string> {
   return env;
 }
 
-/**
- * Write .claude/task-context.json with issue context for the SessionStart hook.
- * Called from IPC during task creation, before Claude spawns.
- */
-export function writeTaskContext(cwd: string, prompt: string, meta?: TaskContextMeta): void {
-  const claudeDir = path.join(cwd, '.claude');
-  const contextPath = path.join(claudeDir, 'task-context.json');
-
-  const payload: Record<string, unknown> = {
-    hookSpecificOutput: {
-      hookEventName: 'SessionStart',
-      additionalContext: prompt,
-    },
-  };
-  if (meta) {
-    payload.meta = meta;
-  }
-
+/** Retrieve stored task context prompt from the database. */
+function getTaskContextPrompt(taskId: string): string | null {
   try {
-    if (!fs.existsSync(claudeDir)) {
-      fs.mkdirSync(claudeDir, { recursive: true });
-    }
-    fs.writeFileSync(contextPath, JSON.stringify(payload, null, 2) + '\n');
-  } catch (err) {
-    console.error('[writeTaskContext] Failed:', err);
+    const task = DatabaseService.getTask(taskId);
+    return task?.contextPrompt ?? null;
+  } catch {
+    return null;
   }
 }
 
@@ -319,13 +301,19 @@ function writeHookSettings(cwd: string, ptyId: string): void {
 
   // Inject task context via SessionStart hook. Fires on startup (new session),
   // and re-injects after compact/clear so Claude retains issue awareness.
-  const contextPath = path.join(claudeDir, 'task-context.json');
-  if (fs.existsSync(contextPath)) {
+  const contextPrompt = getTaskContextPrompt(ptyId);
+  if (contextPrompt) {
+    const hookPayload = JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext: contextPrompt,
+      },
+    });
     const sessionStartHook = {
       hooks: [
         {
           type: 'command',
-          command: `cat "${contextPath}"`,
+          command: `printf '%s' '${hookPayload.replace(/'/g, "'\\''")}'`,
         },
       ],
     };

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -31,7 +31,8 @@ function findClaudeProjectDir(cwd: string): string | null {
     if (match) return path.join(projectsDir, match);
 
     return null;
-  } catch {
+  } catch (err) {
+    console.error('[findClaudeProjectDir] Failed to scan projects dir:', err);
     return null;
   }
 }
@@ -67,6 +68,16 @@ let claudeEnvVars: Record<string, string> = {};
 
 // When true, inherit the full parent process.env as a base instead of the minimal set.
 let syncShellEnv = false;
+
+const RESERVED_ENV_KEYS = new Set([
+  'PATH',
+  'HOME',
+  'USER',
+  'TERM',
+  'COLORTERM',
+  'TERM_PROGRAM',
+  'COLORFGBG',
+]);
 
 export function setCommitAttribution(value: string | undefined): void {
   commitAttributionSetting = value;
@@ -207,15 +218,6 @@ function buildDirectEnv(isDark: boolean): Record<string, string> {
 
   // Merge user-configured Claude Code env vars (curated toggles + custom vars from settings),
   // but prevent overriding internal keys that would break spawned processes.
-  const RESERVED_ENV_KEYS = new Set([
-    'PATH',
-    'HOME',
-    'USER',
-    'TERM',
-    'COLORTERM',
-    'TERM_PROGRAM',
-    'COLORFGBG',
-  ]);
   for (const [key, value] of Object.entries(claudeEnvVars)) {
     if (!RESERVED_ENV_KEYS.has(key)) {
       env[key] = value;
@@ -233,7 +235,8 @@ function getTaskContextPrompt(taskId: string): string | null {
   try {
     const task = DatabaseService.getTask(taskId);
     return task?.contextPrompt ?? null;
-  } catch {
+  } catch (err) {
+    console.error('[getTaskContextPrompt] Failed to read context for task', taskId, err);
     return null;
   }
 }
@@ -287,16 +290,10 @@ function writeHookSettings(cwd: string, ptyId: string): void {
         ],
       },
     ],
-    Notification: [
-      {
-        matcher: 'permission_prompt',
-        hooks: [postHook('/hook/notification')],
-      },
-      {
-        matcher: 'idle_prompt',
-        hooks: [postHook('/hook/notification')],
-      },
-    ],
+    Notification: ['permission_prompt', 'idle_prompt'].map((matcher) => ({
+      matcher,
+      hooks: [postHook('/hook/notification')],
+    })),
   };
 
   // Inject task context via SessionStart hook. Fires on startup (new session),
@@ -309,19 +306,21 @@ function writeHookSettings(cwd: string, ptyId: string): void {
         additionalContext: contextPrompt,
       },
     });
+    // Use base64 encoding to safely embed user-controlled content in a shell command.
+    // Single-quote escaping is fragile with content from GitHub issues / ADO work items.
+    const b64 = Buffer.from(hookPayload).toString('base64');
     const sessionStartHook = {
       hooks: [
         {
           type: 'command',
-          command: `printf '%s' '${hookPayload.replace(/'/g, "'\\''")}'`,
+          command: `echo '${b64}' | base64 -d`,
         },
       ],
     };
-    hookSettings.SessionStart = [
-      { matcher: 'startup', ...sessionStartHook },
-      { matcher: 'compact', ...sessionStartHook },
-      { matcher: 'clear', ...sessionStartHook },
-    ];
+    hookSettings.SessionStart = ['startup', 'compact', 'clear'].map((matcher) => ({
+      matcher,
+      ...sessionStartHook,
+    }));
   }
 
   try {
@@ -334,8 +333,13 @@ function writeHookSettings(cwd: string, ptyId: string): void {
     if (fs.existsSync(settingsPath)) {
       try {
         existing = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
-      } catch {
-        // Corrupted — overwrite
+      } catch (err) {
+        console.error(
+          '[writeHookSettings] Corrupted settings.local.json at',
+          settingsPath,
+          '— overwriting:',
+          err,
+        );
       }
     }
 
@@ -764,12 +768,14 @@ export function killAll(): void {
 export function killByOwner(owner: WebContents): void {
   for (const [id, record] of ptys) {
     if (record.owner === owner) {
+      ptys.delete(id);
+      activityMonitor.unregister(id);
+      remoteControlService.unregister(id);
       try {
         record.proc.kill();
       } catch {
-        activityMonitor.unregister(id);
+        // Already dead
       }
-      ptys.delete(id);
     }
   }
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -269,7 +269,7 @@ export function App() {
   // Rotation: all tasks with activity, minus exclusions
   const rotationTasks = React.useMemo(() => {
     const tasks: Task[] = [];
-    for (const [, projectTasks] of Object.entries(tasksByProject)) {
+    for (const projectTasks of Object.values(tasksByProject)) {
       for (const task of projectTasks) {
         if (
           !task.archivedAt &&

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -955,11 +955,11 @@ export function App() {
       if (saveResp.success && saveResp.data) {
         const taskId = saveResp.data.id;
 
-        // Write task context for SessionStart hook injection
+        // Write task context so startDirectPty can pass it as the initial prompt
         if (linkedItems && linkedItems.length > 0) {
           const prompt = formatTaskContextPrompt(linkedItems);
           if (prompt) {
-            window.electronAPI.ptyWriteTaskContext({
+            await window.electronAPI.ptyWriteTaskContext({
               cwd: taskPath,
               prompt,
               meta: {
@@ -971,6 +971,30 @@ export function App() {
                     : undefined,
               },
             });
+
+            // Notify the user that linked context will be injected
+            const maxVisible = 3;
+            const visible = linkedItems.slice(0, maxVisible);
+            const overflow = linkedItems.length - maxVisible;
+            toast(
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-muted-foreground">Context injected</span>
+                {visible.map((item) => (
+                  <a
+                    key={`${item.provider}-${item.id}`}
+                    href={item.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="px-1.5 py-0.5 rounded-full bg-primary/10 text-primary text-[10px] font-medium hover:bg-primary/20 transition-colors"
+                  >
+                    #{item.id}
+                  </a>
+                ))}
+                {overflow > 0 && (
+                  <span className="text-[10px] text-muted-foreground">+{overflow} more</span>
+                )}
+              </div>,
+            );
           }
         }
 
@@ -1041,9 +1065,14 @@ export function App() {
         }
       }
 
-      // Clean up shell terminal sessions (first tab + any extra tabs)
+      // Clean up all terminal sessions: Claude main session + shell tabs
+      sessionRegistry.dispose(task.id);
       sessionRegistry.dispose(`shell:${task.id}`);
       sessionRegistry.disposeByPrefix(`shell:${task.id}:`);
+
+      // Kill PTY and clear snapshot so a new task in the same cwd starts fresh
+      window.electronAPI.ptyKill(task.id);
+      window.electronAPI.ptyClearSnapshot(task.id);
 
       await window.electronAPI.deleteTask(task.id);
       if (activeTaskId === task.id) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -955,21 +955,13 @@ export function App() {
       if (saveResp.success && saveResp.data) {
         const taskId = saveResp.data.id;
 
-        // Write task context so startDirectPty can pass it as the initial prompt
+        // Store task context so the SessionStart hook can inject it
         if (linkedItems && linkedItems.length > 0) {
           const prompt = formatTaskContextPrompt(linkedItems);
           if (prompt) {
             await window.electronAPI.ptyWriteTaskContext({
-              cwd: taskPath,
+              taskId,
               prompt,
-              meta: {
-                githubIssues:
-                  ghItems.length > 0 ? ghItems.map((i) => ({ id: i.id, url: i.url })) : undefined,
-                adoWorkItems:
-                  adoItems.length > 0
-                    ? adoItems.map((wi) => ({ id: wi.id, url: wi.url }))
-                    : undefined,
-              },
             });
 
             // Notify the user that linked context will be injected

--- a/src/renderer/components/MainContent.tsx
+++ b/src/renderer/components/MainContent.tsx
@@ -13,12 +13,60 @@ import {
 import type {
   Project,
   Task,
+  LinkedItem,
   RemoteControlState,
   PullRequestInfo,
   GitStatus,
 } from '../../shared/types';
 import { linkedItemUrl, isAdoRemote, branchUrl } from '../../shared/urls';
 import { Tooltip } from './ui/Tooltip';
+
+function LinkedItemBadges({
+  items,
+  gitRemote,
+  max = 3,
+}: {
+  items: LinkedItem[];
+  gitRemote: string | null;
+  max?: number;
+}) {
+  const visible = items.slice(0, max);
+  const overflow = items.length - max;
+  return (
+    <div className="flex items-center gap-1">
+      {visible.map((item) => {
+        const url = linkedItemUrl(item, gitRemote);
+        const key = `${item.provider}-${item.id}`;
+        const badge = url ? (
+          <a
+            key={key}
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="px-1.5 py-0.5 rounded-full bg-primary/10 text-primary text-[10px] font-medium hover:bg-primary/20 transition-colors"
+          >
+            #{item.id}
+          </a>
+        ) : (
+          <span
+            key={key}
+            className="px-1.5 py-0.5 rounded-full bg-primary/10 text-primary text-[10px] font-medium"
+          >
+            #{item.id}
+          </span>
+        );
+        return item.title ? (
+          <Tooltip key={key} content={item.title}>
+            {badge}
+          </Tooltip>
+        ) : (
+          badge
+        );
+      })}
+      {overflow > 0 && <span className="text-[10px] text-muted-foreground">+{overflow} more</span>}
+    </div>
+  );
+}
 
 interface MainContentProps {
   activeTask: Task | null;
@@ -232,48 +280,12 @@ export function MainContent({
               {activeTask.name}
             </span>
           </div>
-          {activeTask.linkedItems && activeTask.linkedItems.length > 0
-            ? (() => {
-                const maxVisible = 3;
-                const visible = activeTask.linkedItems.slice(0, maxVisible);
-                const overflow = activeTask.linkedItems.length - maxVisible;
-                return (
-                  <div className="flex items-center gap-1">
-                    {visible.map((item) => {
-                      const url = linkedItemUrl(item, activeProject?.gitRemote ?? null);
-                      const linkEl = url ? (
-                        <a
-                          key={`${item.provider}-${item.id}`}
-                          href={url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="px-1.5 py-0.5 rounded-full bg-primary/10 text-primary text-[10px] font-medium hover:bg-primary/20 transition-colors"
-                        >
-                          #{item.id}
-                        </a>
-                      ) : (
-                        <span
-                          key={`${item.provider}-${item.id}`}
-                          className="px-1.5 py-0.5 rounded-full bg-primary/10 text-primary text-[10px] font-medium"
-                        >
-                          #{item.id}
-                        </span>
-                      );
-                      return item.title ? (
-                        <Tooltip key={`${item.provider}-${item.id}`} content={item.title}>
-                          {linkEl}
-                        </Tooltip>
-                      ) : (
-                        linkEl
-                      );
-                    })}
-                    {overflow > 0 && (
-                      <span className="text-[10px] text-muted-foreground">+{overflow} more</span>
-                    )}
-                  </div>
-                );
-              })()
-            : null}
+          {activeTask.linkedItems && activeTask.linkedItems.length > 0 && (
+            <LinkedItemBadges
+              items={activeTask.linkedItems}
+              gitRemote={activeProject?.gitRemote ?? null}
+            />
+          )}
           <div className="ml-auto flex items-center gap-1.5">
             {activeTask.useWorktree ? (
               <Tooltip content={branchTooltip}>

--- a/src/renderer/components/MainContent.tsx
+++ b/src/renderer/components/MainContent.tsx
@@ -232,38 +232,48 @@ export function MainContent({
               {activeTask.name}
             </span>
           </div>
-          {activeTask.linkedItems && activeTask.linkedItems.length > 0 ? (
-            <div className="flex items-center gap-1">
-              {activeTask.linkedItems.map((item) => {
-                const url = linkedItemUrl(item, activeProject?.gitRemote ?? null);
-                const linkEl = url ? (
-                  <a
-                    key={`${item.provider}-${item.id}`}
-                    href={url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="px-1.5 py-0.5 rounded-full bg-primary/10 text-primary text-[10px] font-medium hover:bg-primary/20 transition-colors"
-                  >
-                    #{item.id}
-                  </a>
-                ) : (
-                  <span
-                    key={`${item.provider}-${item.id}`}
-                    className="px-1.5 py-0.5 rounded-full bg-primary/10 text-primary text-[10px] font-medium"
-                  >
-                    #{item.id}
-                  </span>
+          {activeTask.linkedItems && activeTask.linkedItems.length > 0
+            ? (() => {
+                const maxVisible = 3;
+                const visible = activeTask.linkedItems.slice(0, maxVisible);
+                const overflow = activeTask.linkedItems.length - maxVisible;
+                return (
+                  <div className="flex items-center gap-1">
+                    {visible.map((item) => {
+                      const url = linkedItemUrl(item, activeProject?.gitRemote ?? null);
+                      const linkEl = url ? (
+                        <a
+                          key={`${item.provider}-${item.id}`}
+                          href={url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="px-1.5 py-0.5 rounded-full bg-primary/10 text-primary text-[10px] font-medium hover:bg-primary/20 transition-colors"
+                        >
+                          #{item.id}
+                        </a>
+                      ) : (
+                        <span
+                          key={`${item.provider}-${item.id}`}
+                          className="px-1.5 py-0.5 rounded-full bg-primary/10 text-primary text-[10px] font-medium"
+                        >
+                          #{item.id}
+                        </span>
+                      );
+                      return item.title ? (
+                        <Tooltip key={`${item.provider}-${item.id}`} content={item.title}>
+                          {linkEl}
+                        </Tooltip>
+                      ) : (
+                        linkEl
+                      );
+                    })}
+                    {overflow > 0 && (
+                      <span className="text-[10px] text-muted-foreground">+{overflow} more</span>
+                    )}
+                  </div>
                 );
-                return item.title ? (
-                  <Tooltip key={`${item.provider}-${item.id}`} content={item.title}>
-                    {linkEl}
-                  </Tooltip>
-                ) : (
-                  linkEl
-                );
-              })}
-            </div>
-          ) : null}
+              })()
+            : null}
           <div className="ml-auto flex items-center gap-1.5">
             {activeTask.useWorktree ? (
               <Tooltip content={branchTooltip}>

--- a/src/renderer/components/ProjectOverview.tsx
+++ b/src/renderer/components/ProjectOverview.tsx
@@ -288,7 +288,7 @@ export function ProjectOverview({
                                 {label}
                               </span>
                               <div className="flex flex-wrap gap-1.5">
-                                {linkedItems.map((item) => {
+                                {linkedItems.slice(0, 3).map((item) => {
                                   const url = linkedItemUrl(item, project.gitRemote);
                                   const badge = (
                                     <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-primary/10 text-[10px] text-primary font-medium">
@@ -322,6 +322,11 @@ export function ProjectOverview({
                                     link
                                   );
                                 })}
+                                {linkedItems.length > 3 && (
+                                  <span className="text-[10px] text-muted-foreground self-center">
+                                    +{linkedItems.length - 3} more
+                                  </span>
+                                )}
                               </div>
                             </div>
                           );

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -13,6 +13,7 @@ import {
   ExternalLink,
 } from 'lucide-react';
 import { Tooltip } from './ui/Tooltip';
+import { ToggleSwitch } from './ui/ToggleSwitch';
 import type { KeyBindingMap, KeyBinding } from '../keybindings';
 import {
   getBindingKeys,
@@ -597,27 +598,11 @@ function ClaudeCodeTab({
         <label className="block text-[12px] font-medium text-foreground mb-3">
           Shell Environment
         </label>
-        <button
-          onClick={() => onSyncShellEnvChange(!syncShellEnv)}
-          className={`flex items-center gap-3 w-full px-4 py-3 rounded-lg text-[13px] border transition-all duration-150 ${
-            syncShellEnv
-              ? 'border-primary/40 bg-primary/8 text-foreground ring-1 ring-primary/20'
-              : 'border-border/60 text-foreground/60 hover:bg-accent/40 hover:text-foreground'
-          }`}
-        >
-          <div
-            className={`w-8 h-[18px] rounded-full relative transition-colors duration-150 flex-shrink-0 ${
-              syncShellEnv ? 'bg-primary' : 'bg-border'
-            }`}
-          >
-            <div
-              className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white shadow-sm transition-transform duration-150 ${
-                syncShellEnv ? 'translate-x-[16px]' : 'translate-x-[2px]'
-              }`}
-            />
-          </div>
-          Inherit environment from Dash process
-        </button>
+        <ToggleSwitch
+          enabled={syncShellEnv}
+          onToggle={onSyncShellEnvChange}
+          label="Inherit environment from Dash process"
+        />
         <p className="text-[10px] text-foreground/80 mt-2">
           {syncShellEnv
             ? 'Claude Code inherits all environment variables from the Dash process. Variables below override inherited values.'
@@ -982,27 +967,11 @@ export function SettingsModal({
                 <label className="block text-[12px] font-medium text-foreground mb-3">
                   Desktop Notifications
                 </label>
-                <button
-                  onClick={() => onDesktopNotificationChange(!desktopNotification)}
-                  className={`flex items-center gap-3 w-full px-4 py-3 rounded-lg text-[13px] border transition-all duration-150 ${
-                    desktopNotification
-                      ? 'border-primary/40 bg-primary/8 text-foreground ring-1 ring-primary/20'
-                      : 'border-border/60 text-foreground/60 hover:bg-accent/40 hover:text-foreground'
-                  }`}
-                >
-                  <div
-                    className={`w-8 h-[18px] rounded-full relative transition-colors duration-150 flex-shrink-0 ${
-                      desktopNotification ? 'bg-primary' : 'bg-border'
-                    }`}
-                  >
-                    <div
-                      className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white shadow-sm transition-transform duration-150 ${
-                        desktopNotification ? 'translate-x-[16px]' : 'translate-x-[2px]'
-                      }`}
-                    />
-                  </div>
-                  Show desktop notification when a task finishes
-                </button>
+                <ToggleSwitch
+                  enabled={desktopNotification}
+                  onToggle={onDesktopNotificationChange}
+                  label="Show desktop notification when a task finishes"
+                />
                 <p className="text-[10px] text-foreground/80 mt-2">
                   Notification will include the task name
                 </p>
@@ -1013,27 +982,11 @@ export function SettingsModal({
                 <label className="block text-[12px] font-medium text-foreground mb-3">
                   Active Tasks
                 </label>
-                <button
-                  onClick={() => onShowActiveTasksSectionChange(!showActiveTasksSection)}
-                  className={`flex items-center gap-3 w-full px-4 py-3 rounded-lg text-[13px] border transition-all duration-150 ${
-                    showActiveTasksSection
-                      ? 'border-primary/40 bg-primary/8 text-foreground ring-1 ring-primary/20'
-                      : 'border-border/60 text-foreground/60 hover:bg-accent/40 hover:text-foreground'
-                  }`}
-                >
-                  <div
-                    className={`w-8 h-[18px] rounded-full relative transition-colors duration-150 flex-shrink-0 ${
-                      showActiveTasksSection ? 'bg-primary' : 'bg-border'
-                    }`}
-                  >
-                    <div
-                      className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white shadow-sm transition-transform duration-150 ${
-                        showActiveTasksSection ? 'translate-x-[16px]' : 'translate-x-[2px]'
-                      }`}
-                    />
-                  </div>
-                  Show active tasks in sidebar
-                </button>
+                <ToggleSwitch
+                  enabled={showActiveTasksSection}
+                  onToggle={onShowActiveTasksSectionChange}
+                  label="Show active tasks in sidebar"
+                />
                 <p className="text-[10px] text-foreground/80 mt-2">
                   Quick-switch between running tasks with Ctrl+Tab.
                 </p>
@@ -1044,27 +997,11 @@ export function SettingsModal({
                 <label className="block text-[12px] font-medium text-foreground mb-3">
                   Shell Terminal
                 </label>
-                <button
-                  onClick={() => onShellDrawerEnabledChange(!shellDrawerEnabled)}
-                  className={`flex items-center gap-3 w-full px-4 py-3 rounded-lg text-[13px] border transition-all duration-150 ${
-                    shellDrawerEnabled
-                      ? 'border-primary/40 bg-primary/8 text-foreground ring-1 ring-primary/20'
-                      : 'border-border/60 text-foreground/60 hover:bg-accent/40 hover:text-foreground'
-                  }`}
-                >
-                  <div
-                    className={`w-8 h-[18px] rounded-full relative transition-colors duration-150 flex-shrink-0 ${
-                      shellDrawerEnabled ? 'bg-primary' : 'bg-border'
-                    }`}
-                  >
-                    <div
-                      className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white shadow-sm transition-transform duration-150 ${
-                        shellDrawerEnabled ? 'translate-x-[16px]' : 'translate-x-[2px]'
-                      }`}
-                    />
-                  </div>
-                  Show shell terminal drawer
-                </button>
+                <ToggleSwitch
+                  enabled={shellDrawerEnabled}
+                  onToggle={onShellDrawerEnabledChange}
+                  label="Show shell terminal drawer"
+                />
                 {shellDrawerEnabled && (
                   <div className="grid grid-cols-3 gap-2 mt-3">
                     {[

--- a/src/renderer/components/ui/ToggleSwitch.tsx
+++ b/src/renderer/components/ui/ToggleSwitch.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+export function ToggleSwitch({
+  enabled,
+  onToggle,
+  label,
+}: {
+  enabled: boolean;
+  onToggle: (value: boolean) => void;
+  label: string;
+}) {
+  return (
+    <button
+      onClick={() => onToggle(!enabled)}
+      className={`flex items-center gap-3 w-full px-4 py-3 rounded-lg text-[13px] border transition-all duration-150 ${
+        enabled
+          ? 'border-primary/40 bg-primary/8 text-foreground ring-1 ring-primary/20'
+          : 'border-border/60 text-foreground/60 hover:bg-accent/40 hover:text-foreground'
+      }`}
+    >
+      <div
+        className={`w-8 h-[18px] rounded-full relative transition-colors duration-150 flex-shrink-0 ${
+          enabled ? 'bg-primary' : 'bg-border'
+        }`}
+      >
+        <div
+          className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white shadow-sm transition-transform duration-150 ${
+            enabled ? 'translate-x-[16px]' : 'translate-x-[2px]'
+          }`}
+        />
+      </div>
+      {label}
+    </button>
+  );
+}

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -372,32 +372,6 @@ export class TerminalSessionManager {
             // Best effort
           }
         }
-
-        // Show info line when context was injected via SessionStart hook
-        if (result.taskContextMeta && !result.reattached && !resume) {
-          const { githubIssues, adoWorkItems } = result.taskContextMeta;
-
-          if (githubIssues && githubIssues.length > 0) {
-            const issueLabels = githubIssues.map((issue) => {
-              // OSC 8 hyperlink: \x1b]8;;URL\x07TEXT\x1b]8;;\x07
-              return issue.url
-                ? `\x1b]8;;${issue.url}\x07#${issue.id}\x1b]8;;\x07`
-                : `#${issue.id}`;
-            });
-            this.terminal.write(
-              `\x1b[2m\x1b[36m● Issue context injected: ${issueLabels.join(', ')}\x1b[0m\r\n`,
-            );
-          }
-
-          if (adoWorkItems && adoWorkItems.length > 0) {
-            const wiLabels = adoWorkItems.map((wi) => {
-              return wi.url ? `\x1b]8;;${wi.url}\x07#${wi.id}\x1b]8;;\x07` : `#${wi.id}`;
-            });
-            this.terminal.write(
-              `\x1b[2m\x1b[36m● Work item context injected: ${wiLabels.join(', ')}\x1b[0m\r\n`,
-            );
-          }
-        }
       }
     }
 
@@ -633,7 +607,6 @@ export class TerminalSessionManager {
   private async startPty(resume: boolean = false): Promise<{
     reattached: boolean;
     isDirectSpawn: boolean;
-    taskContextMeta: import('../../shared/types').TaskContextMeta | null;
   }> {
     const dims = this.fitAddon.proposeDimensions();
     const cols = this.ptyCols(dims?.cols ?? 120);
@@ -641,8 +614,6 @@ export class TerminalSessionManager {
 
     let reattached = false;
     let isDirectSpawn = false;
-    let taskContextMeta: import('../../shared/types').TaskContextMeta | null = null;
-
     const resp = await window.electronAPI.ptyStartDirect({
       id: this.id,
       cwd: this.cwd,
@@ -656,7 +627,6 @@ export class TerminalSessionManager {
     if (resp.success) {
       reattached = resp.data?.reattached ?? false;
       isDirectSpawn = resp.data?.isDirectSpawn ?? true;
-      taskContextMeta = resp.data?.taskContextMeta ?? null;
     } else {
       const isNativeModuleError = resp.error?.includes('[native module]');
 
@@ -697,7 +667,7 @@ export class TerminalSessionManager {
 
     this.ptyStarted = true;
 
-    return { reattached, isDirectSpawn, taskContextMeta };
+    return { reattached, isDirectSpawn };
   }
 
   private fireReady() {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -48,6 +48,7 @@ export interface Task {
   autoApprove: boolean;
   branchCreatedByDash: boolean;
   linkedItems: LinkedItem[] | null;
+  contextPrompt: string | null;
   archivedAt: string | null;
   createdAt: string;
   updatedAt: string;
@@ -94,16 +95,6 @@ export interface RemoveWorktreeOptions {
   deleteWorktreeDir?: boolean;
   deleteLocalBranch?: boolean;
   deleteRemoteBranch?: boolean;
-}
-
-export interface TaskContextMetaItem {
-  id: number;
-  url: string;
-}
-
-export interface TaskContextMeta {
-  githubIssues?: TaskContextMetaItem[];
-  adoWorkItems?: TaskContextMetaItem[];
 }
 
 export interface PtyOptions {

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -102,8 +102,6 @@ export interface ElectronAPI {
     IpcResponse<{
       reattached: boolean;
       isDirectSpawn: boolean;
-      hasTaskContext: boolean;
-      taskContextMeta: TaskContextMeta | null;
     }>
   >;
   ptyStart: (args: {

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -14,7 +14,6 @@ import type {
   CommitGraphData,
   CommitDetail,
   RemoteControlState,
-  TaskContextMeta,
   PullRequestInfo,
   PixelAgentsConfig,
   PixelAgentsStatus,
@@ -141,11 +140,7 @@ export interface ElectronAPI {
   ptyHasClaudeSession: (cwd: string) => Promise<IpcResponse<boolean>>;
 
   // Task context for SessionStart hook
-  ptyWriteTaskContext: (args: {
-    cwd: string;
-    prompt: string;
-    meta?: TaskContextMeta;
-  }) => Promise<IpcResponse<void>>;
+  ptyWriteTaskContext: (args: { taskId: string; prompt: string }) => Promise<IpcResponse<void>>;
 
   // App lifecycle
   onBeforeQuit: (callback: () => void) => () => void;


### PR DESCRIPTION
## Summary
- Pin each task to its own Claude session via `--session-id` so tasks sharing the same cwd (e.g. multiple tasks in the main worktree) never resume each other's sessions
- Clean up sessions, PTY, and snapshots on task deletion to prevent stale session leakage
- Re-inject task context on `compact`/`clear` via SessionStart hook matchers so linked issue awareness persists across the session lifecycle
- Replace PTY-based issue injection message with in-app toast notification using clickable issue badges (compatible with NO_FLICKER mode)
- Cap visible linked issue badges to 3 with `+N more` overflow in toast, task header, and project overview
- Store task context prompt in the database (`context_prompt` column on tasks) instead of a file, so it survives main process restarts and is cleaned up automatically via cascade delete

## Test plan
- [x] Create a task with a linked GitHub issue → verify toast shows with clickable badge
- [x] Create a task with multiple linked issues → verify badge overflow works
- [x] Delete a task in main worktree, create a new one → verify it starts a fresh session
- [x] Resume an existing task → verify it resumes the correct session
- [x] Verify context re-injection after `/compact` or `/clear` in Claude
- [x] Restart the app, resume a task with linked issues → verify context is still injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)