### PR TITLE
Add Skills Browser for discovering and installing Claude Code skills

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",
   "license": "MIT",
   "scripts": {
-    "dev": "concurrently -n main,renderer -c blue,green \"pnpm dev:main\" \"pnpm dev:renderer\"",
-    "dev:main": "tsc -p tsconfig.main.json && electron dist/main/main/entry.js --dev",
+    "dev": "concurrently -n tsc,electron,renderer -c blue,magenta,green --kill-others-on-fail \"pnpm dev:main:watch\" \"pnpm dev:main:run\" \"pnpm dev:renderer\"",
+    "dev:main:watch": "rm -rf dist/main && tsc -p tsconfig.main.json -w --preserveWatchOutput",
+    "dev:main:run": "wait-on dist/main/main/entry.js && electronmon dist/main/main/entry.js --dev",
     "dev:renderer": "vite",
     "build": "pnpm build:main && pnpm build:renderer",
     "build:main": "tsc -p tsconfig.main.json",
@@ -111,6 +112,12 @@
       "node-pty"
     ]
   },
+  "electronmon": {
+    "patterns": [
+      "dist/main/**/*"
+    ],
+    "logLevel": "quiet"
+  },
   "dependencies": {
     "@syv-ai/pixel-agents-watcher": "^1.3.0",
     "@types/qrcode": "^1.5.6",
@@ -148,6 +155,7 @@
     "concurrently": "^8.2.0",
     "electron": "^30.5.1",
     "electron-builder": "^24.13.0",
+    "electronmon": "^2.0.4",
     "eslint": "^8.57.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
@@ -160,6 +168,7 @@
     "typescript": "^5.3.0",
     "vite": "^5.4.0",
     "vitest": "^2.1.9",
+    "wait-on": "^9.0.5",
     "xterm": "^5.3.0"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",
   "license": "MIT",
   "scripts": {
-    "dev": "concurrently -n tsc,electron,renderer -c blue,magenta,green --kill-others-on-fail \"pnpm dev:main:watch\" \"pnpm dev:main:run\" \"pnpm dev:renderer\"",
-    "dev:main:watch": "rm -rf dist/main && tsc -p tsconfig.main.json -w --preserveWatchOutput",
-    "dev:main:run": "wait-on dist/main/main/entry.js && electronmon dist/main/main/entry.js --dev",
+    "dev": "concurrently -n main,renderer -c blue,green \"pnpm dev:main\" \"pnpm dev:renderer\"",
+    "dev:main": "tsc -p tsconfig.main.json && electron dist/main/main/entry.js --dev",
     "dev:renderer": "vite",
     "build": "pnpm build:main && pnpm build:renderer",
     "build:main": "tsc -p tsconfig.main.json",
@@ -112,12 +111,6 @@
       "node-pty"
     ]
   },
-  "electronmon": {
-    "patterns": [
-      "dist/main/**/*"
-    ],
-    "logLevel": "quiet"
-  },
   "dependencies": {
     "@syv-ai/pixel-agents-watcher": "^1.3.0",
     "@types/qrcode": "^1.5.6",
@@ -155,7 +148,6 @@
     "concurrently": "^8.2.0",
     "electron": "^30.5.1",
     "electron-builder": "^24.13.0",
-    "electronmon": "^2.0.4",
     "eslint": "^8.57.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
@@ -168,7 +160,6 @@
     "typescript": "^5.3.0",
     "vite": "^5.4.0",
     "vitest": "^2.1.9",
-    "wait-on": "^9.0.5",
     "xterm": "^5.3.0"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       electron-builder:
         specifier: ^24.13.0
         version: 24.13.3(electron-builder-squirrel-windows@24.13.3)
+      electronmon:
+        specifier: ^2.0.4
+        version: 2.0.4
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -147,6 +150,9 @@ importers:
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.19.10)
+      wait-on:
+        specifier: ^9.0.5
+        version: 9.0.5
       xterm:
         specifier: ^5.3.0
         version: 5.3.0
@@ -457,6 +463,26 @@ packages:
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
+  '@hapi/address@5.1.1':
+    resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
+    engines: {node: '>=14.0.0'}
+
+  '@hapi/formula@3.0.2':
+    resolution: {integrity: sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==}
+
+  '@hapi/hoek@11.0.7':
+    resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
+
+  '@hapi/pinpoint@2.0.1':
+    resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
+
+  '@hapi/tlds@1.1.6':
+    resolution: {integrity: sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==}
+    engines: {node: '>=14.0.0'}
+
+  '@hapi/topo@6.0.2':
+    resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -873,79 +899,66 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -980,6 +993,9 @@ packages:
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@syv-ai/pixel-agents-watcher@1.3.0':
     resolution: {integrity: sha512-ZiLD0WOlnm6jVGcZEpjfhLQd8A3RXYURbscCU3tzgGDUhnHkP9bGKOlH2sxLM/kiBT7sbuLXF1zXgpT2XYw0KQ==}
@@ -1319,6 +1335,9 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1429,6 +1448,10 @@ packages:
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
+
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1803,6 +1826,11 @@ packages:
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
+  electronmon@2.0.4:
+    resolution: {integrity: sha512-u6eDrvUbqa+wsnMrhG2vHmo5neL1owLg2e5i1avGWcOb4rHsUf9lSfbs0FvfPsBNpLxxlPO98nrMhAGV+zw/fQ==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -1980,6 +2008,15 @@ packages:
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -2171,6 +2208,10 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-from@3.0.0:
+    resolution: {integrity: sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==}
+    engines: {node: '>=8'}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -2268,6 +2309,10 @@ packages:
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
+
+  joi@18.1.2:
+    resolution: {integrity: sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==}
+    engines: {node: '>= 20'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2369,6 +2414,9 @@ packages:
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -2571,6 +2619,10 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     hasBin: true
 
+  normalize-path@2.1.1:
+    resolution: {integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==}
+    engines: {node: '>=0.10.0'}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -2698,6 +2750,10 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
+  pify@4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -2803,6 +2859,10 @@ packages:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -2900,6 +2960,9 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  remove-trailing-separator@1.1.0:
+    resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -2913,6 +2976,10 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
@@ -2957,6 +3024,10 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  runtime-required@1.1.0:
+    resolution: {integrity: sha512-yX97f5E0WfNpcQnfVjap6vzQcvErkYYCx6eTK4siqGEdC8lglwypUFgZVTX7ShvIlgfkC4XGFl9O1KTYcff0pw==}
+    engines: {node: '>=4.0.0'}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -3282,6 +3353,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unixify@1.0.0:
+    resolution: {integrity: sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==}
+    engines: {node: '>=0.10.0'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -3381,6 +3456,15 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  wait-on@9.0.5:
+    resolution: {integrity: sha512-qgnbHDfDTRIp73ANEJNRW/7kn8CrDUcvZz18xotJQku/P4saTGkbIzvnMZebPmVvVNUiRq1qWAPyqCH+W4H8KA==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  watchboy@0.4.3:
+    resolution: {integrity: sha512-GHs1HxwvxSMBsqd/WfTOZhj5gBdMqf5HQpfgtKxDfZRxrlYPDdVLRB61LCeRzJaWANmvSIMlfmRVDwVmJFgAKA==}
+    engines: {node: '>=8.0.0'}
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -3796,6 +3880,22 @@ snapshots:
   '@floating-ui/utils@0.2.10': {}
 
   '@gar/promisify@1.1.3': {}
+
+  '@hapi/address@5.1.1':
+    dependencies:
+      '@hapi/hoek': 11.0.7
+
+  '@hapi/formula@3.0.2': {}
+
+  '@hapi/hoek@11.0.7': {}
+
+  '@hapi/pinpoint@2.0.1': {}
+
+  '@hapi/tlds@1.1.6': {}
+
+  '@hapi/topo@6.0.2':
+    dependencies:
+      '@hapi/hoek': 11.0.7
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -4253,6 +4353,8 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@syv-ai/pixel-agents-watcher@1.3.0': {}
 
   '@szmarczak/http-timer@4.0.6':
@@ -4673,6 +4775,14 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  axios@1.16.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
@@ -4829,6 +4939,11 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
+
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   chalk@4.1.2:
     dependencies:
@@ -5160,6 +5275,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  electronmon@2.0.4:
+    dependencies:
+      chalk: 3.0.0
+      import-from: 3.0.0
+      runtime-required: 1.1.0
+      watchboy: 0.4.3
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -5381,6 +5503,8 @@ snapshots:
       rimraf: 3.0.2
 
   flatted@3.3.3: {}
+
+  follow-redirects@1.16.0: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -5612,6 +5736,10 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-from@3.0.0:
+    dependencies:
+      resolve-from: 5.0.0
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -5684,6 +5812,16 @@ snapshots:
       picocolors: 1.1.1
 
   jiti@1.21.7: {}
+
+  joi@18.1.2:
+    dependencies:
+      '@hapi/address': 5.1.1
+      '@hapi/formula': 3.0.2
+      '@hapi/hoek': 11.0.7
+      '@hapi/pinpoint': 2.0.1
+      '@hapi/tlds': 1.1.6
+      '@hapi/topo': 6.0.2
+      '@standard-schema/spec': 1.1.0
 
   js-tokens@4.0.0: {}
 
@@ -5777,6 +5915,8 @@ snapshots:
   lodash.union@4.6.0: {}
 
   lodash@4.17.23: {}
+
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -5971,6 +6111,10 @@ snapshots:
     dependencies:
       abbrev: 1.1.1
 
+  normalize-path@2.1.1:
+    dependencies:
+      remove-trailing-separator: 1.1.0
+
   normalize-path@3.0.0: {}
 
   normalize-url@6.1.0: {}
@@ -6076,6 +6220,8 @@ snapshots:
 
   pify@2.3.0: {}
 
+  pify@4.0.1: {}
+
   pirates@4.0.7: {}
 
   plist@3.1.0:
@@ -6161,6 +6307,8 @@ snapshots:
     dependencies:
       err-code: 2.0.3
       retry: 0.12.0
+
+  proxy-from-env@2.1.0: {}
 
   pump@3.0.3:
     dependencies:
@@ -6273,6 +6421,8 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  remove-trailing-separator@1.1.0: {}
+
   require-directory@2.1.1: {}
 
   require-main-filename@2.0.0: {}
@@ -6280,6 +6430,8 @@ snapshots:
   resolve-alpn@1.2.1: {}
 
   resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
 
   resolve@1.22.11:
     dependencies:
@@ -6355,6 +6507,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  runtime-required@1.1.0: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -6684,6 +6838,10 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unixify@1.0.0:
+    dependencies:
+      normalize-path: 2.1.1
+
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -6781,6 +6939,23 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  wait-on@9.0.5:
+    dependencies:
+      axios: 1.16.0
+      joi: 18.1.2
+      lodash: 4.18.1
+      minimist: 1.2.8
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - debug
+
+  watchboy@0.4.3:
+    dependencies:
+      lodash.difference: 4.5.0
+      micromatch: 4.0.8
+      pify: 4.0.1
+      unixify: 1.0.0
 
   wcwidth@1.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,9 +111,6 @@ importers:
       electron-builder:
         specifier: ^24.13.0
         version: 24.13.3(electron-builder-squirrel-windows@24.13.3)
-      electronmon:
-        specifier: ^2.0.4
-        version: 2.0.4
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -150,9 +147,6 @@ importers:
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.19.10)
-      wait-on:
-        specifier: ^9.0.5
-        version: 9.0.5
       xterm:
         specifier: ^5.3.0
         version: 5.3.0
@@ -463,26 +457,6 @@ packages:
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
-
-  '@hapi/address@5.1.1':
-    resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
-    engines: {node: '>=14.0.0'}
-
-  '@hapi/formula@3.0.2':
-    resolution: {integrity: sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==}
-
-  '@hapi/hoek@11.0.7':
-    resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
-
-  '@hapi/pinpoint@2.0.1':
-    resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
-
-  '@hapi/tlds@1.1.6':
-    resolution: {integrity: sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==}
-    engines: {node: '>=14.0.0'}
-
-  '@hapi/topo@6.0.2':
-    resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -899,66 +873,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -993,9 +980,6 @@ packages:
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
-
-  '@standard-schema/spec@1.1.0':
-    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@syv-ai/pixel-agents-watcher@1.3.0':
     resolution: {integrity: sha512-ZiLD0WOlnm6jVGcZEpjfhLQd8A3RXYURbscCU3tzgGDUhnHkP9bGKOlH2sxLM/kiBT7sbuLXF1zXgpT2XYw0KQ==}
@@ -1335,9 +1319,6 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
-  axios@1.16.0:
-    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
-
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1448,10 +1429,6 @@ packages:
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
-
-  chalk@3.0.0:
-    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
-    engines: {node: '>=8'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1826,11 +1803,6 @@ packages:
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
-  electronmon@2.0.4:
-    resolution: {integrity: sha512-u6eDrvUbqa+wsnMrhG2vHmo5neL1owLg2e5i1avGWcOb4rHsUf9lSfbs0FvfPsBNpLxxlPO98nrMhAGV+zw/fQ==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -2008,15 +1980,6 @@ packages:
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
-
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -2208,10 +2171,6 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
-  import-from@3.0.0:
-    resolution: {integrity: sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==}
-    engines: {node: '>=8'}
-
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -2309,10 +2268,6 @@ packages:
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
-
-  joi@18.1.2:
-    resolution: {integrity: sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==}
-    engines: {node: '>= 20'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2414,9 +2369,6 @@ packages:
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
-
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -2619,10 +2571,6 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     hasBin: true
 
-  normalize-path@2.1.1:
-    resolution: {integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==}
-    engines: {node: '>=0.10.0'}
-
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -2750,10 +2698,6 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
-  pify@4.0.1:
-    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
-    engines: {node: '>=6'}
-
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -2859,10 +2803,6 @@ packages:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
 
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
-
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -2960,9 +2900,6 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  remove-trailing-separator@1.1.0:
-    resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
-
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -2976,10 +2913,6 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-
-  resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
 
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
@@ -3024,10 +2957,6 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-
-  runtime-required@1.1.0:
-    resolution: {integrity: sha512-yX97f5E0WfNpcQnfVjap6vzQcvErkYYCx6eTK4siqGEdC8lglwypUFgZVTX7ShvIlgfkC4XGFl9O1KTYcff0pw==}
-    engines: {node: '>=4.0.0'}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -3353,10 +3282,6 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unixify@1.0.0:
-    resolution: {integrity: sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==}
-    engines: {node: '>=0.10.0'}
-
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -3456,15 +3381,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  wait-on@9.0.5:
-    resolution: {integrity: sha512-qgnbHDfDTRIp73ANEJNRW/7kn8CrDUcvZz18xotJQku/P4saTGkbIzvnMZebPmVvVNUiRq1qWAPyqCH+W4H8KA==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-
-  watchboy@0.4.3:
-    resolution: {integrity: sha512-GHs1HxwvxSMBsqd/WfTOZhj5gBdMqf5HQpfgtKxDfZRxrlYPDdVLRB61LCeRzJaWANmvSIMlfmRVDwVmJFgAKA==}
-    engines: {node: '>=8.0.0'}
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -3880,22 +3796,6 @@ snapshots:
   '@floating-ui/utils@0.2.10': {}
 
   '@gar/promisify@1.1.3': {}
-
-  '@hapi/address@5.1.1':
-    dependencies:
-      '@hapi/hoek': 11.0.7
-
-  '@hapi/formula@3.0.2': {}
-
-  '@hapi/hoek@11.0.7': {}
-
-  '@hapi/pinpoint@2.0.1': {}
-
-  '@hapi/tlds@1.1.6': {}
-
-  '@hapi/topo@6.0.2':
-    dependencies:
-      '@hapi/hoek': 11.0.7
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -4353,8 +4253,6 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@standard-schema/spec@1.1.0': {}
-
   '@syv-ai/pixel-agents-watcher@1.3.0': {}
 
   '@szmarczak/http-timer@4.0.6':
@@ -4775,14 +4673,6 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  axios@1.16.0:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
@@ -4939,11 +4829,6 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
-
-  chalk@3.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
 
   chalk@4.1.2:
     dependencies:
@@ -5275,13 +5160,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electronmon@2.0.4:
-    dependencies:
-      chalk: 3.0.0
-      import-from: 3.0.0
-      runtime-required: 1.1.0
-      watchboy: 0.4.3
-
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -5503,8 +5381,6 @@ snapshots:
       rimraf: 3.0.2
 
   flatted@3.3.3: {}
-
-  follow-redirects@1.16.0: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -5736,10 +5612,6 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-from@3.0.0:
-    dependencies:
-      resolve-from: 5.0.0
-
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -5812,16 +5684,6 @@ snapshots:
       picocolors: 1.1.1
 
   jiti@1.21.7: {}
-
-  joi@18.1.2:
-    dependencies:
-      '@hapi/address': 5.1.1
-      '@hapi/formula': 3.0.2
-      '@hapi/hoek': 11.0.7
-      '@hapi/pinpoint': 2.0.1
-      '@hapi/tlds': 1.1.6
-      '@hapi/topo': 6.0.2
-      '@standard-schema/spec': 1.1.0
 
   js-tokens@4.0.0: {}
 
@@ -5915,8 +5777,6 @@ snapshots:
   lodash.union@4.6.0: {}
 
   lodash@4.17.23: {}
-
-  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -6111,10 +5971,6 @@ snapshots:
     dependencies:
       abbrev: 1.1.1
 
-  normalize-path@2.1.1:
-    dependencies:
-      remove-trailing-separator: 1.1.0
-
   normalize-path@3.0.0: {}
 
   normalize-url@6.1.0: {}
@@ -6220,8 +6076,6 @@ snapshots:
 
   pify@2.3.0: {}
 
-  pify@4.0.1: {}
-
   pirates@4.0.7: {}
 
   plist@3.1.0:
@@ -6307,8 +6161,6 @@ snapshots:
     dependencies:
       err-code: 2.0.3
       retry: 0.12.0
-
-  proxy-from-env@2.1.0: {}
 
   pump@3.0.3:
     dependencies:
@@ -6421,8 +6273,6 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
-  remove-trailing-separator@1.1.0: {}
-
   require-directory@2.1.1: {}
 
   require-main-filename@2.0.0: {}
@@ -6430,8 +6280,6 @@ snapshots:
   resolve-alpn@1.2.1: {}
 
   resolve-from@4.0.0: {}
-
-  resolve-from@5.0.0: {}
 
   resolve@1.22.11:
     dependencies:
@@ -6507,8 +6355,6 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-
-  runtime-required@1.1.0: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -6838,10 +6684,6 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unixify@1.0.0:
-    dependencies:
-      normalize-path: 2.1.1
-
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -6939,23 +6781,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-
-  wait-on@9.0.5:
-    dependencies:
-      axios: 1.16.0
-      joi: 18.1.2
-      lodash: 4.18.1
-      minimist: 1.2.8
-      rxjs: 7.8.2
-    transitivePeerDependencies:
-      - debug
-
-  watchboy@0.4.3:
-    dependencies:
-      lodash.difference: 4.5.0
-      micromatch: 4.0.8
-      pify: 4.0.1
-      unixify: 1.0.0
 
   wcwidth@1.0.1:
     dependencies:

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -8,6 +8,7 @@ import { registerAutoUpdateIpc } from './autoUpdateIpc';
 import { registerAzureDevOpsIpc } from './azureDevOpsIpc';
 import { registerPixelAgentsIpc } from './pixelAgentsIpc';
 import { registerTelemetryIpc } from './telemetryIpc';
+import { registerSkillsIpc } from './skillsIpc';
 
 export function registerAllIpc(): void {
   registerAppIpc();
@@ -20,4 +21,5 @@ export function registerAllIpc(): void {
   registerAzureDevOpsIpc();
   registerPixelAgentsIpc();
   registerTelemetryIpc();
+  registerSkillsIpc();
 }

--- a/src/main/ipc/skillsIpc.ts
+++ b/src/main/ipc/skillsIpc.ts
@@ -92,9 +92,9 @@ export function registerSkillsIpc(): void {
     }
   });
 
-  ipcMain.handle('skills:listInstalled', async (_event, args: { probePaths: string[] }) => {
+  ipcMain.handle('skills:listInstalled', (_event, args: { probePaths: string[] }) => {
     try {
-      const data = await SkillsService.listInstalled(args?.probePaths ?? []);
+      const data = SkillsService.listInstalled(args?.probePaths ?? []);
       return { success: true, data };
     } catch (error) {
       return fail('SKILLS_LIST_INSTALLED', error);

--- a/src/main/ipc/skillsIpc.ts
+++ b/src/main/ipc/skillsIpc.ts
@@ -103,9 +103,13 @@ export function registerSkillsIpc(): void {
 
   ipcMain.handle(
     'skills:checkInstalled',
-    (_event, args: { skillName: string; probePaths: string[] }) => {
+    (_event, args: { skillName: string; probePaths: string[]; ref?: SkillRef | null }) => {
       try {
-        const data = SkillsService.checkInstalled(args.skillName, args.probePaths);
+        const data = SkillsService.checkInstalled(
+          args.skillName,
+          args.probePaths,
+          args.ref ?? null,
+        );
         return { success: true, data };
       } catch (error) {
         return fail('SKILLS_CHECK_INSTALLED', error, { skillName: args?.skillName });

--- a/src/main/ipc/skillsIpc.ts
+++ b/src/main/ipc/skillsIpc.ts
@@ -1,0 +1,83 @@
+import { ipcMain } from 'electron';
+import { SkillsService } from '../services/SkillsService';
+
+export function registerSkillsIpc(): void {
+  ipcMain.handle('skills:fetchRegistry', async (_event, args?: { forceRefresh?: boolean }) => {
+    try {
+      const data = await SkillsService.fetchRegistry(args?.forceRefresh);
+      return { success: true, data };
+    } catch (error) {
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle(
+    'skills:search',
+    async (_event, args: { query: string; category?: string; limit?: number; offset?: number }) => {
+      try {
+        const data = await SkillsService.search(args.query, args.category, args.limit, args.offset);
+        return { success: true, data };
+      } catch (error) {
+        return { success: false, error: String(error) };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'skills:getContent',
+    async (_event, args: { repo: string; path: string; branch: string }) => {
+      try {
+        const data = await SkillsService.getSkillContent(args.repo, args.path, args.branch);
+        return { success: true, data };
+      } catch (error) {
+        return { success: false, error: String(error) };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'skills:install',
+    async (
+      _event,
+      args: {
+        repo: string;
+        path: string;
+        branch: string;
+        skillName: string;
+        target: 'global' | 'project';
+        projectPath?: string;
+      },
+    ) => {
+      try {
+        await SkillsService.installSkill(args);
+        return { success: true };
+      } catch (error) {
+        return { success: false, error: String(error) };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'skills:checkInstalled',
+    (_event, args: { skillName: string; projectPaths: string[] }) => {
+      try {
+        const data = SkillsService.checkInstalled(args.skillName, args.projectPaths);
+        return { success: true, data };
+      } catch (error) {
+        return { success: false, error: String(error) };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'skills:uninstall',
+    (_event, args: { skillName: string; target: 'global' | 'project'; projectPath?: string }) => {
+      try {
+        SkillsService.uninstallSkill(args);
+        return { success: true };
+      } catch (error) {
+        return { success: false, error: String(error) };
+      }
+    },
+  );
+}

--- a/src/main/ipc/skillsIpc.ts
+++ b/src/main/ipc/skillsIpc.ts
@@ -5,6 +5,7 @@ import type {
   SkillInstallArgs,
   SkillUninstallArgs,
   SkillsSearchArgs,
+  SkillInstallTarget,
 } from '@shared/types';
 
 function describe(err: unknown): string {
@@ -17,8 +18,6 @@ function fail(errorId: string, err: unknown, ctx?: Record<string, unknown>) {
 }
 
 export function registerSkillsIpc(): void {
-  // Refreshes the SQLite cache from the upstream registry. Returns the new meta only —
-  // the renderer never receives the 155k-row catalog; it pages via skills:search.
   ipcMain.handle('skills:refresh', async (_event, args?: { force?: boolean }) => {
     try {
       const meta = await SkillsService.ensureRegistry(args?.force === true);
@@ -67,14 +66,14 @@ export function registerSkillsIpc(): void {
 
   ipcMain.handle(
     'skills:readLocalSkillMd',
-    (_event, args: { skillName: string; installLocation: string }) => {
+    (_event, args: { skillName: string; target: SkillInstallTarget }) => {
       try {
         const data = SkillsService.readLocalSkillMd(args);
         return { success: true, data };
       } catch (error) {
         return fail('SKILLS_READ_LOCAL', error, {
           skillName: args?.skillName,
-          installLocation: args?.installLocation,
+          targetKind: args?.target?.kind,
         });
       }
     },
@@ -113,6 +112,15 @@ export function registerSkillsIpc(): void {
       }
     },
   );
+
+  ipcMain.handle('skills:resetCache', async () => {
+    try {
+      const meta = await SkillsService.resetCache();
+      return { success: true, data: meta };
+    } catch (error) {
+      return fail('SKILLS_RESET_CACHE', error);
+    }
+  });
 
   ipcMain.handle('skills:uninstall', (_event, args: SkillUninstallArgs) => {
     try {

--- a/src/main/ipc/skillsIpc.ts
+++ b/src/main/ipc/skillsIpc.ts
@@ -1,83 +1,128 @@
 import { ipcMain } from 'electron';
 import { SkillsService } from '../services/SkillsService';
+import type {
+  SkillRef,
+  SkillInstallArgs,
+  SkillUninstallArgs,
+  SkillsSearchArgs,
+} from '@shared/types';
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function fail(errorId: string, err: unknown, ctx?: Record<string, unknown>) {
+  console.error(`[skillsIpc.${errorId}]`, { message: describe(err), ...ctx });
+  return { success: false, error: describe(err) };
+}
 
 export function registerSkillsIpc(): void {
-  ipcMain.handle('skills:fetchRegistry', async (_event, args?: { forceRefresh?: boolean }) => {
+  // Refreshes the SQLite cache from the upstream registry. Returns the new meta only —
+  // the renderer never receives the 155k-row catalog; it pages via skills:search.
+  ipcMain.handle('skills:refresh', async (_event, args?: { force?: boolean }) => {
     try {
-      const data = await SkillsService.fetchRegistry(args?.forceRefresh);
+      const meta = await SkillsService.ensureRegistry(args?.force === true);
+      return { success: true, data: meta };
+    } catch (error) {
+      return fail('SKILLS_REFRESH', error, { force: args?.force });
+    }
+  });
+
+  ipcMain.handle('skills:getMeta', () => {
+    try {
+      return { success: true, data: SkillsService.getMeta() };
+    } catch (error) {
+      return fail('SKILLS_GET_META', error);
+    }
+  });
+
+  ipcMain.handle('skills:getCategories', () => {
+    try {
+      return { success: true, data: SkillsService.getCategories() };
+    } catch (error) {
+      return fail('SKILLS_GET_CATEGORIES', error);
+    }
+  });
+
+  ipcMain.handle('skills:search', (_event, args: SkillsSearchArgs) => {
+    try {
+      const data = SkillsService.search(args);
       return { success: true, data };
     } catch (error) {
-      return { success: false, error: String(error) };
+      return fail('SKILLS_SEARCH', error, {
+        query: args?.query,
+        category: args?.category,
+      });
+    }
+  });
+
+  ipcMain.handle('skills:getContent', async (_event, args: SkillRef) => {
+    try {
+      const data = await SkillsService.getSkillContent(args);
+      return { success: true, data };
+    } catch (error) {
+      return fail('SKILLS_GET_CONTENT', error, { repo: args?.repo, path: args?.path });
     }
   });
 
   ipcMain.handle(
-    'skills:search',
-    async (_event, args: { query: string; category?: string; limit?: number; offset?: number }) => {
+    'skills:readLocalSkillMd',
+    (_event, args: { skillName: string; installLocation: string }) => {
       try {
-        const data = await SkillsService.search(args.query, args.category, args.limit, args.offset);
+        const data = SkillsService.readLocalSkillMd(args);
         return { success: true, data };
       } catch (error) {
-        return { success: false, error: String(error) };
+        return fail('SKILLS_READ_LOCAL', error, {
+          skillName: args?.skillName,
+          installLocation: args?.installLocation,
+        });
       }
     },
   );
 
-  ipcMain.handle(
-    'skills:getContent',
-    async (_event, args: { repo: string; path: string; branch: string }) => {
-      try {
-        const data = await SkillsService.getSkillContent(args.repo, args.path, args.branch);
-        return { success: true, data };
-      } catch (error) {
-        return { success: false, error: String(error) };
-      }
-    },
-  );
+  ipcMain.handle('skills:install', async (_event, args: SkillInstallArgs) => {
+    try {
+      await SkillsService.installSkill(args);
+      return { success: true };
+    } catch (error) {
+      return fail('SKILLS_INSTALL', error, {
+        repo: args?.ref?.repo,
+        skillName: args?.skillName,
+        target: args?.target?.kind,
+      });
+    }
+  });
 
-  ipcMain.handle(
-    'skills:install',
-    async (
-      _event,
-      args: {
-        repo: string;
-        path: string;
-        branch: string;
-        skillName: string;
-        target: 'global' | 'project';
-        projectPath?: string;
-      },
-    ) => {
-      try {
-        await SkillsService.installSkill(args);
-        return { success: true };
-      } catch (error) {
-        return { success: false, error: String(error) };
-      }
-    },
-  );
+  ipcMain.handle('skills:listInstalled', (_event, args: { probePaths: string[] }) => {
+    try {
+      const data = SkillsService.listInstalled(args?.probePaths ?? []);
+      return { success: true, data };
+    } catch (error) {
+      return fail('SKILLS_LIST_INSTALLED', error);
+    }
+  });
 
   ipcMain.handle(
     'skills:checkInstalled',
-    (_event, args: { skillName: string; projectPaths: string[] }) => {
+    (_event, args: { skillName: string; probePaths: string[] }) => {
       try {
-        const data = SkillsService.checkInstalled(args.skillName, args.projectPaths);
+        const data = SkillsService.checkInstalled(args.skillName, args.probePaths);
         return { success: true, data };
       } catch (error) {
-        return { success: false, error: String(error) };
+        return fail('SKILLS_CHECK_INSTALLED', error, { skillName: args?.skillName });
       }
     },
   );
 
-  ipcMain.handle(
-    'skills:uninstall',
-    (_event, args: { skillName: string; target: 'global' | 'project'; projectPath?: string }) => {
-      try {
-        SkillsService.uninstallSkill(args);
-        return { success: true };
-      } catch (error) {
-        return { success: false, error: String(error) };
-      }
-    },
-  );
+  ipcMain.handle('skills:uninstall', (_event, args: SkillUninstallArgs) => {
+    try {
+      SkillsService.uninstallSkill(args);
+      return { success: true };
+    } catch (error) {
+      return fail('SKILLS_UNINSTALL', error, {
+        skillName: args?.skillName,
+        target: args?.target?.kind,
+      });
+    }
+  });
 }

--- a/src/main/ipc/skillsIpc.ts
+++ b/src/main/ipc/skillsIpc.ts
@@ -92,9 +92,9 @@ export function registerSkillsIpc(): void {
     }
   });
 
-  ipcMain.handle('skills:listInstalled', (_event, args: { probePaths: string[] }) => {
+  ipcMain.handle('skills:listInstalled', async (_event, args: { probePaths: string[] }) => {
     try {
-      const data = SkillsService.listInstalled(args?.probePaths ?? []);
+      const data = await SkillsService.listInstalled(args?.probePaths ?? []);
       return { success: true, data };
     } catch (error) {
       return fail('SKILLS_LIST_INSTALLED', error);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -250,27 +250,23 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
 
   // Skills
-  skillsFetchRegistry: (args?: { forceRefresh?: boolean }) =>
-    ipcRenderer.invoke('skills:fetchRegistry', args),
-  skillsSearch: (args: { query: string; category?: string; limit?: number; offset?: number }) =>
+  skillsRefresh: (args?: { force?: boolean }) => ipcRenderer.invoke('skills:refresh', args),
+  skillsGetMeta: () => ipcRenderer.invoke('skills:getMeta'),
+  skillsGetCategories: () => ipcRenderer.invoke('skills:getCategories'),
+  skillsSearch: (args: import('@shared/types').SkillsSearchArgs) =>
     ipcRenderer.invoke('skills:search', args),
-  skillsGetContent: (args: { repo: string; path: string; branch: string }) =>
+  skillsGetContent: (args: import('@shared/types').SkillRef) =>
     ipcRenderer.invoke('skills:getContent', args),
-  skillsInstall: (args: {
-    repo: string;
-    path: string;
-    branch: string;
-    skillName: string;
-    target: 'global' | 'project';
-    projectPath?: string;
-  }) => ipcRenderer.invoke('skills:install', args),
-  skillsCheckInstalled: (args: { skillName: string; projectPaths: string[] }) =>
+  skillsReadLocalSkillMd: (args: { skillName: string; installLocation: string }) =>
+    ipcRenderer.invoke('skills:readLocalSkillMd', args),
+  skillsInstall: (args: import('@shared/types').SkillInstallArgs) =>
+    ipcRenderer.invoke('skills:install', args),
+  skillsCheckInstalled: (args: { skillName: string; probePaths: string[] }) =>
     ipcRenderer.invoke('skills:checkInstalled', args),
-  skillsUninstall: (args: {
-    skillName: string;
-    target: 'global' | 'project';
-    projectPath?: string;
-  }) => ipcRenderer.invoke('skills:uninstall', args),
+  skillsListInstalled: (args: { probePaths: string[] }) =>
+    ipcRenderer.invoke('skills:listInstalled', args),
+  skillsUninstall: (args: import('@shared/types').SkillUninstallArgs) =>
+    ipcRenderer.invoke('skills:uninstall', args),
 
   // Telemetry
   telemetryCapture: (event: string, properties?: Record<string, unknown>) =>

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -249,6 +249,29 @@ contextBridge.exposeInMainWorld('electronAPI', {
     };
   },
 
+  // Skills
+  skillsFetchRegistry: (args?: { forceRefresh?: boolean }) =>
+    ipcRenderer.invoke('skills:fetchRegistry', args),
+  skillsSearch: (args: { query: string; category?: string; limit?: number; offset?: number }) =>
+    ipcRenderer.invoke('skills:search', args),
+  skillsGetContent: (args: { repo: string; path: string; branch: string }) =>
+    ipcRenderer.invoke('skills:getContent', args),
+  skillsInstall: (args: {
+    repo: string;
+    path: string;
+    branch: string;
+    skillName: string;
+    target: 'global' | 'project';
+    projectPath?: string;
+  }) => ipcRenderer.invoke('skills:install', args),
+  skillsCheckInstalled: (args: { skillName: string; projectPaths: string[] }) =>
+    ipcRenderer.invoke('skills:checkInstalled', args),
+  skillsUninstall: (args: {
+    skillName: string;
+    target: 'global' | 'project';
+    projectPath?: string;
+  }) => ipcRenderer.invoke('skills:uninstall', args),
+
   // Telemetry
   telemetryCapture: (event: string, properties?: Record<string, unknown>) =>
     ipcRenderer.invoke('telemetry:capture', { event, properties }),

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -263,8 +263,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   }) => ipcRenderer.invoke('skills:readLocalSkillMd', args),
   skillsInstall: (args: import('@shared/types').SkillInstallArgs) =>
     ipcRenderer.invoke('skills:install', args),
-  skillsCheckInstalled: (args: { skillName: string; probePaths: string[] }) =>
-    ipcRenderer.invoke('skills:checkInstalled', args),
+  skillsCheckInstalled: (args: {
+    skillName: string;
+    probePaths: string[];
+    ref?: import('@shared/types').SkillRef | null;
+  }) => ipcRenderer.invoke('skills:checkInstalled', args),
   skillsListInstalled: (args: { probePaths: string[] }) =>
     ipcRenderer.invoke('skills:listInstalled', args),
   skillsUninstall: (args: import('@shared/types').SkillUninstallArgs) =>

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -257,8 +257,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('skills:search', args),
   skillsGetContent: (args: import('@shared/types').SkillRef) =>
     ipcRenderer.invoke('skills:getContent', args),
-  skillsReadLocalSkillMd: (args: { skillName: string; installLocation: string }) =>
-    ipcRenderer.invoke('skills:readLocalSkillMd', args),
+  skillsReadLocalSkillMd: (args: {
+    skillName: string;
+    target: import('@shared/types').SkillInstallTarget;
+  }) => ipcRenderer.invoke('skills:readLocalSkillMd', args),
   skillsInstall: (args: import('@shared/types').SkillInstallArgs) =>
     ipcRenderer.invoke('skills:install', args),
   skillsCheckInstalled: (args: { skillName: string; probePaths: string[] }) =>
@@ -267,6 +269,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('skills:listInstalled', args),
   skillsUninstall: (args: import('@shared/types').SkillUninstallArgs) =>
     ipcRenderer.invoke('skills:uninstall', args),
+  skillsResetCache: () => ipcRenderer.invoke('skills:resetCache'),
 
   // Telemetry
   telemetryCapture: (event: string, properties?: Record<string, unknown>) =>

--- a/src/main/services/SkillsService.ts
+++ b/src/main/services/SkillsService.ts
@@ -1,261 +1,644 @@
-import { app } from 'electron';
-import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'fs';
+import {
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+  statSync,
+  rmSync,
+  renameSync,
+  readdirSync,
+  type Dirent,
+} from 'fs';
 import path from 'path';
-import type { RegistrySkill, SkillsSearchResult, SkillInstallStatus } from '@shared/types';
+import os from 'os';
+import type {
+  RegistrySkill,
+  SkillsSearchArgs,
+  SkillsSearchResult,
+  SkillInstallStatus,
+  SkillRef,
+  SkillInstallArgs,
+  SkillUninstallArgs,
+  SkillInstallTarget,
+  SkillsRegistryMeta,
+  InstalledSkill,
+} from '@shared/types';
+import { SkillsCache } from './skillsCache';
 
 const REGISTRY_URL =
   'https://raw.githubusercontent.com/majiayu000/claude-skill-registry/main/registry.json';
-const MAX_SKILLS = 500;
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
-const FETCH_TIMEOUT_MS = 60_000; // 60s for the large registry download
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+// The registry's long tail is dominated by abandoned/duplicate entries; top-N-by-stars
+// keeps the on-disk cache compact while covering any skill users are realistically after.
+const MAX_SKILLS = 10_000;
+const REGISTRY_FETCH_TIMEOUT_MS = 60_000;
+const FILE_FETCH_TIMEOUT_MS = 15_000;
+const MAX_FILE_BYTES = 2 * 1024 * 1024;
+const MAX_FILES_PER_SKILL = 50;
+const MAX_RECURSION_DEPTH = 3;
+const RAW_GITHUB_PREFIX = 'https://raw.githubusercontent.com/';
 
-interface SkillsCache {
-  fetchedAt: number;
-  skills: RegistrySkill[];
+const SKILL_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
+const BRANCH_RE = /^[\w./-]+$/;
+const ENTRY_NAME_RE = /^[\w.][\w.-]*$/;
+
+function assertSkillName(name: string): void {
+  if (!SKILL_NAME_RE.test(name)) {
+    throw new Error(`Invalid skill name: ${JSON.stringify(name)}`);
+  }
 }
 
-function getCachePath(): string {
-  return path.join(app.getPath('userData'), 'skills-cache.json');
+// Path segments may contain dots (e.g. ".claude") and dashes; we reject anything that
+// could break the URL we'll build (`?`, `#`, whitespace) or escape the directory.
+const PATH_SEGMENT_RE = /^[\w.][\w.-]*$/;
+
+function assertRef(ref: SkillRef): void {
+  if (!REPO_RE.test(ref.repo)) {
+    throw new Error(`Invalid repo: ${JSON.stringify(ref.repo)}`);
+  }
+  if (!BRANCH_RE.test(ref.branch)) {
+    throw new Error(`Invalid branch: ${JSON.stringify(ref.branch)}`);
+  }
+  const segments = ref.path.split('/').filter(Boolean);
+  for (const seg of segments) {
+    if (seg === '..' || seg.includes('\0') || !PATH_SEGMENT_RE.test(seg)) {
+      throw new Error(`Invalid skill path: ${JSON.stringify(ref.path)}`);
+    }
+  }
 }
 
-function readCache(): SkillsCache | null {
+function resolveSkillsBaseDir(target: SkillInstallTarget): string {
+  switch (target.kind) {
+    case 'global':
+      return path.join(os.homedir(), '.claude', 'skills');
+    case 'project':
+      return path.join(target.projectPath, '.claude', 'skills');
+    case 'task':
+      return path.join(target.worktreePath, '.claude', 'skills');
+    default: {
+      // Forces a compile error if a future SkillInstallTarget variant is added without
+      // updating this switch — we'd rather break the build than silently default to global.
+      const _exhaustive: never = target;
+      throw new Error(`Unhandled install target: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+}
+
+function resolveInstallDir(target: SkillInstallTarget, skillName: string): string {
+  assertSkillName(skillName);
+  const base = resolveSkillsBaseDir(target);
+  const installDir = path.resolve(base, skillName);
+  const rel = path.relative(base, installDir);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new Error(`Resolved install dir escapes base: ${installDir}`);
+  }
+  return installDir;
+}
+
+function resolveChildPath(baseDir: string, name: string): string {
+  if (!ENTRY_NAME_RE.test(name)) {
+    throw new Error(`Invalid file/directory name from registry: ${JSON.stringify(name)}`);
+  }
+  const child = path.resolve(baseDir, name);
+  const rel = path.relative(baseDir, child);
+  if (rel.startsWith('..') || path.isAbsolute(rel) || rel === '') {
+    throw new Error(`Resolved entry escapes parent: ${child}`);
+  }
+  return child;
+}
+
+/** Specialized error so callers can branch on the HTTP status (e.g. 403 = rate limit,
+ *  404 = path moved). The message is human-readable; the `status` is for matching. */
+class FetchHttpError extends Error {
+  constructor(
+    public readonly url: string,
+    public readonly status: number,
+    public readonly statusText: string,
+  ) {
+    super(`Fetch ${url} failed: ${status} ${statusText}`);
+    this.name = 'FetchHttpError';
+  }
+}
+
+async function fetchJson(url: string, signal: AbortSignal, headers?: Record<string, string>) {
+  const resp = await fetch(url, { signal, headers });
+  if (!resp.ok) {
+    throw new FetchHttpError(url, resp.status, resp.statusText);
+  }
+  const text = await resp.text();
   try {
-    const raw = readFileSync(getCachePath(), 'utf-8');
-    return JSON.parse(raw) as SkillsCache;
-  } catch {
-    return null;
+    return JSON.parse(text) as unknown;
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`Fetch ${url} returned non-JSON body (status ${resp.status}): ${detail}`);
   }
 }
 
-function writeCache(cache: SkillsCache): void {
-  writeFileSync(getCachePath(), JSON.stringify(cache));
+interface RawSkill {
+  name?: string;
+  description?: string;
+  repo?: string;
+  path?: string;
+  branch?: string;
+  category?: string;
+  tags?: unknown;
+  stars?: number;
+  distribution?: string;
 }
 
-export class SkillsService {
-  static async fetchRegistry(forceRefresh = false): Promise<RegistrySkill[]> {
-    if (!forceRefresh) {
-      const cache = readCache();
-      if (cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS) {
-        return cache.skills;
-      }
+// A handful of registry entries ship malformed values (e.g. description as ["需要填写描述"]),
+// which would otherwise blow up SQLite bindings. Coerce defensively at the boundary.
+function asString(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (v == null) return '';
+  if (Array.isArray(v)) return v.filter((x) => typeof x === 'string').join(' ');
+  return '';
+}
+
+function normalizeSkill(s: RawSkill): RegistrySkill | null {
+  const name = asString(s.name);
+  const repo = asString(s.repo);
+  const skillPath = asString(s.path);
+  if (!name || !repo || !skillPath) return null;
+  const distribution: RegistrySkill['distribution'] =
+    s.distribution === 'compatible' || s.distribution === 'restricted' ? s.distribution : undefined;
+  return {
+    name,
+    description: asString(s.description),
+    repo,
+    path: skillPath,
+    branch: asString(s.branch) || 'main',
+    category: asString(s.category),
+    tags: Array.isArray(s.tags) ? (s.tags.filter((t) => typeof t === 'string') as string[]) : [],
+    stars: typeof s.stars === 'number' && Number.isFinite(s.stars) ? s.stars : 0,
+    distribution,
+  };
+}
+
+/**
+ * Downloads the registry, normalizes each skill, and replaces the SQLite cache atomically.
+ * We previously tried stream-json for low-memory parsing, but the pipeline silently yielded
+ * 0 rows in our setup (likely a Buffer/Uint8Array mismatch between Readable.fromWeb and
+ * fixUtf8Stream). Buffered parse is reliable and trades ~200 MB transient memory for that.
+ */
+async function downloadAndStoreRegistry(): Promise<{ inserted: number }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REGISTRY_FETCH_TIMEOUT_MS);
+
+  try {
+    const resp = await fetch(REGISTRY_URL, {
+      headers: { 'Accept-Encoding': 'gzip' },
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      throw new Error(`Registry fetch failed: ${resp.status} ${resp.statusText}`);
     }
 
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
+    const text = await resp.text();
+    let parsed: { skills?: unknown };
     try {
-      const resp = await fetch(REGISTRY_URL, {
-        headers: { 'Accept-Encoding': 'gzip' },
-        signal: controller.signal,
-      });
-
-      if (!resp.ok) {
-        throw new Error(`Registry fetch failed: ${resp.status}`);
-      }
-
-      const data = (await resp.json()) as {
-        skills: RegistrySkill[];
-      };
-
-      // Registry is sorted by stars descending; take top N
-      const skills = (data.skills || []).slice(0, MAX_SKILLS).map((s) => ({
-        name: s.name || '',
-        description: s.description || '',
-        repo: s.repo || '',
-        path: s.path || '',
-        branch: s.branch || 'main',
-        category: s.category || '',
-        tags: Array.isArray(s.tags) ? s.tags : [],
-        stars: s.stars || 0,
-        source: s.source || '',
-      }));
-
-      writeCache({ fetchedAt: Date.now(), skills });
-      return skills;
-    } finally {
-      clearTimeout(timeout);
+      parsed = JSON.parse(text) as { skills?: unknown };
+    } catch (err) {
+      throw new Error(`Registry returned non-JSON body (${text.length} bytes): ${String(err)}`);
     }
-  }
 
-  static async search(
-    query: string,
-    category?: string,
-    limit = 50,
-    offset = 0,
-  ): Promise<SkillsSearchResult> {
-    const all = await this.fetchRegistry();
-    const q = query.toLowerCase().trim();
+    // Registry is delivered sorted by stars descending, so a head-slice is "top N by stars".
+    const rawSkills = Array.isArray(parsed.skills)
+      ? (parsed.skills as RawSkill[]).slice(0, MAX_SKILLS)
+      : [];
+    const normalized: RegistrySkill[] = [];
+    let skipped = 0;
+    for (const raw of rawSkills) {
+      const n = normalizeSkill(raw);
+      if (n) normalized.push(n);
+      else skipped += 1;
+    }
 
-    let filtered = all;
+    // Warn loudly if a meaningful chunk failed normalization — likely a registry schema
+    // change rather than the usual 1-2 malformed entries. Below 5% is normal noise.
+    if (rawSkills.length > 0 && skipped / rawSkills.length > 0.05) {
+      console.warn('[SkillsService.downloadAndStoreRegistry] high skip rate', {
+        skipped,
+        total: rawSkills.length,
+        ratio: (skipped / rawSkills.length).toFixed(3),
+      });
+    }
 
-    if (q) {
-      filtered = filtered.filter(
-        (s) =>
-          s.name.toLowerCase().includes(q) ||
-          s.description.toLowerCase().includes(q) ||
-          s.tags.some((t) => t.toLowerCase().includes(q)) ||
-          s.repo.toLowerCase().includes(q),
+    if (normalized.length === 0) {
+      throw new Error(
+        `Registry parsed but yielded 0 valid skills (raw: ${rawSkills.length}, body: ${text.length} bytes)`,
       );
     }
 
-    if (category) {
-      filtered = filtered.filter((s) => s.category === category);
-    }
+    // Atomic replace: previous cache survives if this throws mid-transaction.
+    return SkillsCache.replaceAll(normalized);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
 
-    return {
-      skills: filtered.slice(offset, offset + limit),
-      total: filtered.length,
-    };
+export class SkillsService {
+  static getMeta(): SkillsRegistryMeta {
+    return SkillsCache.getMeta();
   }
 
-  static async getSkillContent(repo: string, skillPath: string, branch: string): Promise<string> {
-    // Determine the SKILL.md URL
-    const normalizedPath = skillPath.endsWith('SKILL.md')
-      ? skillPath
-      : skillPath.endsWith('/')
-        ? `${skillPath}SKILL.md`
-        : `${skillPath}/SKILL.md`;
+  static getCategories(): string[] {
+    return SkillsCache.getCategories();
+  }
 
-    const url = `https://raw.githubusercontent.com/${repo}/${branch}/${normalizedPath}`;
-
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 15_000);
+  /**
+   * If the cache is missing or older than CACHE_TTL_MS, refresh it from the registry.
+   * forceRefresh bypasses the TTL. Returns the post-refresh meta. When a refresh attempt
+   * fails but we have a non-empty cache, returns that cache with `stale: true` and a
+   * human-readable `refreshError` so the UI can show the user why fresh data isn't here.
+   */
+  static async ensureRegistry(forceRefresh = false): Promise<SkillsRegistryMeta> {
+    const meta = SkillsCache.getMeta();
+    const fresh =
+      meta.fetchedAt !== null && meta.totalCount > 0 && Date.now() - meta.fetchedAt < CACHE_TTL_MS;
+    if (fresh && !forceRefresh) return meta;
 
     try {
-      const resp = await fetch(url, { signal: controller.signal });
-      if (!resp.ok) {
-        throw new Error(`Failed to fetch SKILL.md: ${resp.status}`);
+      await downloadAndStoreRegistry();
+    } catch (err) {
+      // Stale-cache fallback: a slow/broken registry shouldn't break the UI if we have
+      // anything cached, but we MUST signal this to the renderer so the user knows their
+      // results are old. Silently returning stale data caused users to sit on weeks-old
+      // caches without realising refresh had been broken.
+      if (meta.totalCount > 0) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error('[SkillsService.ensureRegistry] using stale cache after fetch failure', {
+          message,
+        });
+        return { ...meta, stale: true, refreshError: message };
       }
-      return await resp.text();
-    } finally {
-      clearTimeout(timeout);
+      throw err;
     }
+    return SkillsCache.getMeta();
   }
 
-  static async installSkill(args: {
-    repo: string;
-    path: string;
-    branch: string;
-    skillName: string;
-    target: 'global' | 'project';
-    projectPath?: string;
-  }): Promise<void> {
-    const { repo, path: skillPath, branch, skillName, target, projectPath } = args;
+  static search(args: SkillsSearchArgs): SkillsSearchResult {
+    const result = SkillsCache.search({
+      query: args.query ?? '',
+      category: args.category,
+      limit: args.limit ?? 50,
+      offset: args.offset ?? 0,
+    });
+    return result;
+  }
 
-    // Determine install directory
-    let installDir: string;
-    if (target === 'project' && projectPath) {
-      installDir = path.join(projectPath, '.claude', 'skills', skillName);
-    } else {
-      const home = process.env.HOME || process.env.USERPROFILE || '';
-      installDir = path.join(home, '.claude', 'skills', skillName);
+  static async getSkillContent(ref: SkillRef): Promise<string> {
+    assertRef(ref);
+
+    const normalizedPath = ref.path.endsWith('SKILL.md')
+      ? ref.path
+      : ref.path.endsWith('/')
+        ? `${ref.path}SKILL.md`
+        : `${ref.path}/SKILL.md`;
+
+    const url = `${RAW_GITHUB_PREFIX}${ref.repo}/${ref.branch}/${normalizedPath}`;
+    return fetchTextWithLimit(url, FILE_FETCH_TIMEOUT_MS);
+  }
+
+  /** Reads SKILL.md for a skill installed locally — used when the catalog has no entry
+   *  (custom/long-tail skills) and we therefore can't pull from raw.githubusercontent.com.
+   *  installLocation must be either the special string 'global' (resolved to ~/.claude/skills)
+   *  or an absolute path that the renderer already validated as a known project/worktree path. */
+  static readLocalSkillMd(args: { skillName: string; installLocation: string }): string {
+    assertSkillName(args.skillName);
+    const baseDir =
+      args.installLocation === 'global'
+        ? path.join(os.homedir(), '.claude', 'skills')
+        : path.join(args.installLocation, '.claude', 'skills');
+    // Defense in depth: same escape check we use on writes.
+    const skillDir = path.resolve(baseDir, args.skillName);
+    const rel = path.relative(baseDir, skillDir);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      throw new Error(`Resolved skill dir escapes base: ${skillDir}`);
     }
+    const file = path.join(skillDir, 'SKILL.md');
+    const stat = statSync(file); // throws ENOENT cleanly if missing
+    if (stat.size > MAX_FILE_BYTES) {
+      throw new Error(`SKILL.md exceeds max size (${stat.size} bytes)`);
+    }
+    return readFileSync(file, 'utf-8');
+  }
 
-    mkdirSync(installDir, { recursive: true });
+  static async installSkill(args: SkillInstallArgs): Promise<void> {
+    const { ref, skillName, target } = args;
+    assertRef(ref);
+    const installDir = resolveInstallDir(target, skillName);
 
-    // Fetch the SKILL.md content
-    const content = await this.getSkillContent(repo, skillPath, branch);
-    writeFileSync(path.join(installDir, 'SKILL.md'), content, 'utf-8');
+    // Stage into a sibling temp dir so a mid-install failure (rate limit, network drop,
+    // file-count cap, etc.) can't leave a half-populated skill that checkInstalled would
+    // still report as "installed" because SKILL.md happens to exist.
+    const stagingDir = `${installDir}.tmp-${process.pid}-${Date.now()}`;
+    mkdirSync(stagingDir, { recursive: true });
 
-    // Try to fetch additional files in the skill directory
-    await this.fetchSkillDirectory(repo, skillPath, branch, installDir);
+    try {
+      const content = await this.getSkillContent(ref);
+      writeFileSync(path.join(stagingDir, 'SKILL.md'), content, 'utf-8');
+
+      const counter = { count: 1 };
+      await this.fetchSkillDirectory(ref, stagingDir, MAX_RECURSION_DEPTH, counter);
+
+      // Atomic-ish swap: remove any pre-existing install, then rename. rename within the
+      // same directory is atomic on POSIX; the prior rmSync is the small race window.
+      rmSync(installDir, { recursive: true, force: true });
+      renameSync(stagingDir, installDir);
+    } catch (err) {
+      // Best-effort cleanup of the partial staging tree; never mask the original failure.
+      try {
+        rmSync(stagingDir, { recursive: true, force: true });
+      } catch (cleanupErr) {
+        console.error('[SkillsService.installSkill] staging cleanup failed', {
+          stagingDir,
+          message: String(cleanupErr),
+        });
+      }
+      throw err;
+    }
   }
 
   private static async fetchSkillDirectory(
-    repo: string,
-    skillPath: string,
-    branch: string,
+    ref: SkillRef,
     installDir: string,
+    depthRemaining: number,
+    counter: { count: number },
   ): Promise<void> {
-    // Normalize: remove trailing SKILL.md if present
-    const dirPath = skillPath.endsWith('SKILL.md')
-      ? skillPath.replace(/\/?SKILL\.md$/, '')
-      : skillPath;
+    if (depthRemaining < 0) {
+      // We hit MAX_RECURSION_DEPTH. Skill installs as "successful" but anything deeper
+      // is missing; log so a real bug (registry shipping deep trees we should support)
+      // doesn't masquerade as a clean install.
+      console.warn('[SkillsService.fetchSkillDirectory] depth limit reached; truncating', {
+        repo: ref.repo,
+        path: ref.path,
+      });
+      return;
+    }
+
+    const dirPath = ref.path.endsWith('SKILL.md')
+      ? ref.path.replace(/\/?SKILL\.md$/, '')
+      : ref.path;
 
     if (!dirPath) return;
 
-    const apiUrl = `https://api.github.com/repos/${repo}/contents/${dirPath}?ref=${branch}`;
+    const apiUrl = `https://api.github.com/repos/${ref.repo}/contents/${dirPath}?ref=${ref.branch}`;
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 15_000);
+    const timeout = setTimeout(() => controller.abort(), FILE_FETCH_TIMEOUT_MS);
 
+    let parsed: unknown;
     try {
-      const resp = await fetch(apiUrl, {
-        headers: { Accept: 'application/vnd.github.v3+json' },
-        signal: controller.signal,
+      parsed = await fetchJson(apiUrl, controller.signal, {
+        Accept: 'application/vnd.github.v3+json',
       });
-
-      if (!resp.ok) return; // Non-critical: we already have SKILL.md
-
-      const entries = (await resp.json()) as Array<{
-        name: string;
-        type: string;
-        download_url: string | null;
-        path: string;
-      }>;
-
-      for (const entry of entries) {
-        if (entry.name === 'SKILL.md') continue; // Already saved
-        if (entry.type === 'file' && entry.download_url) {
-          const fileResp = await fetch(entry.download_url);
-          if (fileResp.ok) {
-            const fileContent = await fileResp.text();
-            writeFileSync(path.join(installDir, entry.name), fileContent, 'utf-8');
-          }
-        } else if (entry.type === 'dir') {
-          // Fetch subdirectory contents
-          const subDir = path.join(installDir, entry.name);
-          mkdirSync(subDir, { recursive: true });
-          await this.fetchSkillDirectory(repo, entry.path, branch, subDir);
-        }
+    } catch (err) {
+      // Distinguish 404 (skill moved/renamed upstream — actionable: refresh registry) from
+      // generic failures (5xx, network) so the friendly-error mapping in the renderer can
+      // produce a useful message.
+      if (err instanceof FetchHttpError && err.status === 404) {
+        throw new Error(
+          `Skill source not found at ${ref.repo}/${dirPath} — the upstream may have moved. Refresh the registry and try again.`,
+        );
       }
-    } catch {
-      // Non-critical: we already have the SKILL.md
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to list skill directory ${ref.repo}/${dirPath}: ${detail}`);
     } finally {
       clearTimeout(timeout);
     }
-  }
 
-  static getCategories(skills: RegistrySkill[]): string[] {
-    const cats = new Set<string>();
-    for (const s of skills) {
-      if (s.category) cats.add(s.category);
+    if (!Array.isArray(parsed)) return;
+
+    const entries = parsed as Array<{
+      name: string;
+      type: string;
+      download_url: string | null;
+      size?: number;
+    }>;
+
+    // entry.name and entry.download_url come from GitHub's API response — treat as
+    // untrusted. resolveChildPath validates the name against ENTRY_NAME_RE and ensures
+    // the resolved path stays inside installDir; the download URL is checked against
+    // the raw.githubusercontent.com whitelist. Never feed entry.path into recursion or
+    // FS writes — rebuild paths from sanitized child names instead.
+    for (const entry of entries) {
+      if (counter.count >= MAX_FILES_PER_SKILL) {
+        throw new Error(`Skill exceeds max files (${MAX_FILES_PER_SKILL})`);
+      }
+      if (entry.name === 'SKILL.md') continue;
+
+      if (entry.type === 'file' && entry.download_url) {
+        if (!entry.download_url.startsWith(RAW_GITHUB_PREFIX)) {
+          throw new Error(`Refusing non-GitHub download URL: ${entry.download_url}`);
+        }
+        if (typeof entry.size === 'number' && entry.size > MAX_FILE_BYTES) {
+          throw new Error(`File ${entry.name} exceeds max size (${entry.size} bytes)`);
+        }
+        const dest = resolveChildPath(installDir, entry.name);
+        const body = await fetchTextWithLimit(entry.download_url, FILE_FETCH_TIMEOUT_MS);
+        writeFileSync(dest, body, 'utf-8');
+        counter.count += 1;
+      } else if (entry.type === 'dir') {
+        const subDir = resolveChildPath(installDir, entry.name);
+        mkdirSync(subDir, { recursive: true });
+        const childRef: SkillRef = {
+          repo: ref.repo,
+          branch: ref.branch,
+          path: dirPath ? `${dirPath}/${entry.name}` : entry.name,
+        };
+        await this.fetchSkillDirectory(childRef, subDir, depthRemaining - 1, counter);
+      }
     }
-    return Array.from(cats).sort();
   }
 
-  static checkInstalled(skillName: string, projectPaths: string[]): SkillInstallStatus {
-    const home = process.env.HOME || process.env.USERPROFILE || '';
-    const globalPath = path.join(home, '.claude', 'skills', skillName, 'SKILL.md');
-    const global = existsSync(globalPath);
+  static checkInstalled(skillName: string, probePaths: string[]): SkillInstallStatus {
+    assertSkillName(skillName);
+    const home = os.homedir();
+    const probeErrors: string[] = [];
 
-    const projectIds: string[] = [];
-    for (const pp of projectPaths) {
-      const projectSkillPath = path.join(pp, '.claude', 'skills', skillName, 'SKILL.md');
-      if (existsSync(projectSkillPath)) {
-        projectIds.push(pp);
+    const globalProbe = skillFilePresence(
+      path.join(home, '.claude', 'skills', skillName, 'SKILL.md'),
+    );
+    if (globalProbe.error) probeErrors.push(`global (${globalProbe.error})`);
+
+    const installedPaths: string[] = [];
+    for (const pp of probePaths) {
+      const probe = skillFilePresence(path.join(pp, '.claude', 'skills', skillName, 'SKILL.md'));
+      if (probe.error) probeErrors.push(`${pp} (${probe.error})`);
+      if (probe.present) installedPaths.push(pp);
+    }
+
+    const status: SkillInstallStatus = { global: globalProbe.present, installedPaths };
+    if (probeErrors.length > 0) {
+      status.probeError = `Could not check install status for ${probeErrors.join(', ')}`;
+    }
+    return status;
+  }
+
+  /** Lists every skill installed on disk across global + the supplied probePaths.
+   *  Joins each found folder name back to the registry cache when possible so the UI
+   *  can render full cards; skills installed but not in the cached top-N come back
+   *  with `catalog: null`. */
+  static listInstalled(probePaths: string[]): InstalledSkill[] {
+    const home = os.homedir();
+    type Entry = { installedPaths: string[]; globalInstalled: boolean };
+    const found = new Map<string, Entry>();
+
+    function record(skillName: string, scope: 'global' | string): void {
+      // Defensive: a folder name that wouldn't pass our install validator is suspicious
+      // (manually placed file? old install from a different tool?). Skip it rather than
+      // surface garbage in the UI.
+      if (!SKILL_NAME_RE.test(skillName)) return;
+      const entry = found.get(skillName) ?? { installedPaths: [], globalInstalled: false };
+      if (scope === 'global') entry.globalInstalled = true;
+      else entry.installedPaths.push(scope);
+      found.set(skillName, entry);
+    }
+
+    for (const name of listSkillFolders(path.join(home, '.claude', 'skills'))) {
+      record(name, 'global');
+    }
+    for (const pp of probePaths) {
+      for (const name of listSkillFolders(path.join(pp, '.claude', 'skills'))) {
+        record(name, pp);
       }
     }
 
-    return { global, projectPaths: projectIds };
+    // Build a lookup from sanitized install-name → catalog row so we can attach
+    // metadata to each installed entry. One pass over the cache keeps this O(N) in the
+    // catalog size; per-name SQL would be cheaper but the sanitization rules are awkward
+    // to express in SQL. First wins on collisions.
+    const catalogByInstallName = new Map<string, RegistrySkill>();
+    for (const s of SkillsCache.allSkills()) {
+      const installName = deriveInstallNameFromCatalog(s);
+      if (installName && !catalogByInstallName.has(installName)) {
+        catalogByInstallName.set(installName, s);
+      }
+    }
+
+    const result: InstalledSkill[] = [];
+    for (const [skillName, info] of found) {
+      result.push({
+        skillName,
+        globalInstalled: info.globalInstalled,
+        installedPaths: info.installedPaths,
+        catalog: catalogByInstallName.get(skillName) ?? null,
+      });
+    }
+    result.sort((a, b) => a.skillName.localeCompare(b.skillName));
+    return result;
   }
 
-  static uninstallSkill(args: {
-    skillName: string;
-    target: 'global' | 'project';
-    projectPath?: string;
-  }): void {
-    const { skillName, target, projectPath } = args;
+  static uninstallSkill(args: SkillUninstallArgs): void {
+    const { skillName, target } = args;
+    const skillDir = resolveInstallDir(target, skillName);
 
-    let skillDir: string;
-    if (target === 'project' && projectPath) {
-      skillDir = path.join(projectPath, '.claude', 'skills', skillName);
-    } else {
-      const home = process.env.HOME || process.env.USERPROFILE || '';
-      skillDir = path.join(home, '.claude', 'skills', skillName);
+    try {
+      const stat = statSync(skillDir);
+      if (!stat.isDirectory()) {
+        throw new Error(`Refusing to remove non-directory: ${skillDir}`);
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw err;
     }
+    rmSync(skillDir, { recursive: true, force: true });
+  }
+}
 
-    if (existsSync(skillDir)) {
-      rmSync(skillDir, { recursive: true, force: true });
+/** Lists subdirectories of a `.claude/skills/` directory that contain a SKILL.md file.
+ *  Returns [] if the directory doesn't exist; logs other errors and returns []. */
+function listSkillFolders(skillsDir: string): string[] {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(skillsDir, { withFileTypes: true }) as Dirent[];
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return [];
+    console.error('[SkillsService.listSkillFolders] readdir failed', { skillsDir, code });
+    return [];
+  }
+  const names: string[] = [];
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    if (e.name.startsWith('.')) continue;
+    if (e.name.includes('.tmp-')) continue; // skip in-flight staging dirs
+    if (skillFilePresence(path.join(skillsDir, e.name, 'SKILL.md')).present) {
+      names.push(e.name);
     }
+  }
+  return names;
+}
+
+/** Mirrors the renderer's `deriveInstallSkillName` so we can map a catalog row back
+ *  to the folder name `installSkill` would use for it. Keep these in sync. */
+function deriveInstallNameFromCatalog(skill: RegistrySkill): string {
+  const candidates = [skill.name, lastPathSegment(skill.path)];
+  for (const c of candidates) {
+    if (!c) continue;
+    const sanitized = c
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    if (sanitized && sanitized !== 'unknown' && /^[a-z0-9]/.test(sanitized)) return sanitized;
+  }
+  return '';
+}
+
+function lastPathSegment(p: string): string {
+  const segs = p.split('/').filter(Boolean);
+  const last = segs[segs.length - 1] ?? '';
+  if (last.toLowerCase() === 'skill.md') return segs[segs.length - 2] ?? '';
+  return last;
+}
+
+/** Probes whether a SKILL.md exists. Distinguishes "not present" from "couldn't read"
+ *  so the caller can warn the user when ENOENT is masked by EACCES/EIO etc. */
+function skillFilePresence(filePath: string): { present: boolean; error?: string } {
+  try {
+    statSync(filePath);
+    return { present: true };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return { present: false };
+    console.error('[SkillsService.checkInstalled] stat failed', { filePath, code });
+    return { present: false, error: code || 'unknown error' };
+  }
+}
+
+async function fetchTextWithLimit(url: string, timeoutMs: number): Promise<string> {
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+  try {
+    const resp = await fetch(url, { signal: controller.signal });
+    if (!resp.ok) {
+      throw new Error(`Fetch ${url} failed: ${resp.status} ${resp.statusText}`);
+    }
+    const lenHeader = resp.headers.get('content-length');
+    if (lenHeader) {
+      const len = Number(lenHeader);
+      if (Number.isFinite(len) && len > MAX_FILE_BYTES) {
+        throw new Error(`File at ${url} exceeds max size (${len} bytes)`);
+      }
+    }
+    const text = await resp.text();
+    if (text.length > MAX_FILE_BYTES) {
+      throw new Error(`File at ${url} exceeds max size after read (${text.length} bytes)`);
+    }
+    return text;
+  } catch (err) {
+    // Bare AbortError ("This operation was aborted") tells you nothing about which file
+    // or how long it waited. Repackage with context so logs are diagnosable.
+    if (timedOut) {
+      throw new Error(`Timeout after ${timeoutMs}ms fetching ${url}`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/src/main/services/SkillsService.ts
+++ b/src/main/services/SkillsService.ts
@@ -1,0 +1,261 @@
+import { app } from 'electron';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'fs';
+import path from 'path';
+import type { RegistrySkill, SkillsSearchResult, SkillInstallStatus } from '@shared/types';
+
+const REGISTRY_URL =
+  'https://raw.githubusercontent.com/majiayu000/claude-skill-registry/main/registry.json';
+const MAX_SKILLS = 500;
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const FETCH_TIMEOUT_MS = 60_000; // 60s for the large registry download
+
+interface SkillsCache {
+  fetchedAt: number;
+  skills: RegistrySkill[];
+}
+
+function getCachePath(): string {
+  return path.join(app.getPath('userData'), 'skills-cache.json');
+}
+
+function readCache(): SkillsCache | null {
+  try {
+    const raw = readFileSync(getCachePath(), 'utf-8');
+    return JSON.parse(raw) as SkillsCache;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(cache: SkillsCache): void {
+  writeFileSync(getCachePath(), JSON.stringify(cache));
+}
+
+export class SkillsService {
+  static async fetchRegistry(forceRefresh = false): Promise<RegistrySkill[]> {
+    if (!forceRefresh) {
+      const cache = readCache();
+      if (cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS) {
+        return cache.skills;
+      }
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    try {
+      const resp = await fetch(REGISTRY_URL, {
+        headers: { 'Accept-Encoding': 'gzip' },
+        signal: controller.signal,
+      });
+
+      if (!resp.ok) {
+        throw new Error(`Registry fetch failed: ${resp.status}`);
+      }
+
+      const data = (await resp.json()) as {
+        skills: RegistrySkill[];
+      };
+
+      // Registry is sorted by stars descending; take top N
+      const skills = (data.skills || []).slice(0, MAX_SKILLS).map((s) => ({
+        name: s.name || '',
+        description: s.description || '',
+        repo: s.repo || '',
+        path: s.path || '',
+        branch: s.branch || 'main',
+        category: s.category || '',
+        tags: Array.isArray(s.tags) ? s.tags : [],
+        stars: s.stars || 0,
+        source: s.source || '',
+      }));
+
+      writeCache({ fetchedAt: Date.now(), skills });
+      return skills;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  static async search(
+    query: string,
+    category?: string,
+    limit = 50,
+    offset = 0,
+  ): Promise<SkillsSearchResult> {
+    const all = await this.fetchRegistry();
+    const q = query.toLowerCase().trim();
+
+    let filtered = all;
+
+    if (q) {
+      filtered = filtered.filter(
+        (s) =>
+          s.name.toLowerCase().includes(q) ||
+          s.description.toLowerCase().includes(q) ||
+          s.tags.some((t) => t.toLowerCase().includes(q)) ||
+          s.repo.toLowerCase().includes(q),
+      );
+    }
+
+    if (category) {
+      filtered = filtered.filter((s) => s.category === category);
+    }
+
+    return {
+      skills: filtered.slice(offset, offset + limit),
+      total: filtered.length,
+    };
+  }
+
+  static async getSkillContent(repo: string, skillPath: string, branch: string): Promise<string> {
+    // Determine the SKILL.md URL
+    const normalizedPath = skillPath.endsWith('SKILL.md')
+      ? skillPath
+      : skillPath.endsWith('/')
+        ? `${skillPath}SKILL.md`
+        : `${skillPath}/SKILL.md`;
+
+    const url = `https://raw.githubusercontent.com/${repo}/${branch}/${normalizedPath}`;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15_000);
+
+    try {
+      const resp = await fetch(url, { signal: controller.signal });
+      if (!resp.ok) {
+        throw new Error(`Failed to fetch SKILL.md: ${resp.status}`);
+      }
+      return await resp.text();
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  static async installSkill(args: {
+    repo: string;
+    path: string;
+    branch: string;
+    skillName: string;
+    target: 'global' | 'project';
+    projectPath?: string;
+  }): Promise<void> {
+    const { repo, path: skillPath, branch, skillName, target, projectPath } = args;
+
+    // Determine install directory
+    let installDir: string;
+    if (target === 'project' && projectPath) {
+      installDir = path.join(projectPath, '.claude', 'skills', skillName);
+    } else {
+      const home = process.env.HOME || process.env.USERPROFILE || '';
+      installDir = path.join(home, '.claude', 'skills', skillName);
+    }
+
+    mkdirSync(installDir, { recursive: true });
+
+    // Fetch the SKILL.md content
+    const content = await this.getSkillContent(repo, skillPath, branch);
+    writeFileSync(path.join(installDir, 'SKILL.md'), content, 'utf-8');
+
+    // Try to fetch additional files in the skill directory
+    await this.fetchSkillDirectory(repo, skillPath, branch, installDir);
+  }
+
+  private static async fetchSkillDirectory(
+    repo: string,
+    skillPath: string,
+    branch: string,
+    installDir: string,
+  ): Promise<void> {
+    // Normalize: remove trailing SKILL.md if present
+    const dirPath = skillPath.endsWith('SKILL.md')
+      ? skillPath.replace(/\/?SKILL\.md$/, '')
+      : skillPath;
+
+    if (!dirPath) return;
+
+    const apiUrl = `https://api.github.com/repos/${repo}/contents/${dirPath}?ref=${branch}`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15_000);
+
+    try {
+      const resp = await fetch(apiUrl, {
+        headers: { Accept: 'application/vnd.github.v3+json' },
+        signal: controller.signal,
+      });
+
+      if (!resp.ok) return; // Non-critical: we already have SKILL.md
+
+      const entries = (await resp.json()) as Array<{
+        name: string;
+        type: string;
+        download_url: string | null;
+        path: string;
+      }>;
+
+      for (const entry of entries) {
+        if (entry.name === 'SKILL.md') continue; // Already saved
+        if (entry.type === 'file' && entry.download_url) {
+          const fileResp = await fetch(entry.download_url);
+          if (fileResp.ok) {
+            const fileContent = await fileResp.text();
+            writeFileSync(path.join(installDir, entry.name), fileContent, 'utf-8');
+          }
+        } else if (entry.type === 'dir') {
+          // Fetch subdirectory contents
+          const subDir = path.join(installDir, entry.name);
+          mkdirSync(subDir, { recursive: true });
+          await this.fetchSkillDirectory(repo, entry.path, branch, subDir);
+        }
+      }
+    } catch {
+      // Non-critical: we already have the SKILL.md
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  static getCategories(skills: RegistrySkill[]): string[] {
+    const cats = new Set<string>();
+    for (const s of skills) {
+      if (s.category) cats.add(s.category);
+    }
+    return Array.from(cats).sort();
+  }
+
+  static checkInstalled(skillName: string, projectPaths: string[]): SkillInstallStatus {
+    const home = process.env.HOME || process.env.USERPROFILE || '';
+    const globalPath = path.join(home, '.claude', 'skills', skillName, 'SKILL.md');
+    const global = existsSync(globalPath);
+
+    const projectIds: string[] = [];
+    for (const pp of projectPaths) {
+      const projectSkillPath = path.join(pp, '.claude', 'skills', skillName, 'SKILL.md');
+      if (existsSync(projectSkillPath)) {
+        projectIds.push(pp);
+      }
+    }
+
+    return { global, projectPaths: projectIds };
+  }
+
+  static uninstallSkill(args: {
+    skillName: string;
+    target: 'global' | 'project';
+    projectPath?: string;
+  }): void {
+    const { skillName, target, projectPath } = args;
+
+    let skillDir: string;
+    if (target === 'project' && projectPath) {
+      skillDir = path.join(projectPath, '.claude', 'skills', skillName);
+    } else {
+      const home = process.env.HOME || process.env.USERPROFILE || '';
+      skillDir = path.join(home, '.claude', 'skills', skillName);
+    }
+
+    if (existsSync(skillDir)) {
+      rmSync(skillDir, { recursive: true, force: true });
+    }
+  }
+}

--- a/src/main/services/SkillsService.ts
+++ b/src/main/services/SkillsService.ts
@@ -612,9 +612,10 @@ export class SkillsService {
     return status;
   }
 
-  static async listInstalled(probePaths: string[]): Promise<InstalledSkillsResult> {
+  static listInstalled(probePaths: string[]): InstalledSkillsResult {
     const home = os.homedir();
-    const found = new Map<string, InstalledEntry>();
+    type Entry = { installedPaths: string[]; globalInstalled: boolean };
+    const found = new Map<string, Entry>();
     const probeFailures: ProbeFailure[] = [];
 
     function record(skillName: string, scope: 'global' | string): void {
@@ -638,20 +639,17 @@ export class SkillsService {
       if (probe.error) probeFailures.push({ scope: pp, code: probe.error });
     }
 
-    // Backfill markers on legacy installs (from before the marker contract existed).
-    // Runs before the catalog join so freshly-written markers are picked up below.
-    await backfillOrphanMarkers(found, home);
-
     // Catalog join is keyed by (repo, path) read from each install's marker file.
     // The previous sanitized-folder-name fuzzy match conflated unrelated skills that
     // happened to share a name (e.g. user's custom "validate" → registry "validate").
-    // Folders without a marker fall through with catalog: null and render as Custom.
+    // Folders without a marker — pre-existing custom skills, or older Dash installs
+    // from before markers existed — fall through with catalog: null and render as Custom.
     const catalogByRepoPath = new Map<string, RegistrySkill>();
     for (const s of SkillsCache.allSkills()) {
       catalogByRepoPath.set(`${s.repo}|${s.path}`, s);
     }
 
-    function lookupCatalog(skillName: string, info: InstalledEntry): RegistrySkill | null {
+    function lookupCatalog(skillName: string, info: Entry): RegistrySkill | null {
       const candidates: string[] = [];
       if (info.globalInstalled) {
         candidates.push(path.join(home, '.claude', 'skills', skillName));
@@ -728,109 +726,6 @@ function listSkillFolders(skillsDir: string): { names: string[]; error?: string 
     }
   }
   return { names };
-}
-
-interface InstalledEntry {
-  installedPaths: string[];
-  globalInstalled: boolean;
-}
-
-// Mirrors the renderer's `deriveInstallSkillName` so we can map a catalog row back to
-// the folder name `installSkill` would use for it. Used now only by the legacy backfill
-// to find candidate registry matches for marker-less install dirs — keep these in sync.
-function deriveInstallNameFromCatalog(skill: RegistrySkill): string {
-  const candidates = [skill.name, lastPathSegment(skill.path)];
-  for (const c of candidates) {
-    if (!c) continue;
-    const sanitized = c
-      .toLowerCase()
-      .replace(/[^a-z0-9-]/g, '-')
-      .replace(/-+/g, '-')
-      .replace(/^-+|-+$/g, '');
-    if (sanitized && sanitized !== 'unknown' && /^[a-z0-9]/.test(sanitized)) return sanitized;
-  }
-  return '';
-}
-
-function lastPathSegment(p: string): string {
-  const segs = p.split('/').filter(Boolean);
-  const last = segs[segs.length - 1] ?? '';
-  if (last.toLowerCase() === 'skill.md') return segs[segs.length - 2] ?? '';
-  return last;
-}
-
-// In-memory memo of (dir, repo|path) pairs we've already attempted to verify. A skill
-// folder whose SKILL.md doesn't match the registry candidate is likely truly custom;
-// retrying the fetch every time the user opens the modal is wasteful. Cleared on app
-// restart, which is cheap because the work is bounded by orphan-folder count.
-const backfillTried = new Set<string>();
-
-// Best-effort migration for installs from before the marker contract existed (PR
-// 0.9.13 and earlier). For each marker-less folder, look up the unique registry skill
-// whose sanitized install-name matches the folder name; fetch its SKILL.md; if local
-// content is byte-equal, write the marker. On ambiguity (multiple candidates) or any
-// difference, the folder stays Custom — we don't guess. Skips already-marked dirs.
-async function backfillOrphanMarkers(
-  found: Map<string, InstalledEntry>,
-  home: string,
-): Promise<void> {
-  const candidatesByName = new Map<string, RegistrySkill[]>();
-  for (const s of SkillsCache.allSkills()) {
-    const name = deriveInstallNameFromCatalog(s);
-    if (!name) continue;
-    const arr = candidatesByName.get(name) ?? [];
-    arr.push(s);
-    candidatesByName.set(name, arr);
-  }
-
-  await Promise.all(
-    Array.from(found.entries()).map(async ([skillName, info]) => {
-      const candidates = candidatesByName.get(skillName) ?? [];
-      if (candidates.length !== 1) return; // Ambiguous or no candidate → leave as Custom.
-      const ref = candidates[0];
-      const refKey = `${ref.repo}|${ref.path}`;
-
-      const dirs: string[] = [];
-      if (info.globalInstalled) dirs.push(path.join(home, '.claude', 'skills', skillName));
-      for (const pp of info.installedPaths) {
-        dirs.push(path.join(pp, '.claude', 'skills', skillName));
-      }
-
-      const orphans = dirs.filter((d) => {
-        if (backfillTried.has(`${d}|${refKey}`)) return false;
-        return readSkillMarker(d) === null;
-      });
-      if (orphans.length === 0) return;
-
-      orphans.forEach((d) => backfillTried.add(`${d}|${refKey}`));
-
-      let registryContent: string;
-      try {
-        registryContent = await SkillsService.getSkillContent(ref);
-      } catch (err) {
-        console.warn('[SkillsService.backfill] could not fetch registry SKILL.md', {
-          repo: ref.repo,
-          path: ref.path,
-          message: err instanceof Error ? err.message : String(err),
-        });
-        return;
-      }
-
-      for (const dir of orphans) {
-        try {
-          const localContent = readFileSync(path.join(dir, 'SKILL.md'), 'utf-8');
-          if (localContent === registryContent) {
-            writeSkillMarker(dir, ref);
-          }
-        } catch (err) {
-          console.warn('[SkillsService.backfill] could not read local SKILL.md', {
-            dir,
-            message: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
-    }),
-  );
 }
 
 // "Is this skill dir an install of `expectedRef`?" — when expectedRef is null, falls

--- a/src/main/services/SkillsService.ts
+++ b/src/main/services/SkillsService.ts
@@ -21,20 +21,58 @@ import type {
   SkillInstallTarget,
   SkillsRegistryMeta,
   InstalledSkill,
+  InstalledSkillsResult,
+  ProbeFailure,
 } from '@shared/types';
 import { SkillsCache } from './skillsCache';
 
+// Trust boundary: this third-party GitHub repo is effectively Dash's package registry.
+// Pinning to a specific repo+branch+filename is a deliberate choice; changing this
+// constant changes who can ship code to every Dash user.
 const REGISTRY_URL =
   'https://raw.githubusercontent.com/majiayu000/claude-skill-registry/main/registry.json';
+
+// 24h matches the registry's typical update cadence (daily refresh of GitHub stars).
+// Shorter would just hammer raw.githubusercontent.com without surfacing newer data;
+// longer would let users sit on stale popularity rankings.
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-// The registry's long tail is dominated by abandoned/duplicate entries; top-N-by-stars
-// keeps the on-disk cache compact while covering any skill users are realistically after.
+
+// The registry's long tail is dominated by abandoned/duplicate entries. 10K covers
+// every skill with non-trivial star counts at current registry sizes (~150K total),
+// keeps the SQLite file under ~30 MB, and bounds the buffered JSON parse memory.
 const MAX_SKILLS = 10_000;
+
+// 60s is generous for a ~10 MB JSON payload over a slow connection. Short enough that
+// a hung server fails the open-lifecycle within the user's patience window.
 const REGISTRY_FETCH_TIMEOUT_MS = 60_000;
+
+// Per-file timeout for SKILL.md and sibling assets. 15s covers slow connections
+// without making a stuck connection block the install for minutes.
 const FILE_FETCH_TIMEOUT_MS = 15_000;
+
+// Wall-clock cap on a single install. Without this, a pathological skill (50 files,
+// each hanging until FILE_FETCH_TIMEOUT_MS) keeps the user staring at a spinner for
+// >12 min. In-flight fetches still drain on their own timers; this only fails the
+// user-facing op.
+const INSTALL_TIMEOUT_MS = 120_000;
+
+// SKILL.md files in the registry are <100 KB in practice; 2 MB allows for the rare
+// long-form skill while bounding the worst-case download per file. Also caps the
+// readFileSync we do on local installs.
 const MAX_FILE_BYTES = 2 * 1024 * 1024;
+
+// Largest legitimate skill in the registry has ~10 files. 50 is a defensive cap
+// against a malicious registry entry pointing at a bloated directory; combined with
+// MAX_FILE_BYTES it bounds total install download to ~100 MB.
 const MAX_FILES_PER_SKILL = 50;
+
+// Skills are flat or one level deep in observed registry data; 3 is permissive but
+// still rejects pathological recursive trees.
 const MAX_RECURSION_DEPTH = 3;
+
+// Pinned host for content downloads. Anything outside this prefix is refused even if
+// the GitHub contents API points us there — defense in depth against a compromised
+// registry that supplies attacker-hosted download_url values.
 const RAW_GITHUB_PREFIX = 'https://raw.githubusercontent.com/';
 
 const SKILL_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
@@ -42,7 +80,7 @@ const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
 const BRANCH_RE = /^[\w./-]+$/;
 const ENTRY_NAME_RE = /^[\w.][\w.-]*$/;
 
-function assertSkillName(name: string): void {
+export function assertSkillName(name: string): void {
   if (!SKILL_NAME_RE.test(name)) {
     throw new Error(`Invalid skill name: ${JSON.stringify(name)}`);
   }
@@ -52,7 +90,7 @@ function assertSkillName(name: string): void {
 // could break the URL we'll build (`?`, `#`, whitespace) or escape the directory.
 const PATH_SEGMENT_RE = /^[\w.][\w.-]*$/;
 
-function assertRef(ref: SkillRef): void {
+export function assertRef(ref: SkillRef): void {
   if (!REPO_RE.test(ref.repo)) {
     throw new Error(`Invalid repo: ${JSON.stringify(ref.repo)}`);
   }
@@ -76,15 +114,13 @@ function resolveSkillsBaseDir(target: SkillInstallTarget): string {
     case 'task':
       return path.join(target.worktreePath, '.claude', 'skills');
     default: {
-      // Forces a compile error if a future SkillInstallTarget variant is added without
-      // updating this switch — we'd rather break the build than silently default to global.
       const _exhaustive: never = target;
       throw new Error(`Unhandled install target: ${JSON.stringify(_exhaustive)}`);
     }
   }
 }
 
-function resolveInstallDir(target: SkillInstallTarget, skillName: string): string {
+export function resolveInstallDir(target: SkillInstallTarget, skillName: string): string {
   assertSkillName(skillName);
   const base = resolveSkillsBaseDir(target);
   const installDir = path.resolve(base, skillName);
@@ -95,7 +131,7 @@ function resolveInstallDir(target: SkillInstallTarget, skillName: string): strin
   return installDir;
 }
 
-function resolveChildPath(baseDir: string, name: string): string {
+export function resolveChildPath(baseDir: string, name: string): string {
   if (!ENTRY_NAME_RE.test(name)) {
     throw new Error(`Invalid file/directory name from registry: ${JSON.stringify(name)}`);
   }
@@ -107,8 +143,6 @@ function resolveChildPath(baseDir: string, name: string): string {
   return child;
 }
 
-/** Specialized error so callers can branch on the HTTP status (e.g. 403 = rate limit,
- *  404 = path moved). The message is human-readable; the `status` is for matching. */
 class FetchHttpError extends Error {
   constructor(
     public readonly url: string,
@@ -148,6 +182,11 @@ interface RawSkill {
 
 // A handful of registry entries ship malformed values (e.g. description as ["需要填写描述"]),
 // which would otherwise blow up SQLite bindings. Coerce defensively at the boundary.
+function clampInt(v: number | undefined, fallback: number, min: number, max: number): number {
+  if (typeof v !== 'number' || !Number.isFinite(v)) return fallback;
+  return Math.min(Math.max(Math.trunc(v), min), max);
+}
+
 function asString(v: unknown): string {
   if (typeof v === 'string') return v;
   if (v == null) return '';
@@ -175,12 +214,9 @@ function normalizeSkill(s: RawSkill): RegistrySkill | null {
   };
 }
 
-/**
- * Downloads the registry, normalizes each skill, and replaces the SQLite cache atomically.
- * We previously tried stream-json for low-memory parsing, but the pipeline silently yielded
- * 0 rows in our setup (likely a Buffer/Uint8Array mismatch between Readable.fromWeb and
- * fixUtf8Stream). Buffered parse is reliable and trades ~200 MB transient memory for that.
- */
+// Buffered parse rather than stream-json: a Buffer/Uint8Array mismatch between
+// Readable.fromWeb and fixUtf8Stream silently yielded 0 rows in our setup. Cost is
+// ~200 MB transient memory during the JSON.parse.
 async function downloadAndStoreRegistry(): Promise<{ inserted: number }> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REGISTRY_FETCH_TIMEOUT_MS);
@@ -237,6 +273,10 @@ async function downloadAndStoreRegistry(): Promise<{ inserted: number }> {
   }
 }
 
+// Per-installDir lock: two clicks on "Install" (e.g. dropdown re-open) would otherwise
+// race the rmSync+renameSync swap and either stomp each other or fail with ENOTEMPTY.
+const installsInFlight = new Set<string>();
+
 export class SkillsService {
   static getMeta(): SkillsRegistryMeta {
     return SkillsCache.getMeta();
@@ -246,17 +286,10 @@ export class SkillsService {
     return SkillsCache.getCategories();
   }
 
-  /**
-   * If the cache is missing or older than CACHE_TTL_MS, refresh it from the registry.
-   * forceRefresh bypasses the TTL. Returns the post-refresh meta. When a refresh attempt
-   * fails but we have a non-empty cache, returns that cache with `stale: true` and a
-   * human-readable `refreshError` so the UI can show the user why fresh data isn't here.
-   */
   static async ensureRegistry(forceRefresh = false): Promise<SkillsRegistryMeta> {
     const meta = SkillsCache.getMeta();
-    const fresh =
-      meta.fetchedAt !== null && meta.totalCount > 0 && Date.now() - meta.fetchedAt < CACHE_TTL_MS;
-    if (fresh && !forceRefresh) return meta;
+    const isFresh = meta.status === 'fresh' && Date.now() - meta.fetchedAt < CACHE_TTL_MS;
+    if (isFresh && !forceRefresh) return meta;
 
     try {
       await downloadAndStoreRegistry();
@@ -265,12 +298,17 @@ export class SkillsService {
       // anything cached, but we MUST signal this to the renderer so the user knows their
       // results are old. Silently returning stale data caused users to sit on weeks-old
       // caches without realising refresh had been broken.
-      if (meta.totalCount > 0) {
+      if (meta.status !== 'never-fetched') {
         const message = err instanceof Error ? err.message : String(err);
         console.error('[SkillsService.ensureRegistry] using stale cache after fetch failure', {
           message,
         });
-        return { ...meta, stale: true, refreshError: message };
+        return {
+          status: 'stale',
+          totalCount: meta.totalCount,
+          fetchedAt: meta.fetchedAt,
+          refreshError: message,
+        };
       }
       throw err;
     }
@@ -278,13 +316,17 @@ export class SkillsService {
   }
 
   static search(args: SkillsSearchArgs): SkillsSearchResult {
-    const result = SkillsCache.search({
+    // Clamp to defend against negative or wildly-large values from a misbehaving caller —
+    // SQLite happily accepts a negative LIMIT but the result is a confused empty page,
+    // not a clear error.
+    const limit = clampInt(args.limit, 50, 1, 200);
+    const offset = clampInt(args.offset, 0, 0, Number.MAX_SAFE_INTEGER);
+    return SkillsCache.search({
       query: args.query ?? '',
       category: args.category,
-      limit: args.limit ?? 50,
-      offset: args.offset ?? 0,
+      limit,
+      offset,
     });
-    return result;
   }
 
   static async getSkillContent(ref: SkillRef): Promise<string> {
@@ -302,20 +344,10 @@ export class SkillsService {
 
   /** Reads SKILL.md for a skill installed locally — used when the catalog has no entry
    *  (custom/long-tail skills) and we therefore can't pull from raw.githubusercontent.com.
-   *  installLocation must be either the special string 'global' (resolved to ~/.claude/skills)
-   *  or an absolute path that the renderer already validated as a known project/worktree path. */
-  static readLocalSkillMd(args: { skillName: string; installLocation: string }): string {
-    assertSkillName(args.skillName);
-    const baseDir =
-      args.installLocation === 'global'
-        ? path.join(os.homedir(), '.claude', 'skills')
-        : path.join(args.installLocation, '.claude', 'skills');
-    // Defense in depth: same escape check we use on writes.
-    const skillDir = path.resolve(baseDir, args.skillName);
-    const rel = path.relative(baseDir, skillDir);
-    if (rel.startsWith('..') || path.isAbsolute(rel)) {
-      throw new Error(`Resolved skill dir escapes base: ${skillDir}`);
-    }
+   *  Takes the same SkillInstallTarget union as install/uninstall so the base dir is
+   *  resolved through the same closed switch. */
+  static readLocalSkillMd(args: { skillName: string; target: SkillInstallTarget }): string {
+    const skillDir = resolveInstallDir(args.target, args.skillName);
     const file = path.join(skillDir, 'SKILL.md');
     const stat = statSync(file); // throws ENOENT cleanly if missing
     if (stat.size > MAX_FILE_BYTES) {
@@ -329,23 +361,44 @@ export class SkillsService {
     assertRef(ref);
     const installDir = resolveInstallDir(target, skillName);
 
+    if (installsInFlight.has(installDir)) {
+      throw new Error(
+        `An install for ${skillName} at this location is already in progress. Wait for it to finish.`,
+      );
+    }
+    installsInFlight.add(installDir);
+
     // Stage into a sibling temp dir so a mid-install failure (rate limit, network drop,
     // file-count cap, etc.) can't leave a half-populated skill that checkInstalled would
     // still report as "installed" because SKILL.md happens to exist.
     const stagingDir = `${installDir}.tmp-${process.pid}-${Date.now()}`;
     mkdirSync(stagingDir, { recursive: true });
 
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(
+        () => reject(new Error(`Install timed out after ${INSTALL_TIMEOUT_MS / 1000}s`)),
+        INSTALL_TIMEOUT_MS,
+      );
+    });
+
     try {
-      const content = await this.getSkillContent(ref);
-      writeFileSync(path.join(stagingDir, 'SKILL.md'), content, 'utf-8');
+      await Promise.race([
+        (async () => {
+          const content = await this.getSkillContent(ref);
+          writeFileSync(path.join(stagingDir, 'SKILL.md'), content, 'utf-8');
 
-      const counter = { count: 1 };
-      await this.fetchSkillDirectory(ref, stagingDir, MAX_RECURSION_DEPTH, counter);
+          const counter = { count: 1 };
+          await this.fetchSkillDirectory(ref, stagingDir, MAX_RECURSION_DEPTH, counter);
 
-      // Atomic-ish swap: remove any pre-existing install, then rename. rename within the
-      // same directory is atomic on POSIX; the prior rmSync is the small race window.
-      rmSync(installDir, { recursive: true, force: true });
-      renameSync(stagingDir, installDir);
+          // Atomic-ish swap: remove any pre-existing install, then rename. rename within
+          // the same directory is atomic on POSIX; the in-flight lock above guards
+          // against concurrent installs racing rmSync+renameSync.
+          rmSync(installDir, { recursive: true, force: true });
+          renameSync(stagingDir, installDir);
+        })(),
+        timeoutPromise,
+      ]);
     } catch (err) {
       // Best-effort cleanup of the partial staging tree; never mask the original failure.
       try {
@@ -357,6 +410,9 @@ export class SkillsService {
         });
       }
       throw err;
+    } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      installsInFlight.delete(installDir);
     }
   }
 
@@ -407,7 +463,15 @@ export class SkillsService {
       clearTimeout(timeout);
     }
 
-    if (!Array.isArray(parsed)) return;
+    if (!Array.isArray(parsed)) {
+      // GitHub returns an object (not an array) when the path resolves to a single file
+      // or to an error envelope (e.g. `{ message: "Not Found" }`). The previous behavior
+      // silently skipped this — install would report success after copying SKILL.md only.
+      // Fail loudly so users see the upstream weirdness instead of an incomplete install.
+      throw new Error(
+        `GitHub contents API returned non-array shape for ${ref.repo}/${dirPath}; the upstream may have moved or rate-limited.`,
+      );
+    }
 
     const entries = parsed as Array<{
       name: string;
@@ -454,35 +518,30 @@ export class SkillsService {
   static checkInstalled(skillName: string, probePaths: string[]): SkillInstallStatus {
     assertSkillName(skillName);
     const home = os.homedir();
-    const probeErrors: string[] = [];
+    const probeFailures: ProbeFailure[] = [];
 
     const globalProbe = skillFilePresence(
       path.join(home, '.claude', 'skills', skillName, 'SKILL.md'),
     );
-    if (globalProbe.error) probeErrors.push(`global (${globalProbe.error})`);
+    if (globalProbe.error) probeFailures.push({ scope: 'global', code: globalProbe.error });
 
     const installedPaths: string[] = [];
     for (const pp of probePaths) {
       const probe = skillFilePresence(path.join(pp, '.claude', 'skills', skillName, 'SKILL.md'));
-      if (probe.error) probeErrors.push(`${pp} (${probe.error})`);
+      if (probe.error) probeFailures.push({ scope: pp, code: probe.error });
       if (probe.present) installedPaths.push(pp);
     }
 
     const status: SkillInstallStatus = { global: globalProbe.present, installedPaths };
-    if (probeErrors.length > 0) {
-      status.probeError = `Could not check install status for ${probeErrors.join(', ')}`;
-    }
+    if (probeFailures.length > 0) status.probeFailures = probeFailures;
     return status;
   }
 
-  /** Lists every skill installed on disk across global + the supplied probePaths.
-   *  Joins each found folder name back to the registry cache when possible so the UI
-   *  can render full cards; skills installed but not in the cached top-N come back
-   *  with `catalog: null`. */
-  static listInstalled(probePaths: string[]): InstalledSkill[] {
+  static listInstalled(probePaths: string[]): InstalledSkillsResult {
     const home = os.homedir();
     type Entry = { installedPaths: string[]; globalInstalled: boolean };
     const found = new Map<string, Entry>();
+    const probeFailures: ProbeFailure[] = [];
 
     function record(skillName: string, scope: 'global' | string): void {
       // Defensive: a folder name that wouldn't pass our install validator is suspicious
@@ -495,19 +554,16 @@ export class SkillsService {
       found.set(skillName, entry);
     }
 
-    for (const name of listSkillFolders(path.join(home, '.claude', 'skills'))) {
-      record(name, 'global');
-    }
+    const globalProbe = listSkillFolders(path.join(home, '.claude', 'skills'));
+    for (const name of globalProbe.names) record(name, 'global');
+    if (globalProbe.error) probeFailures.push({ scope: 'global', code: globalProbe.error });
+
     for (const pp of probePaths) {
-      for (const name of listSkillFolders(path.join(pp, '.claude', 'skills'))) {
-        record(name, pp);
-      }
+      const probe = listSkillFolders(path.join(pp, '.claude', 'skills'));
+      for (const name of probe.names) record(name, pp);
+      if (probe.error) probeFailures.push({ scope: pp, code: probe.error });
     }
 
-    // Build a lookup from sanitized install-name → catalog row so we can attach
-    // metadata to each installed entry. One pass over the cache keeps this O(N) in the
-    // catalog size; per-name SQL would be cheaper but the sanitization rules are awkward
-    // to express in SQL. First wins on collisions.
     const catalogByInstallName = new Map<string, RegistrySkill>();
     for (const s of SkillsCache.allSkills()) {
       const installName = deriveInstallNameFromCatalog(s);
@@ -516,17 +572,26 @@ export class SkillsService {
       }
     }
 
-    const result: InstalledSkill[] = [];
+    const skills: InstalledSkill[] = [];
     for (const [skillName, info] of found) {
-      result.push({
+      skills.push({
         skillName,
         globalInstalled: info.globalInstalled,
         installedPaths: info.installedPaths,
         catalog: catalogByInstallName.get(skillName) ?? null,
       });
     }
-    result.sort((a, b) => a.skillName.localeCompare(b.skillName));
-    return result;
+    skills.sort((a, b) => a.skillName.localeCompare(b.skillName));
+    return { skills, probeFailures };
+  }
+
+  /** Wipes the on-disk cache and refetches the registry. Last-resort recovery for when
+   *  the SQLite cache has corrupted in a way that the auto-retry on read methods can't
+   *  fix on its own. */
+  static async resetCache(): Promise<SkillsRegistryMeta> {
+    SkillsCache.resetCache();
+    await downloadAndStoreRegistry();
+    return SkillsCache.getMeta();
   }
 
   static uninstallSkill(args: SkillUninstallArgs): void {
@@ -546,17 +611,18 @@ export class SkillsService {
   }
 }
 
-/** Lists subdirectories of a `.claude/skills/` directory that contain a SKILL.md file.
- *  Returns [] if the directory doesn't exist; logs other errors and returns []. */
-function listSkillFolders(skillsDir: string): string[] {
+// Returns the SKILL.md-bearing folders under a `.claude/skills/` dir. ENOENT collapses
+// to "empty"; any other errno (EACCES, EIO, …) is reported via `error` so the caller
+// can surface the truncation to the user instead of silently returning [].
+function listSkillFolders(skillsDir: string): { names: string[]; error?: string } {
   let entries: Dirent[];
   try {
     entries = readdirSync(skillsDir, { withFileTypes: true }) as Dirent[];
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
-    if (code === 'ENOENT') return [];
+    if (code === 'ENOENT') return { names: [] };
     console.error('[SkillsService.listSkillFolders] readdir failed', { skillsDir, code });
-    return [];
+    return { names: [], error: code || 'unknown' };
   }
   const names: string[] = [];
   for (const e of entries) {
@@ -567,7 +633,7 @@ function listSkillFolders(skillsDir: string): string[] {
       names.push(e.name);
     }
   }
-  return names;
+  return { names };
 }
 
 /** Mirrors the renderer's `deriveInstallSkillName` so we can map a catalog row back
@@ -593,8 +659,8 @@ function lastPathSegment(p: string): string {
   return last;
 }
 
-/** Probes whether a SKILL.md exists. Distinguishes "not present" from "couldn't read"
- *  so the caller can warn the user when ENOENT is masked by EACCES/EIO etc. */
+// Distinguishes "not present" from "couldn't read" so callers can warn the user when
+// ENOENT is masked by EACCES/EIO etc.
 function skillFilePresence(filePath: string): { present: boolean; error?: string } {
   try {
     statSync(filePath);

--- a/src/main/services/SkillsService.ts
+++ b/src/main/services/SkillsService.ts
@@ -8,6 +8,7 @@ import {
   readdirSync,
   type Dirent,
 } from 'fs';
+import { createHash } from 'crypto';
 import path from 'path';
 import os from 'os';
 import type {
@@ -115,6 +116,53 @@ function readSkillMarker(skillDir: string): SkillMarker | null {
       return null;
     }
     return parsed as SkillMarker;
+  } catch {
+    return null;
+  }
+}
+
+// Negative-cache sentinel: when content-match against the unique registry candidate
+// fails for an orphan folder, we record the local SKILL.md hash at check time. Future
+// listInstalled calls skip the fetch as long as the local content hasn't changed.
+// Editing the skill invalidates the sentinel naturally (different hash); a new install
+// via Dash overwrites both files atomically.
+const VERIFIED_CUSTOM_FILENAME = '.dash-skill-checked.json';
+const VERIFIED_CUSTOM_VERSION = 1;
+
+interface VerifiedCustomRecord {
+  version: number;
+  checkedAt: number;
+  /** SHA-256 of the local SKILL.md at the time we checked. The cache is invalid once
+   *  the user edits the file, so we re-check and (potentially) bind to a registry
+   *  entry that now matches. */
+  contentSha256: string;
+}
+
+function sha256(s: string): string {
+  return createHash('sha256').update(s).digest('hex');
+}
+
+function writeVerifiedCustom(skillDir: string, contentSha256: string): void {
+  const record: VerifiedCustomRecord = {
+    version: VERIFIED_CUSTOM_VERSION,
+    checkedAt: Date.now(),
+    contentSha256,
+  };
+  writeFileSync(path.join(skillDir, VERIFIED_CUSTOM_FILENAME), JSON.stringify(record), 'utf-8');
+}
+
+function readVerifiedCustom(skillDir: string): VerifiedCustomRecord | null {
+  try {
+    const text = readFileSync(path.join(skillDir, VERIFIED_CUSTOM_FILENAME), 'utf-8');
+    const parsed = JSON.parse(text) as Partial<VerifiedCustomRecord>;
+    if (
+      parsed.version !== VERIFIED_CUSTOM_VERSION ||
+      typeof parsed.contentSha256 !== 'string' ||
+      typeof parsed.checkedAt !== 'number'
+    ) {
+      return null;
+    }
+    return parsed as VerifiedCustomRecord;
   } catch {
     return null;
   }
@@ -612,10 +660,9 @@ export class SkillsService {
     return status;
   }
 
-  static listInstalled(probePaths: string[]): InstalledSkillsResult {
+  static async listInstalled(probePaths: string[]): Promise<InstalledSkillsResult> {
     const home = os.homedir();
-    type Entry = { installedPaths: string[]; globalInstalled: boolean };
-    const found = new Map<string, Entry>();
+    const found = new Map<string, InstalledEntry>();
     const probeFailures: ProbeFailure[] = [];
 
     function record(skillName: string, scope: 'global' | string): void {
@@ -639,17 +686,21 @@ export class SkillsService {
       if (probe.error) probeFailures.push({ scope: pp, code: probe.error });
     }
 
+    // Recognise externally-installed registry skills (skills.sh, Claude Code native
+    // skills, manual installs) by content match. Runs before the catalog join so any
+    // freshly-written markers are picked up below. The persistent verified-custom
+    // sentinel means each truly-custom folder pays the fetch cost at most once.
+    await backfillExternalInstalls(found, home);
+
     // Catalog join is keyed by (repo, path) read from each install's marker file.
-    // The previous sanitized-folder-name fuzzy match conflated unrelated skills that
-    // happened to share a name (e.g. user's custom "validate" → registry "validate").
-    // Folders without a marker — pre-existing custom skills, or older Dash installs
-    // from before markers existed — fall through with catalog: null and render as Custom.
+    // Folders without a marker — user's own custom skills, ambiguous name matches —
+    // fall through with catalog: null and render as Custom.
     const catalogByRepoPath = new Map<string, RegistrySkill>();
     for (const s of SkillsCache.allSkills()) {
       catalogByRepoPath.set(`${s.repo}|${s.path}`, s);
     }
 
-    function lookupCatalog(skillName: string, info: Entry): RegistrySkill | null {
+    function lookupCatalog(skillName: string, info: InstalledEntry): RegistrySkill | null {
       const candidates: string[] = [];
       if (info.globalInstalled) {
         candidates.push(path.join(home, '.claude', 'skills', skillName));
@@ -726,6 +777,120 @@ function listSkillFolders(skillsDir: string): { names: string[]; error?: string 
     }
   }
   return { names };
+}
+
+interface InstalledEntry {
+  installedPaths: string[];
+  globalInstalled: boolean;
+}
+
+// Mirrors the renderer's `deriveInstallSkillName` so backfill can map a catalog row to
+// the folder name `installSkill` would use for it. Used to find candidate registry
+// matches for marker-less install dirs — keep these in sync.
+function deriveInstallNameFromCatalog(skill: RegistrySkill): string {
+  const candidates = [skill.name, lastPathSegment(skill.path)];
+  for (const c of candidates) {
+    if (!c) continue;
+    const sanitized = c
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    if (sanitized && sanitized !== 'unknown' && /^[a-z0-9]/.test(sanitized)) return sanitized;
+  }
+  return '';
+}
+
+function lastPathSegment(p: string): string {
+  const segs = p.split('/').filter(Boolean);
+  const last = segs[segs.length - 1] ?? '';
+  if (last.toLowerCase() === 'skill.md') return segs[segs.length - 2] ?? '';
+  return last;
+}
+
+// Recognises skill folders installed outside Dash (via skills.sh, Claude Code's native
+// skills system, manual clone, etc.) that match a registry entry byte-for-byte. For
+// each marker-less folder with a unique name-matching candidate, fetches the registry
+// SKILL.md and compares; on match writes the marker so the catalog metadata renders.
+// On no match, writes a sentinel keyed by the local content hash so the same folder
+// isn't refetched until the user edits the file.
+async function backfillExternalInstalls(
+  found: Map<string, InstalledEntry>,
+  home: string,
+): Promise<void> {
+  const candidatesByName = new Map<string, RegistrySkill[]>();
+  for (const s of SkillsCache.allSkills()) {
+    const name = deriveInstallNameFromCatalog(s);
+    if (!name) continue;
+    const arr = candidatesByName.get(name) ?? [];
+    arr.push(s);
+    candidatesByName.set(name, arr);
+  }
+
+  await Promise.all(
+    Array.from(found.entries()).map(async ([skillName, info]) => {
+      const candidates = candidatesByName.get(skillName) ?? [];
+      // Ambiguous name (multiple candidates) or no candidate at all → leave as Custom
+      // and don't write a sentinel: there's nothing to learn from a fetch we wouldn't
+      // do, and a future registry refresh might disambiguate.
+      if (candidates.length !== 1) return;
+      const ref = candidates[0];
+
+      const dirs: string[] = [];
+      if (info.globalInstalled) dirs.push(path.join(home, '.claude', 'skills', skillName));
+      for (const pp of info.installedPaths) {
+        dirs.push(path.join(pp, '.claude', 'skills', skillName));
+      }
+
+      // Filter to dirs that are still orphan candidates: no marker (so not already
+      // bound) AND no matching verified-custom sentinel (so we haven't already shown
+      // the local content doesn't match this registry entry).
+      const orphans = dirs.filter((d) => {
+        if (readSkillMarker(d) !== null) return false;
+        const sentinel = readVerifiedCustom(d);
+        if (!sentinel) return true;
+        let local: string;
+        try {
+          local = readFileSync(path.join(d, 'SKILL.md'), 'utf-8');
+        } catch {
+          return false;
+        }
+        // Re-check if user edited the file since the sentinel was written.
+        return sha256(local) !== sentinel.contentSha256;
+      });
+      if (orphans.length === 0) return;
+
+      let registryContent: string;
+      try {
+        registryContent = await SkillsService.getSkillContent(ref);
+      } catch (err) {
+        console.warn('[SkillsService.backfill] could not fetch registry SKILL.md', {
+          repo: ref.repo,
+          path: ref.path,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+
+      for (const dir of orphans) {
+        let localContent: string;
+        try {
+          localContent = readFileSync(path.join(dir, 'SKILL.md'), 'utf-8');
+        } catch (err) {
+          console.warn('[SkillsService.backfill] could not read local SKILL.md', {
+            dir,
+            message: err instanceof Error ? err.message : String(err),
+          });
+          continue;
+        }
+        if (localContent === registryContent) {
+          writeSkillMarker(dir, ref);
+        } else {
+          writeVerifiedCustom(dir, sha256(localContent));
+        }
+      }
+    }),
+  );
 }
 
 // "Is this skill dir an install of `expectedRef`?" — when expectedRef is null, falls

--- a/src/main/services/SkillsService.ts
+++ b/src/main/services/SkillsService.ts
@@ -25,6 +25,7 @@ import type {
   InstalledSkillsResult,
   ProbeFailure,
 } from '@shared/types';
+import { deriveSkillFolderName } from '@shared/skills';
 import { SkillsCache } from './skillsCache';
 
 // Trust boundary: this third-party GitHub repo is effectively Dash's package registry.
@@ -85,12 +86,22 @@ const MARKER_FILENAME = '.dash-skill.json';
 const MARKER_VERSION = 1;
 
 interface SkillMarker {
-  version: number;
+  version: 1;
   repo: string;
   branch: string;
   path: string;
   installedAt: number;
 }
+
+// Discriminated union so callers can distinguish "no marker" (legitimate custom-skill
+// folder) from "marker present but unreadable" (truncated, schema-mismatched, or hit by
+// AV). The earlier null-on-any-failure shape collapsed those modes, leading to:
+// checkInstalled saying "not installed" while installSkill refused with "already exists
+// but was not installed by Dash" — two contradictory truths from the same FS state.
+type MarkerReadResult =
+  | { kind: 'absent' }
+  | { kind: 'present'; marker: SkillMarker }
+  | { kind: 'corrupt'; reason: string };
 
 function writeSkillMarker(skillDir: string, ref: SkillRef): void {
   const marker: SkillMarker = {
@@ -103,40 +114,65 @@ function writeSkillMarker(skillDir: string, ref: SkillRef): void {
   writeFileSync(path.join(skillDir, MARKER_FILENAME), JSON.stringify(marker), 'utf-8');
 }
 
-function readSkillMarker(skillDir: string): SkillMarker | null {
+function readSkillMarker(skillDir: string): MarkerReadResult {
+  const file = path.join(skillDir, MARKER_FILENAME);
+  let text: string;
   try {
-    const text = readFileSync(path.join(skillDir, MARKER_FILENAME), 'utf-8');
-    const parsed = JSON.parse(text) as Partial<SkillMarker>;
-    if (
-      parsed.version !== MARKER_VERSION ||
-      typeof parsed.repo !== 'string' ||
-      typeof parsed.path !== 'string' ||
-      typeof parsed.branch !== 'string'
-    ) {
-      return null;
-    }
-    return parsed as SkillMarker;
-  } catch {
-    return null;
+    text = readFileSync(file, 'utf-8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return { kind: 'absent' };
+    console.error('[SkillsService.readSkillMarker] read failed', { file, code });
+    return { kind: 'corrupt', reason: code || 'read-failed' };
   }
+  let parsed: Partial<SkillMarker>;
+  try {
+    parsed = JSON.parse(text) as Partial<SkillMarker>;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[SkillsService.readSkillMarker] parse failed', { file, message });
+    return { kind: 'corrupt', reason: 'parse-error' };
+  }
+  if (
+    parsed.version !== MARKER_VERSION ||
+    typeof parsed.repo !== 'string' ||
+    typeof parsed.path !== 'string' ||
+    typeof parsed.branch !== 'string'
+  ) {
+    console.error('[SkillsService.readSkillMarker] schema mismatch', {
+      file,
+      version: parsed.version,
+    });
+    return { kind: 'corrupt', reason: 'schema-mismatch' };
+  }
+  return { kind: 'present', marker: parsed as SkillMarker };
 }
 
 // Negative-cache sentinel: when content-match against the unique registry candidate
 // fails for an orphan folder, we record the local SKILL.md hash at check time. Future
 // listInstalled calls skip the fetch as long as the local content hasn't changed.
 // Editing the skill invalidates the sentinel naturally (different hash); a new install
-// via Dash overwrites both files atomically.
+// via Dash replaces the whole skill directory in the staging swap, so any stale sentinel
+// goes with it.
 const VERIFIED_CUSTOM_FILENAME = '.dash-skill-checked.json';
 const VERIFIED_CUSTOM_VERSION = 1;
 
 interface VerifiedCustomRecord {
-  version: number;
+  version: 1;
   checkedAt: number;
   /** SHA-256 of the local SKILL.md at the time we checked. The cache is invalid once
    *  the user edits the file, so we re-check and (potentially) bind to a registry
    *  entry that now matches. */
   contentSha256: string;
 }
+
+// Same three-state shape as MarkerReadResult so backfill can tell the difference between
+// "never checked" (absent) and "stale sentinel" (corrupt) — the latter must trigger a
+// re-fetch, not be treated as if the user has never opted in.
+type VerifiedCustomReadResult =
+  | { kind: 'absent' }
+  | { kind: 'present'; record: VerifiedCustomRecord }
+  | { kind: 'corrupt'; reason: string };
 
 function sha256(s: string): string {
   return createHash('sha256').update(s).digest('hex');
@@ -151,21 +187,37 @@ function writeVerifiedCustom(skillDir: string, contentSha256: string): void {
   writeFileSync(path.join(skillDir, VERIFIED_CUSTOM_FILENAME), JSON.stringify(record), 'utf-8');
 }
 
-function readVerifiedCustom(skillDir: string): VerifiedCustomRecord | null {
+function readVerifiedCustom(skillDir: string): VerifiedCustomReadResult {
+  const file = path.join(skillDir, VERIFIED_CUSTOM_FILENAME);
+  let text: string;
   try {
-    const text = readFileSync(path.join(skillDir, VERIFIED_CUSTOM_FILENAME), 'utf-8');
-    const parsed = JSON.parse(text) as Partial<VerifiedCustomRecord>;
-    if (
-      parsed.version !== VERIFIED_CUSTOM_VERSION ||
-      typeof parsed.contentSha256 !== 'string' ||
-      typeof parsed.checkedAt !== 'number'
-    ) {
-      return null;
-    }
-    return parsed as VerifiedCustomRecord;
-  } catch {
-    return null;
+    text = readFileSync(file, 'utf-8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return { kind: 'absent' };
+    console.error('[SkillsService.readVerifiedCustom] read failed', { file, code });
+    return { kind: 'corrupt', reason: code || 'read-failed' };
   }
+  let parsed: Partial<VerifiedCustomRecord>;
+  try {
+    parsed = JSON.parse(text) as Partial<VerifiedCustomRecord>;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[SkillsService.readVerifiedCustom] parse failed', { file, message });
+    return { kind: 'corrupt', reason: 'parse-error' };
+  }
+  if (
+    parsed.version !== VERIFIED_CUSTOM_VERSION ||
+    typeof parsed.contentSha256 !== 'string' ||
+    typeof parsed.checkedAt !== 'number'
+  ) {
+    console.error('[SkillsService.readVerifiedCustom] schema mismatch', {
+      file,
+      version: parsed.version,
+    });
+    return { kind: 'corrupt', reason: 'schema-mismatch' };
+  }
+  return { kind: 'present', record: parsed as VerifiedCustomRecord };
 }
 
 const SKILL_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
@@ -466,10 +518,21 @@ export class SkillsService {
     // ENOENT and any other unexpected stat error are deferred to the swap itself.
     try {
       const stat = statSync(installDir);
-      if (stat.isDirectory() && !readSkillMarker(installDir)) {
-        throw new Error(
-          `${installDir} already exists but was not installed by Dash. Refusing to overwrite — rename or remove the existing folder first if you want to install this skill here.`,
-        );
+      if (stat.isDirectory()) {
+        const markerResult = readSkillMarker(installDir);
+        if (markerResult.kind === 'absent') {
+          throw new Error(
+            `${installDir} already exists but was not installed by Dash. Refusing to overwrite — rename or remove the existing folder first if you want to install this skill here.`,
+          );
+        }
+        if (markerResult.kind === 'corrupt') {
+          // Corrupt-but-Dash-managed: don't silently overwrite, but give an error a user
+          // can act on (uninstall via Dash, then install). Without this branch the user
+          // hit "already exists but was not installed by Dash" and had to rm -rf manually.
+          throw new Error(
+            `Install marker for ${skillName} at ${installDir} is corrupt (${markerResult.reason}). Click Uninstall to remove the folder, then Install again.`,
+          );
+        }
       }
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
@@ -503,16 +566,17 @@ export class SkillsService {
           const counter = { count: 1 };
           await this.fetchSkillDirectory(ref, stagingDir, MAX_RECURSION_DEPTH, counter);
 
-          // Write the marker last so it overwrites any registry-supplied .dash-skill.json
-          // (we own this filename). The marker carries the registry coordinates so the
-          // installed-list view and checkInstalled can match by (repo, path) instead of
-          // sanitized folder name.
+          // Write the marker last. The fetch loop skips entries named SKILL.md, but
+          // .dash-skill.json isn't on that allow-list — a registry that ships its own
+          // file by that name would otherwise leave a stale marker on disk after the
+          // recursive copy. Writing here guarantees we own the final bytes.
           writeSkillMarker(stagingDir, ref);
 
-          // Atomic-ish swap: remove any pre-existing install, then rename. rename within
-          // the same directory is atomic on POSIX; the in-flight lock above guards
-          // against concurrent installs racing rmSync+renameSync. The precondition
-          // above guarantees we only rmSync a Dash-installed dir.
+          // Atomic-ish swap: remove any pre-existing install, then rename the whole
+          // staging directory in. rename within the same parent is atomic on POSIX; the
+          // in-flight lock above guards against concurrent installs racing
+          // rmSync+renameSync. The precondition above guarantees we only rmSync a
+          // Dash-installed dir.
           rmSync(installDir, { recursive: true, force: true });
           renameSync(stagingDir, installDir);
         })(),
@@ -651,7 +715,7 @@ export class SkillsService {
     const installedPaths: string[] = [];
     for (const pp of probePaths) {
       const probe = scopeMatchesRef(path.join(pp, '.claude', 'skills', skillName), ref);
-      if (probe.error) probeFailures.push({ scope: pp, code: probe.error });
+      if (probe.error) probeFailures.push({ scope: 'path', path: pp, code: probe.error });
       if (probe.present) installedPaths.push(pp);
     }
 
@@ -683,7 +747,7 @@ export class SkillsService {
     for (const pp of probePaths) {
       const probe = listSkillFolders(path.join(pp, '.claude', 'skills'));
       for (const name of probe.names) record(name, pp);
-      if (probe.error) probeFailures.push({ scope: pp, code: probe.error });
+      if (probe.error) probeFailures.push({ scope: 'path', path: pp, code: probe.error });
     }
 
     // Recognise externally-installed registry skills (skills.sh, Claude Code native
@@ -709,8 +773,10 @@ export class SkillsService {
         candidates.push(path.join(pp, '.claude', 'skills', skillName));
       }
       for (const dir of candidates) {
-        const marker = readSkillMarker(dir);
-        if (marker) return catalogByRepoPath.get(`${marker.repo}|${marker.path}`) ?? null;
+        const result = readSkillMarker(dir);
+        if (result.kind === 'present') {
+          return catalogByRepoPath.get(`${result.marker.repo}|${result.marker.path}`) ?? null;
+        }
       }
       return null;
     }
@@ -784,30 +850,6 @@ interface InstalledEntry {
   globalInstalled: boolean;
 }
 
-// Mirrors the renderer's `deriveInstallSkillName` so backfill can map a catalog row to
-// the folder name `installSkill` would use for it. Used to find candidate registry
-// matches for marker-less install dirs — keep these in sync.
-function deriveInstallNameFromCatalog(skill: RegistrySkill): string {
-  const candidates = [skill.name, lastPathSegment(skill.path)];
-  for (const c of candidates) {
-    if (!c) continue;
-    const sanitized = c
-      .toLowerCase()
-      .replace(/[^a-z0-9-]/g, '-')
-      .replace(/-+/g, '-')
-      .replace(/^-+|-+$/g, '');
-    if (sanitized && sanitized !== 'unknown' && /^[a-z0-9]/.test(sanitized)) return sanitized;
-  }
-  return '';
-}
-
-function lastPathSegment(p: string): string {
-  const segs = p.split('/').filter(Boolean);
-  const last = segs[segs.length - 1] ?? '';
-  if (last.toLowerCase() === 'skill.md') return segs[segs.length - 2] ?? '';
-  return last;
-}
-
 // Recognises skill folders installed outside Dash (via skills.sh, Claude Code's native
 // skills system, manual clone, etc.) that match a registry entry byte-for-byte. For
 // each marker-less folder with a unique name-matching candidate, fetches the registry
@@ -820,83 +862,114 @@ async function backfillExternalInstalls(
 ): Promise<void> {
   const candidatesByName = new Map<string, RegistrySkill[]>();
   for (const s of SkillsCache.allSkills()) {
-    const name = deriveInstallNameFromCatalog(s);
+    const name = deriveSkillFolderName(s);
     if (!name) continue;
     const arr = candidatesByName.get(name) ?? [];
     arr.push(s);
     candidatesByName.set(name, arr);
   }
 
+  // Per-skill try/catch so one failure (EACCES on a single mount, network glitch, JSON
+  // parse error in a sentinel) doesn't reject the whole Promise.all and blank the
+  // installed list. Backfill is best-effort — a failure here just means the affected
+  // folder shows up as "Custom" until the next listInstalled call retries it.
   await Promise.all(
     Array.from(found.entries()).map(async ([skillName, info]) => {
-      const candidates = candidatesByName.get(skillName) ?? [];
-      // Ambiguous name (multiple candidates) or no candidate at all → leave as Custom
-      // and don't write a sentinel: there's nothing to learn from a fetch we wouldn't
-      // do, and a future registry refresh might disambiguate.
-      if (candidates.length !== 1) return;
-      const ref = candidates[0];
-
-      const dirs: string[] = [];
-      if (info.globalInstalled) dirs.push(path.join(home, '.claude', 'skills', skillName));
-      for (const pp of info.installedPaths) {
-        dirs.push(path.join(pp, '.claude', 'skills', skillName));
-      }
-
-      // Filter to dirs that are still orphan candidates: no marker (so not already
-      // bound) AND no matching verified-custom sentinel (so we haven't already shown
-      // the local content doesn't match this registry entry).
-      const orphans = dirs.filter((d) => {
-        if (readSkillMarker(d) !== null) return false;
-        const sentinel = readVerifiedCustom(d);
-        if (!sentinel) return true;
-        let local: string;
-        try {
-          local = readFileSync(path.join(d, 'SKILL.md'), 'utf-8');
-        } catch {
-          return false;
-        }
-        // Re-check if user edited the file since the sentinel was written.
-        return sha256(local) !== sentinel.contentSha256;
-      });
-      if (orphans.length === 0) return;
-
-      let registryContent: string;
       try {
-        registryContent = await SkillsService.getSkillContent(ref);
+        await tryBackfillOne(skillName, info, candidatesByName, home);
       } catch (err) {
-        console.warn('[SkillsService.backfill] could not fetch registry SKILL.md', {
-          repo: ref.repo,
-          path: ref.path,
+        console.warn('[SkillsService.backfill] skill-level failure', {
+          skillName,
           message: err instanceof Error ? err.message : String(err),
         });
-        return;
-      }
-
-      for (const dir of orphans) {
-        let localContent: string;
-        try {
-          localContent = readFileSync(path.join(dir, 'SKILL.md'), 'utf-8');
-        } catch (err) {
-          console.warn('[SkillsService.backfill] could not read local SKILL.md', {
-            dir,
-            message: err instanceof Error ? err.message : String(err),
-          });
-          continue;
-        }
-        if (localContent === registryContent) {
-          writeSkillMarker(dir, ref);
-        } else {
-          writeVerifiedCustom(dir, sha256(localContent));
-        }
       }
     }),
   );
 }
 
+async function tryBackfillOne(
+  skillName: string,
+  info: InstalledEntry,
+  candidatesByName: Map<string, RegistrySkill[]>,
+  home: string,
+): Promise<void> {
+  const candidates = candidatesByName.get(skillName) ?? [];
+  // Ambiguous name (multiple candidates) or no candidate at all → leave as Custom
+  // and don't write a sentinel: there's nothing to learn from a fetch we wouldn't
+  // do, and a future registry refresh might disambiguate.
+  if (candidates.length !== 1) return;
+  const ref = candidates[0];
+
+  const dirs: string[] = [];
+  if (info.globalInstalled) dirs.push(path.join(home, '.claude', 'skills', skillName));
+  for (const pp of info.installedPaths) {
+    dirs.push(path.join(pp, '.claude', 'skills', skillName));
+  }
+
+  // Filter to dirs that are still orphan candidates: no marker (so not already bound),
+  // and either no sentinel or a stale sentinel (the user has edited the SKILL.md or
+  // the previous record is unreadable, so we should re-check). A `corrupt` marker is
+  // *not* treated as orphan — the install precondition errors will guide the user to
+  // uninstall+reinstall instead.
+  const orphans = dirs.filter((d) => {
+    const marker = readSkillMarker(d);
+    if (marker.kind === 'present' || marker.kind === 'corrupt') return false;
+    const sentinel = readVerifiedCustom(d);
+    if (sentinel.kind === 'absent' || sentinel.kind === 'corrupt') return true;
+    let local: string;
+    try {
+      local = readFileSync(path.join(d, 'SKILL.md'), 'utf-8');
+    } catch {
+      return false;
+    }
+    // Re-check if user edited the file since the sentinel was written.
+    return sha256(local) !== sentinel.record.contentSha256;
+  });
+  if (orphans.length === 0) return;
+
+  let registryContent: string;
+  try {
+    registryContent = await SkillsService.getSkillContent(ref);
+  } catch (err) {
+    console.warn('[SkillsService.backfill] could not fetch registry SKILL.md', {
+      repo: ref.repo,
+      path: ref.path,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  for (const dir of orphans) {
+    let localContent: string;
+    try {
+      localContent = readFileSync(path.join(dir, 'SKILL.md'), 'utf-8');
+    } catch (err) {
+      console.warn('[SkillsService.backfill] could not read local SKILL.md', {
+        dir,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+    try {
+      if (localContent === registryContent) {
+        writeSkillMarker(dir, ref);
+      } else {
+        writeVerifiedCustom(dir, sha256(localContent));
+      }
+    } catch (err) {
+      console.warn('[SkillsService.backfill] could not write marker/sentinel', {
+        dir,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
 // "Is this skill dir an install of `expectedRef`?" — when expectedRef is null, falls
 // back to "does SKILL.md exist". When expectedRef is supplied, requires the Dash marker
-// to be present AND match (repo, path), so a user's custom folder of the same name
-// doesn't get reported as the registry skill being installed.
+// to be present AND match (repo, path). A corrupt marker is surfaced as an error so the
+// UI can show "marker-corrupt" in probe failures rather than reporting the same FS
+// state as both "not installed" (here) and "already exists but not Dash" (install path).
 function scopeMatchesRef(
   skillDir: string,
   expectedRef: SkillRef | null,
@@ -904,9 +977,10 @@ function scopeMatchesRef(
   const presence = skillFilePresence(path.join(skillDir, 'SKILL.md'));
   if (!presence.present) return presence;
   if (!expectedRef) return presence;
-  const marker = readSkillMarker(skillDir);
-  if (!marker) return { present: false };
-  if (marker.repo !== expectedRef.repo || marker.path !== expectedRef.path) {
+  const result = readSkillMarker(skillDir);
+  if (result.kind === 'absent') return { present: false };
+  if (result.kind === 'corrupt') return { present: false, error: 'marker-corrupt' };
+  if (result.marker.repo !== expectedRef.repo || result.marker.path !== expectedRef.path) {
     return { present: false };
   }
   return { present: true };

--- a/src/main/services/SkillsService.ts
+++ b/src/main/services/SkillsService.ts
@@ -75,6 +75,51 @@ const MAX_RECURSION_DEPTH = 3;
 // registry that supplies attacker-hosted download_url values.
 const RAW_GITHUB_PREFIX = 'https://raw.githubusercontent.com/';
 
+// Dash-owned marker dropped into every install dir so we can distinguish skills
+// installed via Dash (and from which registry entry) from a user's pre-existing folder
+// of the same name. Without this, a registry skill named "validate" silently overwrites
+// a user's custom ~/.claude/skills/validate, and the installed-list view conflates the
+// two by sanitized-name fuzzy match.
+const MARKER_FILENAME = '.dash-skill.json';
+const MARKER_VERSION = 1;
+
+interface SkillMarker {
+  version: number;
+  repo: string;
+  branch: string;
+  path: string;
+  installedAt: number;
+}
+
+function writeSkillMarker(skillDir: string, ref: SkillRef): void {
+  const marker: SkillMarker = {
+    version: MARKER_VERSION,
+    repo: ref.repo,
+    branch: ref.branch,
+    path: ref.path,
+    installedAt: Date.now(),
+  };
+  writeFileSync(path.join(skillDir, MARKER_FILENAME), JSON.stringify(marker), 'utf-8');
+}
+
+function readSkillMarker(skillDir: string): SkillMarker | null {
+  try {
+    const text = readFileSync(path.join(skillDir, MARKER_FILENAME), 'utf-8');
+    const parsed = JSON.parse(text) as Partial<SkillMarker>;
+    if (
+      parsed.version !== MARKER_VERSION ||
+      typeof parsed.repo !== 'string' ||
+      typeof parsed.path !== 'string' ||
+      typeof parsed.branch !== 'string'
+    ) {
+      return null;
+    }
+    return parsed as SkillMarker;
+  } catch {
+    return null;
+  }
+}
+
 const SKILL_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
 const BRANCH_RE = /^[\w./-]+$/;
@@ -366,6 +411,25 @@ export class SkillsService {
         `An install for ${skillName} at this location is already in progress. Wait for it to finish.`,
       );
     }
+
+    // Refuse to overwrite a directory that wasn't installed by Dash. Without this guard,
+    // installing a registry skill whose name collides with a user's existing folder
+    // (e.g. a custom "validate" skill) would silently rmSync their data on the swap.
+    // ENOENT and any other unexpected stat error are deferred to the swap itself.
+    try {
+      const stat = statSync(installDir);
+      if (stat.isDirectory() && !readSkillMarker(installDir)) {
+        throw new Error(
+          `${installDir} already exists but was not installed by Dash. Refusing to overwrite — rename or remove the existing folder first if you want to install this skill here.`,
+        );
+      }
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      // Allow ENOENT (the install dir simply doesn't exist yet); rethrow our own
+      // refusal error and any unexpected errno (EACCES on the parent etc).
+      if (code !== 'ENOENT') throw err;
+    }
+
     installsInFlight.add(installDir);
 
     // Stage into a sibling temp dir so a mid-install failure (rate limit, network drop,
@@ -391,9 +455,16 @@ export class SkillsService {
           const counter = { count: 1 };
           await this.fetchSkillDirectory(ref, stagingDir, MAX_RECURSION_DEPTH, counter);
 
+          // Write the marker last so it overwrites any registry-supplied .dash-skill.json
+          // (we own this filename). The marker carries the registry coordinates so the
+          // installed-list view and checkInstalled can match by (repo, path) instead of
+          // sanitized folder name.
+          writeSkillMarker(stagingDir, ref);
+
           // Atomic-ish swap: remove any pre-existing install, then rename. rename within
           // the same directory is atomic on POSIX; the in-flight lock above guards
-          // against concurrent installs racing rmSync+renameSync.
+          // against concurrent installs racing rmSync+renameSync. The precondition
+          // above guarantees we only rmSync a Dash-installed dir.
           rmSync(installDir, { recursive: true, force: true });
           renameSync(stagingDir, installDir);
         })(),
@@ -515,19 +586,23 @@ export class SkillsService {
     }
   }
 
-  static checkInstalled(skillName: string, probePaths: string[]): SkillInstallStatus {
+  static checkInstalled(
+    skillName: string,
+    probePaths: string[],
+    ref: SkillRef | null = null,
+  ): SkillInstallStatus {
     assertSkillName(skillName);
+    if (ref) assertRef(ref);
     const home = os.homedir();
     const probeFailures: ProbeFailure[] = [];
 
-    const globalProbe = skillFilePresence(
-      path.join(home, '.claude', 'skills', skillName, 'SKILL.md'),
-    );
+    const globalDir = path.join(home, '.claude', 'skills', skillName);
+    const globalProbe = scopeMatchesRef(globalDir, ref);
     if (globalProbe.error) probeFailures.push({ scope: 'global', code: globalProbe.error });
 
     const installedPaths: string[] = [];
     for (const pp of probePaths) {
-      const probe = skillFilePresence(path.join(pp, '.claude', 'skills', skillName, 'SKILL.md'));
+      const probe = scopeMatchesRef(path.join(pp, '.claude', 'skills', skillName), ref);
       if (probe.error) probeFailures.push({ scope: pp, code: probe.error });
       if (probe.present) installedPaths.push(pp);
     }
@@ -564,12 +639,29 @@ export class SkillsService {
       if (probe.error) probeFailures.push({ scope: pp, code: probe.error });
     }
 
-    const catalogByInstallName = new Map<string, RegistrySkill>();
+    // Catalog join is keyed by (repo, path) read from each install's marker file.
+    // The previous sanitized-folder-name fuzzy match conflated unrelated skills that
+    // happened to share a name (e.g. user's custom "validate" → registry "validate").
+    // Folders without a marker — pre-existing custom skills, or older Dash installs
+    // from before markers existed — fall through with catalog: null and render as Custom.
+    const catalogByRepoPath = new Map<string, RegistrySkill>();
     for (const s of SkillsCache.allSkills()) {
-      const installName = deriveInstallNameFromCatalog(s);
-      if (installName && !catalogByInstallName.has(installName)) {
-        catalogByInstallName.set(installName, s);
+      catalogByRepoPath.set(`${s.repo}|${s.path}`, s);
+    }
+
+    function lookupCatalog(skillName: string, info: Entry): RegistrySkill | null {
+      const candidates: string[] = [];
+      if (info.globalInstalled) {
+        candidates.push(path.join(home, '.claude', 'skills', skillName));
       }
+      for (const pp of info.installedPaths) {
+        candidates.push(path.join(pp, '.claude', 'skills', skillName));
+      }
+      for (const dir of candidates) {
+        const marker = readSkillMarker(dir);
+        if (marker) return catalogByRepoPath.get(`${marker.repo}|${marker.path}`) ?? null;
+      }
+      return null;
     }
 
     const skills: InstalledSkill[] = [];
@@ -578,7 +670,7 @@ export class SkillsService {
         skillName,
         globalInstalled: info.globalInstalled,
         installedPaths: info.installedPaths,
-        catalog: catalogByInstallName.get(skillName) ?? null,
+        catalog: lookupCatalog(skillName, info),
       });
     }
     skills.sort((a, b) => a.skillName.localeCompare(b.skillName));
@@ -636,27 +728,23 @@ function listSkillFolders(skillsDir: string): { names: string[]; error?: string 
   return { names };
 }
 
-/** Mirrors the renderer's `deriveInstallSkillName` so we can map a catalog row back
- *  to the folder name `installSkill` would use for it. Keep these in sync. */
-function deriveInstallNameFromCatalog(skill: RegistrySkill): string {
-  const candidates = [skill.name, lastPathSegment(skill.path)];
-  for (const c of candidates) {
-    if (!c) continue;
-    const sanitized = c
-      .toLowerCase()
-      .replace(/[^a-z0-9-]/g, '-')
-      .replace(/-+/g, '-')
-      .replace(/^-+|-+$/g, '');
-    if (sanitized && sanitized !== 'unknown' && /^[a-z0-9]/.test(sanitized)) return sanitized;
+// "Is this skill dir an install of `expectedRef`?" — when expectedRef is null, falls
+// back to "does SKILL.md exist". When expectedRef is supplied, requires the Dash marker
+// to be present AND match (repo, path), so a user's custom folder of the same name
+// doesn't get reported as the registry skill being installed.
+function scopeMatchesRef(
+  skillDir: string,
+  expectedRef: SkillRef | null,
+): { present: boolean; error?: string } {
+  const presence = skillFilePresence(path.join(skillDir, 'SKILL.md'));
+  if (!presence.present) return presence;
+  if (!expectedRef) return presence;
+  const marker = readSkillMarker(skillDir);
+  if (!marker) return { present: false };
+  if (marker.repo !== expectedRef.repo || marker.path !== expectedRef.path) {
+    return { present: false };
   }
-  return '';
-}
-
-function lastPathSegment(p: string): string {
-  const segs = p.split('/').filter(Boolean);
-  const last = segs[segs.length - 1] ?? '';
-  if (last.toLowerCase() === 'skill.md') return segs[segs.length - 2] ?? '';
-  return last;
+  return { present: true };
 }
 
 // Distinguishes "not present" from "couldn't read" so callers can warn the user when

--- a/src/main/services/SkillsService.ts
+++ b/src/main/services/SkillsService.ts
@@ -612,10 +612,9 @@ export class SkillsService {
     return status;
   }
 
-  static listInstalled(probePaths: string[]): InstalledSkillsResult {
+  static async listInstalled(probePaths: string[]): Promise<InstalledSkillsResult> {
     const home = os.homedir();
-    type Entry = { installedPaths: string[]; globalInstalled: boolean };
-    const found = new Map<string, Entry>();
+    const found = new Map<string, InstalledEntry>();
     const probeFailures: ProbeFailure[] = [];
 
     function record(skillName: string, scope: 'global' | string): void {
@@ -639,17 +638,20 @@ export class SkillsService {
       if (probe.error) probeFailures.push({ scope: pp, code: probe.error });
     }
 
+    // Backfill markers on legacy installs (from before the marker contract existed).
+    // Runs before the catalog join so freshly-written markers are picked up below.
+    await backfillOrphanMarkers(found, home);
+
     // Catalog join is keyed by (repo, path) read from each install's marker file.
     // The previous sanitized-folder-name fuzzy match conflated unrelated skills that
     // happened to share a name (e.g. user's custom "validate" → registry "validate").
-    // Folders without a marker — pre-existing custom skills, or older Dash installs
-    // from before markers existed — fall through with catalog: null and render as Custom.
+    // Folders without a marker fall through with catalog: null and render as Custom.
     const catalogByRepoPath = new Map<string, RegistrySkill>();
     for (const s of SkillsCache.allSkills()) {
       catalogByRepoPath.set(`${s.repo}|${s.path}`, s);
     }
 
-    function lookupCatalog(skillName: string, info: Entry): RegistrySkill | null {
+    function lookupCatalog(skillName: string, info: InstalledEntry): RegistrySkill | null {
       const candidates: string[] = [];
       if (info.globalInstalled) {
         candidates.push(path.join(home, '.claude', 'skills', skillName));
@@ -726,6 +728,109 @@ function listSkillFolders(skillsDir: string): { names: string[]; error?: string 
     }
   }
   return { names };
+}
+
+interface InstalledEntry {
+  installedPaths: string[];
+  globalInstalled: boolean;
+}
+
+// Mirrors the renderer's `deriveInstallSkillName` so we can map a catalog row back to
+// the folder name `installSkill` would use for it. Used now only by the legacy backfill
+// to find candidate registry matches for marker-less install dirs — keep these in sync.
+function deriveInstallNameFromCatalog(skill: RegistrySkill): string {
+  const candidates = [skill.name, lastPathSegment(skill.path)];
+  for (const c of candidates) {
+    if (!c) continue;
+    const sanitized = c
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    if (sanitized && sanitized !== 'unknown' && /^[a-z0-9]/.test(sanitized)) return sanitized;
+  }
+  return '';
+}
+
+function lastPathSegment(p: string): string {
+  const segs = p.split('/').filter(Boolean);
+  const last = segs[segs.length - 1] ?? '';
+  if (last.toLowerCase() === 'skill.md') return segs[segs.length - 2] ?? '';
+  return last;
+}
+
+// In-memory memo of (dir, repo|path) pairs we've already attempted to verify. A skill
+// folder whose SKILL.md doesn't match the registry candidate is likely truly custom;
+// retrying the fetch every time the user opens the modal is wasteful. Cleared on app
+// restart, which is cheap because the work is bounded by orphan-folder count.
+const backfillTried = new Set<string>();
+
+// Best-effort migration for installs from before the marker contract existed (PR
+// 0.9.13 and earlier). For each marker-less folder, look up the unique registry skill
+// whose sanitized install-name matches the folder name; fetch its SKILL.md; if local
+// content is byte-equal, write the marker. On ambiguity (multiple candidates) or any
+// difference, the folder stays Custom — we don't guess. Skips already-marked dirs.
+async function backfillOrphanMarkers(
+  found: Map<string, InstalledEntry>,
+  home: string,
+): Promise<void> {
+  const candidatesByName = new Map<string, RegistrySkill[]>();
+  for (const s of SkillsCache.allSkills()) {
+    const name = deriveInstallNameFromCatalog(s);
+    if (!name) continue;
+    const arr = candidatesByName.get(name) ?? [];
+    arr.push(s);
+    candidatesByName.set(name, arr);
+  }
+
+  await Promise.all(
+    Array.from(found.entries()).map(async ([skillName, info]) => {
+      const candidates = candidatesByName.get(skillName) ?? [];
+      if (candidates.length !== 1) return; // Ambiguous or no candidate → leave as Custom.
+      const ref = candidates[0];
+      const refKey = `${ref.repo}|${ref.path}`;
+
+      const dirs: string[] = [];
+      if (info.globalInstalled) dirs.push(path.join(home, '.claude', 'skills', skillName));
+      for (const pp of info.installedPaths) {
+        dirs.push(path.join(pp, '.claude', 'skills', skillName));
+      }
+
+      const orphans = dirs.filter((d) => {
+        if (backfillTried.has(`${d}|${refKey}`)) return false;
+        return readSkillMarker(d) === null;
+      });
+      if (orphans.length === 0) return;
+
+      orphans.forEach((d) => backfillTried.add(`${d}|${refKey}`));
+
+      let registryContent: string;
+      try {
+        registryContent = await SkillsService.getSkillContent(ref);
+      } catch (err) {
+        console.warn('[SkillsService.backfill] could not fetch registry SKILL.md', {
+          repo: ref.repo,
+          path: ref.path,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+
+      for (const dir of orphans) {
+        try {
+          const localContent = readFileSync(path.join(dir, 'SKILL.md'), 'utf-8');
+          if (localContent === registryContent) {
+            writeSkillMarker(dir, ref);
+          }
+        } catch (err) {
+          console.warn('[SkillsService.backfill] could not read local SKILL.md', {
+            dir,
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }),
+  );
 }
 
 // "Is this skill dir an install of `expectedRef`?" — when expectedRef is null, falls

--- a/src/main/services/__tests__/skillsEnsureRegistry.test.ts
+++ b/src/main/services/__tests__/skillsEnsureRegistry.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+import os from 'os';
+
+// The stale-cache fallback in ensureRegistry exists because users were silently sitting
+// on weeks-old caches when refresh broke. These tests pin that contract:
+//   - fresh cache: no fetch, returns it
+//   - stale cache + fetch fails: returns stale meta with refreshError, never throws
+//   - empty cache + fetch fails: throws (so the modal can't show an empty browser silently)
+//   - forceRefresh: bypasses TTL even when fresh
+
+vi.mock('electron', () => ({
+  default: {},
+  app: { getPath: () => os.tmpdir() },
+}));
+vi.mock('better-sqlite3', () => ({
+  default: vi.fn(() => ({
+    pragma: vi.fn(),
+    exec: vi.fn(),
+    prepare: vi.fn(() => ({ get: () => undefined, all: () => [], run: vi.fn() })),
+    transaction: (fn: (...args: unknown[]) => unknown) => fn,
+    close: vi.fn(),
+  })),
+}));
+
+import { SkillsService } from '../SkillsService';
+import { SkillsCache } from '../skillsCache';
+
+const ONE_HOUR = 60 * 60 * 1000;
+const ONE_DAY = 24 * ONE_HOUR;
+
+let fetchSpy: MockInstance<typeof globalThis.fetch>;
+let getMetaSpy: MockInstance<typeof SkillsCache.getMeta>;
+let replaceAllSpy: MockInstance<typeof SkillsCache.replaceAll>;
+
+beforeEach(() => {
+  fetchSpy = vi.spyOn(globalThis, 'fetch');
+  getMetaSpy = vi.spyOn(SkillsCache, 'getMeta');
+  replaceAllSpy = vi.spyOn(SkillsCache, 'replaceAll');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function freshMeta() {
+  return { status: 'fresh' as const, fetchedAt: Date.now() - ONE_HOUR, totalCount: 100 };
+}
+function staleMeta() {
+  return { status: 'fresh' as const, fetchedAt: Date.now() - 2 * ONE_DAY, totalCount: 100 };
+}
+function emptyMeta() {
+  return { status: 'never-fetched' as const, fetchedAt: null, totalCount: 0 as const };
+}
+
+function mockRegistryFetch(payload: { skills: unknown[] }) {
+  fetchSpy.mockResolvedValueOnce(
+    new Response(JSON.stringify(payload), { status: 200 }) as unknown as Response,
+  );
+}
+
+function mockRegistryFetchFailure() {
+  fetchSpy.mockRejectedValueOnce(new Error('network down'));
+}
+
+describe('ensureRegistry', () => {
+  it('short-circuits when cache is fresh and not forced', async () => {
+    getMetaSpy.mockReturnValue(freshMeta());
+
+    const meta = await SkillsService.ensureRegistry(false);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(replaceAllSpy).not.toHaveBeenCalled();
+    expect(meta.totalCount).toBe(100);
+  });
+
+  it('refetches when forceRefresh is true even if cache is fresh', async () => {
+    getMetaSpy.mockReturnValue(freshMeta());
+    mockRegistryFetch({
+      skills: [{ name: 'a', repo: 'o/r', path: 'p' }],
+    });
+    replaceAllSpy.mockReturnValue({ inserted: 1 });
+
+    await SkillsService.ensureRegistry(true);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(replaceAllSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches when cache is older than CACHE_TTL_MS', async () => {
+    getMetaSpy.mockReturnValue(staleMeta());
+    mockRegistryFetch({ skills: [{ name: 'a', repo: 'o/r', path: 'p' }] });
+    replaceAllSpy.mockReturnValue({ inserted: 1 });
+
+    await SkillsService.ensureRegistry(false);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches when cache is empty', async () => {
+    getMetaSpy.mockReturnValue(emptyMeta());
+    mockRegistryFetch({ skills: [{ name: 'a', repo: 'o/r', path: 'p' }] });
+    replaceAllSpy.mockReturnValue({ inserted: 1 });
+
+    await SkillsService.ensureRegistry(false);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns stale meta with refreshError when fetch fails but cache is non-empty', async () => {
+    const stale = staleMeta();
+    getMetaSpy.mockReturnValue(stale);
+    mockRegistryFetchFailure();
+
+    const meta = await SkillsService.ensureRegistry(false);
+
+    expect(meta.status).toBe('stale');
+    expect(meta.totalCount).toBe(stale.totalCount);
+    expect(meta.fetchedAt).toBe(stale.fetchedAt);
+    if (meta.status === 'stale') {
+      expect(meta.refreshError).toContain('network down');
+    }
+  });
+
+  it('throws when fetch fails AND the cache is empty', async () => {
+    getMetaSpy.mockReturnValue(emptyMeta());
+    mockRegistryFetchFailure();
+
+    await expect(SkillsService.ensureRegistry(false)).rejects.toThrow(/network down/);
+  });
+
+  it('throws when registry parses but yields zero valid skills', async () => {
+    getMetaSpy.mockReturnValue(emptyMeta());
+    // Registry returns rows that all fail normalization (no name/repo/path).
+    mockRegistryFetch({ skills: [{}, {}, { foo: 'bar' }] });
+
+    await expect(SkillsService.ensureRegistry(false)).rejects.toThrow(/0 valid skills/);
+    expect(replaceAllSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/services/__tests__/skillsInstall.test.ts
+++ b/src/main/services/__tests__/skillsInstall.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+import os from 'os';
+import path from 'path';
+import { mkdtempSync, rmSync, existsSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+
+// Verifies the install pipeline's load-bearing invariants:
+//   - atomic staging swap (mid-install failures don't leave half-installed skills)
+//   - file-count and file-size caps actually abort the install
+//   - non-raw.githubusercontent.com download URLs are refused
+//   - SKILL.md path traversal is rejected even if the registry returns it
+
+vi.mock('electron', () => ({
+  default: {},
+  app: { getPath: () => os.tmpdir() },
+}));
+vi.mock('better-sqlite3', () => ({
+  default: vi.fn(() => ({
+    pragma: vi.fn(),
+    exec: vi.fn(),
+    prepare: vi.fn(() => ({ get: () => undefined, all: () => [], run: vi.fn() })),
+    transaction: (fn: (...args: unknown[]) => unknown) => fn,
+    close: vi.fn(),
+  })),
+}));
+
+import { SkillsService } from '../SkillsService';
+
+const RAW = 'https://raw.githubusercontent.com';
+const validRef = { repo: 'owner/repo', branch: 'main', path: 'skills/demo' };
+
+interface FetchStub {
+  status?: number;
+  body: string;
+  headers?: Record<string, string>;
+}
+
+let tmpRoot: string;
+let fetchSpy: MockInstance<typeof globalThis.fetch>;
+let routes: Array<{ match: (url: string) => boolean; respond: () => FetchStub }>;
+
+function projectTarget() {
+  return { kind: 'project' as const, projectPath: tmpRoot };
+}
+
+function installDir() {
+  return path.join(tmpRoot, '.claude', 'skills', 'demo');
+}
+
+function skillsParent() {
+  return path.join(tmpRoot, '.claude', 'skills');
+}
+
+function setRoute(match: (url: string) => boolean, respond: () => FetchStub) {
+  routes.unshift({ match, respond });
+}
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'dash-skills-test-'));
+  routes = [];
+  fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : '';
+    const route = routes.find((r) => r.match(url));
+    if (!route) {
+      throw new Error(`unexpected fetch: ${url}`);
+    }
+    const stub = route.respond();
+    return new Response(stub.body, {
+      status: stub.status ?? 200,
+      statusText: stub.status === 200 || !stub.status ? 'OK' : 'ERR',
+      headers: stub.headers,
+    });
+  });
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('installSkill — happy path', () => {
+  it('writes SKILL.md and any sibling files atomically into the install dir', async () => {
+    setRoute(
+      (u) => u.startsWith(`${RAW}/owner/repo/main/skills/demo/SKILL.md`),
+      () => ({ body: '# Demo skill' }),
+    );
+    setRoute(
+      (u) => u.startsWith('https://api.github.com/repos/owner/repo/contents/skills/demo'),
+      () => ({
+        body: JSON.stringify([
+          {
+            name: 'SKILL.md',
+            type: 'file',
+            download_url: `${RAW}/owner/repo/main/skills/demo/SKILL.md`,
+          },
+          {
+            name: 'helper.md',
+            type: 'file',
+            download_url: `${RAW}/owner/repo/main/skills/demo/helper.md`,
+            size: 100,
+          },
+        ]),
+      }),
+    );
+    setRoute(
+      (u) => u.startsWith(`${RAW}/owner/repo/main/skills/demo/helper.md`),
+      () => ({ body: '## Helper' }),
+    );
+
+    await SkillsService.installSkill({ ref: validRef, skillName: 'demo', target: projectTarget() });
+
+    expect(existsSync(installDir())).toBe(true);
+    expect(readFileSync(path.join(installDir(), 'SKILL.md'), 'utf-8')).toBe('# Demo skill');
+    expect(readFileSync(path.join(installDir(), 'helper.md'), 'utf-8')).toBe('## Helper');
+    expect(readdirSync(skillsParent()).filter((n) => n.includes('.tmp-'))).toHaveLength(0);
+  });
+});
+
+describe('installSkill — staging cleanup on failure', () => {
+  it('removes the staging dir and preserves a prior install when the SKILL.md fetch fails', async () => {
+    // Pre-existing install we expect to survive
+    const prior = installDir();
+    const fs = await import('fs');
+    fs.mkdirSync(prior, { recursive: true });
+    writeFileSync(path.join(prior, 'SKILL.md'), 'OLD CONTENT', 'utf-8');
+
+    setRoute(
+      (u) => u.includes('/SKILL.md'),
+      () => ({ status: 500, body: 'oops' }),
+    );
+
+    await expect(
+      SkillsService.installSkill({ ref: validRef, skillName: 'demo', target: projectTarget() }),
+    ).rejects.toThrow();
+
+    // Prior install survives — staging swap never happened.
+    expect(readFileSync(path.join(prior, 'SKILL.md'), 'utf-8')).toBe('OLD CONTENT');
+    // No leftover staging dirs
+    expect(readdirSync(skillsParent()).filter((n) => n.includes('.tmp-'))).toHaveLength(0);
+  });
+
+  it('removes the staging dir when a sibling fetch fails after SKILL.md succeeded', async () => {
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# Demo' }),
+    );
+    setRoute(
+      (u) => u.startsWith('https://api.github.com/'),
+      () => ({
+        body: JSON.stringify([
+          {
+            name: 'helper.md',
+            type: 'file',
+            download_url: `${RAW}/owner/repo/main/skills/demo/helper.md`,
+          },
+        ]),
+      }),
+    );
+    setRoute(
+      (u) => u.endsWith('/helper.md'),
+      () => ({ status: 503, body: 'service unavailable' }),
+    );
+
+    await expect(
+      SkillsService.installSkill({ ref: validRef, skillName: 'demo', target: projectTarget() }),
+    ).rejects.toThrow();
+
+    expect(existsSync(installDir())).toBe(false);
+    expect(readdirSync(skillsParent()).filter((n) => n.includes('.tmp-'))).toHaveLength(0);
+  });
+});
+
+describe('installSkill — security guards', () => {
+  it('refuses non-raw.githubusercontent.com download URLs', async () => {
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# Demo' }),
+    );
+    setRoute(
+      (u) => u.startsWith('https://api.github.com/'),
+      () => ({
+        body: JSON.stringify([
+          {
+            name: 'evil.md',
+            type: 'file',
+            // Different host — must be refused
+            download_url: 'https://attacker.example.com/payload.md',
+          },
+        ]),
+      }),
+    );
+
+    await expect(
+      SkillsService.installSkill({ ref: validRef, skillName: 'demo', target: projectTarget() }),
+    ).rejects.toThrow(/non-GitHub download URL/);
+    expect(existsSync(installDir())).toBe(false);
+  });
+
+  it('rejects entry names that would escape the install dir', async () => {
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# Demo' }),
+    );
+    setRoute(
+      (u) => u.startsWith('https://api.github.com/'),
+      () => ({
+        body: JSON.stringify([
+          {
+            name: '../evil.md',
+            type: 'file',
+            download_url: `${RAW}/owner/repo/main/skills/demo/evil.md`,
+          },
+        ]),
+      }),
+    );
+
+    await expect(
+      SkillsService.installSkill({ ref: validRef, skillName: 'demo', target: projectTarget() }),
+    ).rejects.toThrow(/Invalid file\/directory name/);
+  });
+
+  it('aborts when an entry reports size > MAX_FILE_BYTES', async () => {
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# Demo' }),
+    );
+    setRoute(
+      (u) => u.startsWith('https://api.github.com/'),
+      () => ({
+        body: JSON.stringify([
+          {
+            name: 'huge.md',
+            type: 'file',
+            download_url: `${RAW}/owner/repo/main/skills/demo/huge.md`,
+            size: 10 * 1024 * 1024,
+          },
+        ]),
+      }),
+    );
+
+    await expect(
+      SkillsService.installSkill({ ref: validRef, skillName: 'demo', target: projectTarget() }),
+    ).rejects.toThrow(/exceeds max size/);
+  });
+
+  it('aborts when a directory contains more than MAX_FILES_PER_SKILL files', async () => {
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# Demo' }),
+    );
+    setRoute(
+      (u) => u.startsWith('https://api.github.com/'),
+      () => ({
+        body: JSON.stringify(
+          Array.from({ length: 60 }, (_, i) => ({
+            name: `f${i}.md`,
+            type: 'file',
+            download_url: `${RAW}/owner/repo/main/skills/demo/f${i}.md`,
+          })),
+        ),
+      }),
+    );
+    setRoute(
+      (u) => /\/f\d+\.md$/.test(u),
+      () => ({ body: 'x' }),
+    );
+
+    await expect(
+      SkillsService.installSkill({ ref: validRef, skillName: 'demo', target: projectTarget() }),
+    ).rejects.toThrow(/exceeds max files/);
+  });
+
+  it('rejects invalid skill names before any fetch', async () => {
+    await expect(
+      SkillsService.installSkill({
+        ref: validRef,
+        skillName: '../evil',
+        target: projectTarget(),
+      }),
+    ).rejects.toThrow(/Invalid skill name/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects an in-flight install of the same skill', async () => {
+    let resolveSkill: (() => void) | null = null;
+    const skillBlocked = new Promise<void>((r) => {
+      resolveSkill = r;
+    });
+
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# Demo' }),
+    );
+    setRoute(
+      (u) => u.startsWith('https://api.github.com/'),
+      () => ({ body: JSON.stringify([]) }),
+    );
+
+    // Block the SKILL.md fetch by hijacking the implementation for this test only.
+    fetchSpy.mockImplementationOnce(async (input) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : '';
+      if (url.endsWith('/SKILL.md')) {
+        await skillBlocked;
+        return new Response('# Demo', { status: 200 });
+      }
+      return new Response(JSON.stringify([]), { status: 200 });
+    });
+
+    const first = SkillsService.installSkill({
+      ref: validRef,
+      skillName: 'demo',
+      target: projectTarget(),
+    });
+
+    // Second install for the SAME (skill, target) should be rejected immediately.
+    await expect(
+      SkillsService.installSkill({
+        ref: validRef,
+        skillName: 'demo',
+        target: projectTarget(),
+      }),
+    ).rejects.toThrow(/already in progress/);
+
+    resolveSkill!();
+    await first;
+  });
+});

--- a/src/main/services/__tests__/skillsInstall.test.ts
+++ b/src/main/services/__tests__/skillsInstall.test.ts
@@ -638,3 +638,168 @@ describe('listInstalled — externally-installed registry skills', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 });
+
+// Marker corruption is its own failure mode: ENOENT means "user's custom skill", but a
+// truncated/parse-failing/version-mismatched marker means "Dash install gone wrong".
+// The earlier null-on-any-failure shape collapsed the two, leading to contradictory UX
+// (checkInstalled said "not installed" but installSkill refused with "already exists").
+describe('installSkill — corrupt marker handling', () => {
+  function writeMarker(skillDir: string, raw: string) {
+    writeFileSync(path.join(skillDir, '.dash-skill.json'), raw, 'utf-8');
+  }
+
+  it.each([
+    ['truncated json', 'not-json'],
+    ['version mismatch', JSON.stringify({ version: 999, repo: 'a/b', branch: 'main', path: 'p' })],
+    [
+      'missing field',
+      JSON.stringify({ version: 1, repo: 'a/b', branch: 'main' /* path missing */ }),
+    ],
+  ])('rejects install with a clear message when marker is %s', async (_label, body) => {
+    const prior = installDir();
+    mkdirSync(prior, { recursive: true });
+    writeFileSync(path.join(prior, 'SKILL.md'), 'OLD', 'utf-8');
+    writeMarker(prior, body);
+
+    await expect(
+      SkillsService.installSkill({ ref: validRef, skillName: 'demo', target: projectTarget() }),
+    ).rejects.toThrow(/marker.*corrupt|Click Uninstall/i);
+
+    // Untouched: the precondition aborted before the staging swap.
+    expect(readFileSync(path.join(prior, 'SKILL.md'), 'utf-8')).toBe('OLD');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('checkInstalled — corrupt marker surfaces probe failure', () => {
+  it('reports marker-corrupt when the ref is supplied and the marker is unparseable', () => {
+    const dir = path.join(tmpRoot, '.claude', 'skills', 'demo');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, 'SKILL.md'), '# whatever', 'utf-8');
+    writeFileSync(path.join(dir, '.dash-skill.json'), 'not-json', 'utf-8');
+
+    const status = SkillsService.checkInstalled('demo', [tmpRoot], {
+      repo: 'owner/repo',
+      branch: 'main',
+      path: 'skills/demo',
+    });
+
+    expect(status.installedPaths).toEqual([]);
+    expect(status.probeFailures).toBeDefined();
+    expect(status.probeFailures?.[0]).toMatchObject({
+      scope: 'path',
+      path: tmpRoot,
+      code: 'marker-corrupt',
+    });
+  });
+
+  it('reports marker-corrupt under global scope when the global marker is bad', () => {
+    // Drive the home dir to tmpRoot so we don't touch the real user's filesystem.
+    const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmpRoot);
+    try {
+      const dir = path.join(tmpRoot, '.claude', 'skills', 'demo');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(path.join(dir, 'SKILL.md'), '# whatever', 'utf-8');
+      writeFileSync(
+        path.join(dir, '.dash-skill.json'),
+        JSON.stringify({ version: 99, repo: 'a/b', branch: 'main', path: 'p' }),
+        'utf-8',
+      );
+
+      const status = SkillsService.checkInstalled('demo', [], {
+        repo: 'owner/repo',
+        branch: 'main',
+        path: 'skills/demo',
+      });
+
+      expect(status.global).toBe(false);
+      expect(status.probeFailures?.[0]).toEqual({ scope: 'global', code: 'marker-corrupt' });
+    } finally {
+      homeSpy.mockRestore();
+    }
+  });
+});
+
+describe('listInstalled — corrupt sentinel re-fetches and rewrites', () => {
+  function stubCatalog(skills: RegistrySkill[]) {
+    return vi.spyOn(SkillsCache, 'allSkills').mockReturnValue(skills);
+  }
+
+  function makeRegistrySkill(over: Partial<RegistrySkill> = {}): RegistrySkill {
+    return {
+      name: 'demo',
+      description: '',
+      repo: 'someone/skills',
+      path: 'skills/demo',
+      branch: 'main',
+      category: '',
+      tags: [],
+      stars: 0,
+      ...over,
+    };
+  }
+
+  it('re-checks an orphan with an unparseable sentinel and rewrites it', async () => {
+    stubCatalog([makeRegistrySkill({ name: 'demo' })]);
+    const dir = path.join(tmpRoot, '.claude', 'skills', 'demo');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, 'SKILL.md'), '# user custom', 'utf-8');
+    writeFileSync(path.join(dir, '.dash-skill-checked.json'), 'broken-sentinel{', 'utf-8');
+
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# upstream different' }),
+    );
+
+    await SkillsService.listInstalled([tmpRoot]);
+
+    // The sentinel was unreadable, so we should have re-fetched and rewritten it.
+    expect(fetchSpy).toHaveBeenCalled();
+    const sentinel = JSON.parse(readFileSync(path.join(dir, '.dash-skill-checked.json'), 'utf-8'));
+    expect(sentinel.version).toBe(1);
+    expect(typeof sentinel.contentSha256).toBe('string');
+  });
+
+  it('one slow/failing skill does not blank the entire installed list', async () => {
+    // Two distinct catalog entries → two parallel orphans. The first errors mid-fetch;
+    // the second must still complete and its row must come back bound.
+    // Drive home to tmpRoot so we don't pick up the developer's real ~/.claude/skills.
+    const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmpRoot);
+    try {
+      stubCatalog([
+        makeRegistrySkill({ name: 'demo', path: 'skills/demo' }),
+        makeRegistrySkill({ name: 'other', repo: 'someone/skills', path: 'skills/other' }),
+      ]);
+      const demoDir = path.join(tmpRoot, '.claude', 'skills', 'demo');
+      const otherDir = path.join(tmpRoot, '.claude', 'skills', 'other');
+      mkdirSync(demoDir, { recursive: true });
+      mkdirSync(otherDir, { recursive: true });
+      writeFileSync(path.join(demoDir, 'SKILL.md'), '# demo content', 'utf-8');
+      writeFileSync(path.join(otherDir, 'SKILL.md'), '# other content', 'utf-8');
+
+      setRoute(
+        (u) => u.includes('skills/demo/SKILL.md'),
+        () => ({ status: 503, body: 'oops' }),
+      );
+      setRoute(
+        (u) => u.includes('skills/other/SKILL.md'),
+        () => ({ body: '# other content' }),
+      );
+
+      // Pass tmpRoot as a project probe AND lean on the homedir mock for global probe —
+      // both rows show up but without the user's real installed skills bleeding in.
+      const result = await SkillsService.listInstalled([tmpRoot]);
+
+      // Both skills appear in the result; the failing one falls through to Custom.
+      const demo = result.skills.find((s) => s.skillName === 'demo');
+      const other = result.skills.find((s) => s.skillName === 'other');
+      expect(demo).toBeDefined();
+      expect(other).toBeDefined();
+      expect(other?.catalog?.repo).toBe('someone/skills');
+      // Marker present for the one that succeeded.
+      expect(existsSync(path.join(otherDir, '.dash-skill.json'))).toBe(true);
+    } finally {
+      homeSpy.mockRestore();
+    }
+  });
+});

--- a/src/main/services/__tests__/skillsInstall.test.ts
+++ b/src/main/services/__tests__/skillsInstall.test.ts
@@ -32,6 +32,8 @@ vi.mock('better-sqlite3', () => ({
 }));
 
 import { SkillsService } from '../SkillsService';
+import { SkillsCache } from '../skillsCache';
+import type { RegistrySkill } from '@shared/types';
 
 const RAW = 'https://raw.githubusercontent.com';
 const validRef = { repo: 'owner/repo', branch: 'main', path: 'skills/demo' };
@@ -496,5 +498,92 @@ describe('checkInstalled — marker matching', () => {
     const status = SkillsService.checkInstalled('validate', [tmpRoot]);
 
     expect(status.installedPaths).toEqual([tmpRoot]);
+  });
+});
+
+describe('listInstalled — legacy marker backfill', () => {
+  // Catalog rows the backfill will see. SkillsCache.allSkills is module-level and
+  // returns [] under our better-sqlite3 mock, so we override per-test.
+  function stubCatalog(skills: RegistrySkill[]) {
+    return vi.spyOn(SkillsCache, 'allSkills').mockReturnValue(skills);
+  }
+
+  function makeRegistrySkill(over: Partial<RegistrySkill> = {}): RegistrySkill {
+    return {
+      name: 'demo',
+      description: '',
+      repo: 'someone/skills',
+      path: 'skills/demo',
+      branch: 'main',
+      category: '',
+      tags: [],
+      stars: 0,
+      ...over,
+    };
+  }
+
+  function legacyInstall(folderName: string, content: string) {
+    const dir = path.join(tmpRoot, '.claude', 'skills', folderName);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, 'SKILL.md'), content, 'utf-8');
+    return dir;
+  }
+
+  it('backfills the marker when SKILL.md matches the unique registry candidate', async () => {
+    stubCatalog([makeRegistrySkill({ name: 'demo' })]);
+    const dir = legacyInstall('demo', '# Demo content');
+
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# Demo content' }),
+    );
+
+    const result = await SkillsService.listInstalled([tmpRoot]);
+
+    const marker = JSON.parse(readFileSync(path.join(dir, '.dash-skill.json'), 'utf-8'));
+    expect(marker.repo).toBe('someone/skills');
+    expect(marker.path).toBe('skills/demo');
+    expect(result.skills[0].catalog?.repo).toBe('someone/skills');
+  });
+
+  it('leaves the install Custom when SKILL.md differs from the registry candidate', async () => {
+    stubCatalog([makeRegistrySkill({ name: 'demo' })]);
+    const dir = legacyInstall('demo', '# I edited this');
+
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# Different upstream content' }),
+    );
+
+    const result = await SkillsService.listInstalled([tmpRoot]);
+
+    expect(existsSync(path.join(dir, '.dash-skill.json'))).toBe(false);
+    expect(result.skills[0].catalog).toBeNull();
+  });
+
+  it('does not backfill when multiple registry skills match the folder name', async () => {
+    // Two registry skills both derive to "demo" — ambiguous, can't safely guess.
+    stubCatalog([
+      makeRegistrySkill({ repo: 'one/skills', path: 'skills/demo' }),
+      makeRegistrySkill({ repo: 'two/skills', path: 'demo' }),
+    ]);
+    const dir = legacyInstall('demo', 'whatever');
+
+    const result = await SkillsService.listInstalled([tmpRoot]);
+
+    expect(existsSync(path.join(dir, '.dash-skill.json'))).toBe(false);
+    expect(result.skills[0].catalog).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not backfill when no registry candidate matches', async () => {
+    stubCatalog([makeRegistrySkill({ name: 'pdf-extract' })]);
+    const dir = legacyInstall('validate', '# user custom skill');
+
+    const result = await SkillsService.listInstalled([tmpRoot]);
+
+    expect(existsSync(path.join(dir, '.dash-skill.json'))).toBe(false);
+    expect(result.skills[0].catalog).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/main/services/__tests__/skillsInstall.test.ts
+++ b/src/main/services/__tests__/skillsInstall.test.ts
@@ -32,8 +32,6 @@ vi.mock('better-sqlite3', () => ({
 }));
 
 import { SkillsService } from '../SkillsService';
-import { SkillsCache } from '../skillsCache';
-import type { RegistrySkill } from '@shared/types';
 
 const RAW = 'https://raw.githubusercontent.com';
 const validRef = { repo: 'owner/repo', branch: 'main', path: 'skills/demo' };
@@ -498,92 +496,5 @@ describe('checkInstalled — marker matching', () => {
     const status = SkillsService.checkInstalled('validate', [tmpRoot]);
 
     expect(status.installedPaths).toEqual([tmpRoot]);
-  });
-});
-
-describe('listInstalled — legacy marker backfill', () => {
-  // Catalog rows the backfill will see. SkillsCache.allSkills is module-level and
-  // returns [] under our better-sqlite3 mock, so we override per-test.
-  function stubCatalog(skills: RegistrySkill[]) {
-    return vi.spyOn(SkillsCache, 'allSkills').mockReturnValue(skills);
-  }
-
-  function makeRegistrySkill(over: Partial<RegistrySkill> = {}): RegistrySkill {
-    return {
-      name: 'demo',
-      description: '',
-      repo: 'someone/skills',
-      path: 'skills/demo',
-      branch: 'main',
-      category: '',
-      tags: [],
-      stars: 0,
-      ...over,
-    };
-  }
-
-  function legacyInstall(folderName: string, content: string) {
-    const dir = path.join(tmpRoot, '.claude', 'skills', folderName);
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(path.join(dir, 'SKILL.md'), content, 'utf-8');
-    return dir;
-  }
-
-  it('backfills the marker when SKILL.md matches the unique registry candidate', async () => {
-    stubCatalog([makeRegistrySkill({ name: 'demo' })]);
-    const dir = legacyInstall('demo', '# Demo content');
-
-    setRoute(
-      (u) => u.endsWith('/SKILL.md'),
-      () => ({ body: '# Demo content' }),
-    );
-
-    const result = await SkillsService.listInstalled([tmpRoot]);
-
-    const marker = JSON.parse(readFileSync(path.join(dir, '.dash-skill.json'), 'utf-8'));
-    expect(marker.repo).toBe('someone/skills');
-    expect(marker.path).toBe('skills/demo');
-    expect(result.skills[0].catalog?.repo).toBe('someone/skills');
-  });
-
-  it('leaves the install Custom when SKILL.md differs from the registry candidate', async () => {
-    stubCatalog([makeRegistrySkill({ name: 'demo' })]);
-    const dir = legacyInstall('demo', '# I edited this');
-
-    setRoute(
-      (u) => u.endsWith('/SKILL.md'),
-      () => ({ body: '# Different upstream content' }),
-    );
-
-    const result = await SkillsService.listInstalled([tmpRoot]);
-
-    expect(existsSync(path.join(dir, '.dash-skill.json'))).toBe(false);
-    expect(result.skills[0].catalog).toBeNull();
-  });
-
-  it('does not backfill when multiple registry skills match the folder name', async () => {
-    // Two registry skills both derive to "demo" — ambiguous, can't safely guess.
-    stubCatalog([
-      makeRegistrySkill({ repo: 'one/skills', path: 'skills/demo' }),
-      makeRegistrySkill({ repo: 'two/skills', path: 'demo' }),
-    ]);
-    const dir = legacyInstall('demo', 'whatever');
-
-    const result = await SkillsService.listInstalled([tmpRoot]);
-
-    expect(existsSync(path.join(dir, '.dash-skill.json'))).toBe(false);
-    expect(result.skills[0].catalog).toBeNull();
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  it('does not backfill when no registry candidate matches', async () => {
-    stubCatalog([makeRegistrySkill({ name: 'pdf-extract' })]);
-    const dir = legacyInstall('validate', '# user custom skill');
-
-    const result = await SkillsService.listInstalled([tmpRoot]);
-
-    expect(existsSync(path.join(dir, '.dash-skill.json'))).toBe(false);
-    expect(result.skills[0].catalog).toBeNull();
-    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/main/services/__tests__/skillsInstall.test.ts
+++ b/src/main/services/__tests__/skillsInstall.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
 import os from 'os';
 import path from 'path';
-import { mkdtempSync, rmSync, existsSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  mkdirSync,
+} from 'fs';
 
 // Verifies the install pipeline's load-bearing invariants:
 //   - atomic staging swap (mid-install failures don't leave half-installed skills)
@@ -117,11 +125,23 @@ describe('installSkill — happy path', () => {
 
 describe('installSkill — staging cleanup on failure', () => {
   it('removes the staging dir and preserves a prior install when the SKILL.md fetch fails', async () => {
-    // Pre-existing install we expect to survive
+    // Pre-existing install we expect to survive. Tag it with a Dash marker so the
+    // install precondition allows the swap path to be exercised — without a marker
+    // the install would refuse before any fetch happens (covered separately below).
     const prior = installDir();
-    const fs = await import('fs');
-    fs.mkdirSync(prior, { recursive: true });
+    mkdirSync(prior, { recursive: true });
     writeFileSync(path.join(prior, 'SKILL.md'), 'OLD CONTENT', 'utf-8');
+    writeFileSync(
+      path.join(prior, '.dash-skill.json'),
+      JSON.stringify({
+        version: 1,
+        repo: 'owner/repo',
+        branch: 'main',
+        path: 'skills/demo',
+        installedAt: 0,
+      }),
+      'utf-8',
+    );
 
     setRoute(
       (u) => u.includes('/SKILL.md'),
@@ -322,5 +342,159 @@ describe('installSkill — security guards', () => {
 
     resolveSkill!();
     await first;
+  });
+});
+
+describe('installSkill — marker / custom-skill protection', () => {
+  it('refuses to overwrite an existing dir that has no Dash marker', async () => {
+    // User's pre-existing custom skill: a SKILL.md, no marker file.
+    const prior = installDir();
+    mkdirSync(prior, { recursive: true });
+    writeFileSync(path.join(prior, 'SKILL.md'), 'CUSTOM USER CONTENT', 'utf-8');
+
+    await expect(
+      SkillsService.installSkill({ ref: validRef, skillName: 'demo', target: projectTarget() }),
+    ).rejects.toThrow(/not installed by Dash/);
+
+    // The user's data must survive untouched.
+    expect(readFileSync(path.join(prior, 'SKILL.md'), 'utf-8')).toBe('CUSTOM USER CONTENT');
+    // No fetches should have happened — we refused before any network call.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('writes a marker carrying the registry coordinates after a successful install', async () => {
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# Demo' }),
+    );
+    setRoute(
+      (u) => u.startsWith('https://api.github.com/'),
+      () => ({ body: JSON.stringify([]) }),
+    );
+
+    await SkillsService.installSkill({ ref: validRef, skillName: 'demo', target: projectTarget() });
+
+    const markerText = readFileSync(path.join(installDir(), '.dash-skill.json'), 'utf-8');
+    const marker = JSON.parse(markerText);
+    expect(marker.version).toBe(1);
+    expect(marker.repo).toBe(validRef.repo);
+    expect(marker.path).toBe(validRef.path);
+    expect(marker.branch).toBe(validRef.branch);
+    expect(typeof marker.installedAt).toBe('number');
+  });
+
+  it('allows reinstalling over an existing Dash install (marker present)', async () => {
+    const prior = installDir();
+    mkdirSync(prior, { recursive: true });
+    writeFileSync(path.join(prior, 'SKILL.md'), 'OLD', 'utf-8');
+    writeFileSync(
+      path.join(prior, '.dash-skill.json'),
+      JSON.stringify({
+        version: 1,
+        repo: 'owner/repo',
+        branch: 'main',
+        path: 'skills/demo',
+        installedAt: 0,
+      }),
+      'utf-8',
+    );
+
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# NEW' }),
+    );
+    setRoute(
+      (u) => u.startsWith('https://api.github.com/'),
+      () => ({ body: JSON.stringify([]) }),
+    );
+
+    await SkillsService.installSkill({ ref: validRef, skillName: 'demo', target: projectTarget() });
+
+    expect(readFileSync(path.join(installDir(), 'SKILL.md'), 'utf-8')).toBe('# NEW');
+    // Fresh marker should have been written (installedAt > 0).
+    const marker = JSON.parse(readFileSync(path.join(installDir(), '.dash-skill.json'), 'utf-8'));
+    expect(marker.installedAt).toBeGreaterThan(0);
+  });
+});
+
+describe('checkInstalled — marker matching', () => {
+  function setupCustomSkill() {
+    // Mimic the user's custom skill: bare SKILL.md, no marker, in the project's scope.
+    const customDir = path.join(tmpRoot, '.claude', 'skills', 'validate');
+    mkdirSync(customDir, { recursive: true });
+    writeFileSync(path.join(customDir, 'SKILL.md'), '# User custom validate', 'utf-8');
+    return customDir;
+  }
+
+  it('does NOT report a registry skill as installed when a same-named custom folder exists', () => {
+    setupCustomSkill();
+
+    const status = SkillsService.checkInstalled(
+      'validate',
+      [tmpRoot],
+      // Registry coordinates for some "validate" skill from anywhere
+      { repo: 'someone/skills', branch: 'main', path: 'skills/validate' },
+    );
+
+    expect(status.global).toBe(false);
+    expect(status.installedPaths).toEqual([]);
+  });
+
+  it('reports a registry skill as installed when the marker matches the ref', () => {
+    const dir = path.join(tmpRoot, '.claude', 'skills', 'validate');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, 'SKILL.md'), '# Registry', 'utf-8');
+    writeFileSync(
+      path.join(dir, '.dash-skill.json'),
+      JSON.stringify({
+        version: 1,
+        repo: 'someone/skills',
+        branch: 'main',
+        path: 'skills/validate',
+        installedAt: 1,
+      }),
+      'utf-8',
+    );
+
+    const status = SkillsService.checkInstalled('validate', [tmpRoot], {
+      repo: 'someone/skills',
+      branch: 'main',
+      path: 'skills/validate',
+    });
+
+    expect(status.installedPaths).toEqual([tmpRoot]);
+  });
+
+  it('does NOT report installed when the marker is for a different registry skill', () => {
+    const dir = path.join(tmpRoot, '.claude', 'skills', 'validate');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, 'SKILL.md'), '# Different', 'utf-8');
+    writeFileSync(
+      path.join(dir, '.dash-skill.json'),
+      JSON.stringify({
+        version: 1,
+        repo: 'other/skills',
+        branch: 'main',
+        path: 'skills/validate',
+        installedAt: 1,
+      }),
+      'utf-8',
+    );
+
+    const status = SkillsService.checkInstalled('validate', [tmpRoot], {
+      repo: 'someone/skills',
+      branch: 'main',
+      path: 'skills/validate',
+    });
+
+    expect(status.installedPaths).toEqual([]);
+  });
+
+  it('falls back to presence-only when no ref is provided (legacy callers)', () => {
+    setupCustomSkill();
+
+    const status = SkillsService.checkInstalled('validate', [tmpRoot]);
+
+    expect(status.installedPaths).toEqual([tmpRoot]);
   });
 });

--- a/src/main/services/__tests__/skillsInstall.test.ts
+++ b/src/main/services/__tests__/skillsInstall.test.ts
@@ -31,7 +31,10 @@ vi.mock('better-sqlite3', () => ({
   })),
 }));
 
+import { createHash } from 'crypto';
 import { SkillsService } from '../SkillsService';
+import { SkillsCache } from '../skillsCache';
+import type { RegistrySkill } from '@shared/types';
 
 const RAW = 'https://raw.githubusercontent.com';
 const validRef = { repo: 'owner/repo', branch: 'main', path: 'skills/demo' };
@@ -496,5 +499,142 @@ describe('checkInstalled — marker matching', () => {
     const status = SkillsService.checkInstalled('validate', [tmpRoot]);
 
     expect(status.installedPaths).toEqual([tmpRoot]);
+  });
+});
+
+describe('listInstalled — externally-installed registry skills', () => {
+  function stubCatalog(skills: RegistrySkill[]) {
+    return vi.spyOn(SkillsCache, 'allSkills').mockReturnValue(skills);
+  }
+
+  function makeRegistrySkill(over: Partial<RegistrySkill> = {}): RegistrySkill {
+    return {
+      name: 'demo',
+      description: '',
+      repo: 'someone/skills',
+      path: 'skills/demo',
+      branch: 'main',
+      category: '',
+      tags: [],
+      stars: 0,
+      ...over,
+    };
+  }
+
+  function externalInstall(folderName: string, content: string) {
+    const dir = path.join(tmpRoot, '.claude', 'skills', folderName);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, 'SKILL.md'), content, 'utf-8');
+    return dir;
+  }
+
+  function sha256(s: string): string {
+    return createHash('sha256').update(s).digest('hex');
+  }
+
+  it('binds the marker when SKILL.md byte-matches the unique registry candidate', async () => {
+    stubCatalog([makeRegistrySkill({ name: 'demo' })]);
+    const dir = externalInstall('demo', '# Demo content');
+
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# Demo content' }),
+    );
+
+    const result = await SkillsService.listInstalled([tmpRoot]);
+
+    const marker = JSON.parse(readFileSync(path.join(dir, '.dash-skill.json'), 'utf-8'));
+    expect(marker.repo).toBe('someone/skills');
+    expect(marker.path).toBe('skills/demo');
+    expect(result.skills[0].catalog?.repo).toBe('someone/skills');
+    // No verified-custom sentinel when we bound successfully.
+    expect(existsSync(path.join(dir, '.dash-skill-checked.json'))).toBe(false);
+  });
+
+  it('writes a verified-custom sentinel keyed by content hash on no-match', async () => {
+    stubCatalog([makeRegistrySkill({ name: 'demo' })]);
+    const localContent = '# I edited this';
+    const dir = externalInstall('demo', localContent);
+
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# Different upstream content' }),
+    );
+
+    const result = await SkillsService.listInstalled([tmpRoot]);
+
+    expect(existsSync(path.join(dir, '.dash-skill.json'))).toBe(false);
+    expect(result.skills[0].catalog).toBeNull();
+
+    const sentinel = JSON.parse(readFileSync(path.join(dir, '.dash-skill-checked.json'), 'utf-8'));
+    expect(sentinel.contentSha256).toBe(sha256(localContent));
+  });
+
+  it('skips the fetch on later listInstalled calls when the sentinel hash still matches', async () => {
+    stubCatalog([makeRegistrySkill({ name: 'demo' })]);
+    externalInstall('demo', '# user custom');
+
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# different upstream' }),
+    );
+
+    await SkillsService.listInstalled([tmpRoot]);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Second call must NOT refetch — sentinel says we already checked this content.
+    fetchSpy.mockClear();
+    await SkillsService.listInstalled([tmpRoot]);
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('re-checks when the user has edited the local SKILL.md since the sentinel was written', async () => {
+    stubCatalog([makeRegistrySkill({ name: 'demo' })]);
+    const dir = externalInstall('demo', '# v1 user content');
+
+    // First pass: registry returns something different → sentinel written for v1 hash.
+    setRoute(
+      (u) => u.endsWith('/SKILL.md'),
+      () => ({ body: '# upstream' }),
+    );
+    await SkillsService.listInstalled([tmpRoot]);
+    expect(existsSync(path.join(dir, '.dash-skill-checked.json'))).toBe(true);
+
+    // User edits the file. Sentinel hash no longer matches local content.
+    writeFileSync(path.join(dir, 'SKILL.md'), '# upstream', 'utf-8');
+
+    // Second pass: registry happens to match the new local content → bind.
+    fetchSpy.mockClear();
+    await SkillsService.listInstalled([tmpRoot]);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(existsSync(path.join(dir, '.dash-skill.json'))).toBe(true);
+  });
+
+  it('does not bind when multiple registry skills derive to the same name', async () => {
+    stubCatalog([
+      makeRegistrySkill({ repo: 'one/skills', path: 'skills/demo' }),
+      makeRegistrySkill({ repo: 'two/skills', path: 'demo' }),
+    ]);
+    const dir = externalInstall('demo', 'whatever');
+
+    const result = await SkillsService.listInstalled([tmpRoot]);
+
+    expect(existsSync(path.join(dir, '.dash-skill.json'))).toBe(false);
+    expect(existsSync(path.join(dir, '.dash-skill-checked.json'))).toBe(false);
+    expect(result.skills[0].catalog).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not bind or fetch when no registry candidate matches the folder name', async () => {
+    stubCatalog([makeRegistrySkill({ name: 'pdf-extract' })]);
+    const dir = externalInstall('validate', '# user custom');
+
+    const result = await SkillsService.listInstalled([tmpRoot]);
+
+    expect(existsSync(path.join(dir, '.dash-skill.json'))).toBe(false);
+    expect(existsSync(path.join(dir, '.dash-skill-checked.json'))).toBe(false);
+    expect(result.skills[0].catalog).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/main/services/__tests__/skillsPathValidation.test.ts
+++ b/src/main/services/__tests__/skillsPathValidation.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+
+// Path validators are the entire defence between attacker-controlled registry data
+// (`name`, `repo`, `path`, GitHub API `entry.name`) and arbitrary file writes anywhere
+// on the user's filesystem. A regression here writes attacker bytes to ~/.ssh/authorized_keys
+// or ~/.zshrc. Test the validators directly so a refactor can't quietly relax them.
+
+vi.mock('electron', () => ({
+  default: {},
+  app: { getPath: () => os.tmpdir() },
+}));
+vi.mock('better-sqlite3', () => ({
+  default: vi.fn(() => ({
+    pragma: vi.fn(),
+    exec: vi.fn(),
+    prepare: vi.fn(() => ({ get: () => undefined, all: () => [], run: vi.fn() })),
+    transaction: (fn: (...args: unknown[]) => unknown) => fn,
+    close: vi.fn(),
+  })),
+}));
+
+import { assertSkillName, assertRef, resolveInstallDir, resolveChildPath } from '../SkillsService';
+
+describe('assertSkillName', () => {
+  it('accepts valid lowercase-kebab names', () => {
+    expect(() => assertSkillName('pdf-extract')).not.toThrow();
+    expect(() => assertSkillName('a')).not.toThrow();
+    expect(() => assertSkillName('skill-1')).not.toThrow();
+  });
+
+  it('rejects path traversal', () => {
+    expect(() => assertSkillName('../etc/passwd')).toThrow(/Invalid skill name/);
+    expect(() => assertSkillName('..')).toThrow(/Invalid skill name/);
+    expect(() => assertSkillName('foo/bar')).toThrow(/Invalid skill name/);
+    expect(() => assertSkillName('foo\\bar')).toThrow(/Invalid skill name/);
+  });
+
+  it('rejects null bytes and whitespace', () => {
+    expect(() => assertSkillName('foo\0bar')).toThrow(/Invalid skill name/);
+    expect(() => assertSkillName('foo bar')).toThrow(/Invalid skill name/);
+    expect(() => assertSkillName('foo\tbar')).toThrow(/Invalid skill name/);
+    expect(() => assertSkillName('foo\nbar')).toThrow(/Invalid skill name/);
+  });
+
+  it('rejects uppercase and non-ASCII', () => {
+    expect(() => assertSkillName('FooBar')).toThrow(/Invalid skill name/);
+    expect(() => assertSkillName('skíll')).toThrow(/Invalid skill name/);
+  });
+
+  it('rejects names that do not start with a letter or digit', () => {
+    expect(() => assertSkillName('-leading-dash')).toThrow(/Invalid skill name/);
+    expect(() => assertSkillName('.dotfile')).toThrow(/Invalid skill name/);
+  });
+
+  it('rejects empty and over-long names', () => {
+    expect(() => assertSkillName('')).toThrow(/Invalid skill name/);
+    expect(() => assertSkillName('a'.repeat(65))).toThrow(/Invalid skill name/);
+  });
+});
+
+describe('assertRef', () => {
+  const valid = { repo: 'owner/repo', branch: 'main', path: 'skills/foo' };
+
+  it('accepts a valid ref', () => {
+    expect(() => assertRef(valid)).not.toThrow();
+  });
+
+  it('rejects bad repos', () => {
+    expect(() => assertRef({ ...valid, repo: 'no-slash' })).toThrow(/Invalid repo/);
+    expect(() => assertRef({ ...valid, repo: 'a/b/c' })).toThrow(/Invalid repo/);
+    expect(() => assertRef({ ...valid, repo: 'has space/repo' })).toThrow(/Invalid repo/);
+    expect(() => assertRef({ ...valid, repo: 'a\0/b' })).toThrow(/Invalid repo/);
+    expect(() => assertRef({ ...valid, repo: '' })).toThrow(/Invalid repo/);
+  });
+
+  it('rejects bad branches', () => {
+    expect(() => assertRef({ ...valid, branch: 'bad branch' })).toThrow(/Invalid branch/);
+    expect(() => assertRef({ ...valid, branch: 'has\0null' })).toThrow(/Invalid branch/);
+  });
+
+  it('rejects path traversal in path segments', () => {
+    expect(() => assertRef({ ...valid, path: '../escape' })).toThrow(/Invalid skill path/);
+    expect(() => assertRef({ ...valid, path: 'skills/../../etc' })).toThrow(/Invalid skill path/);
+    expect(() => assertRef({ ...valid, path: 'skills/foo/..' })).toThrow(/Invalid skill path/);
+  });
+
+  it('rejects null bytes and disallowed chars in path segments', () => {
+    expect(() => assertRef({ ...valid, path: 'foo\0/bar' })).toThrow(/Invalid skill path/);
+    expect(() => assertRef({ ...valid, path: 'foo bar' })).toThrow(/Invalid skill path/);
+    expect(() => assertRef({ ...valid, path: 'foo?bar' })).toThrow(/Invalid skill path/);
+    expect(() => assertRef({ ...valid, path: 'foo#bar' })).toThrow(/Invalid skill path/);
+  });
+});
+
+describe('resolveInstallDir', () => {
+  it('returns a path inside the resolved base for valid inputs', () => {
+    const tmp = os.tmpdir();
+    const target = { kind: 'project' as const, projectPath: tmp };
+    const dir = resolveInstallDir(target, 'pdf-extract');
+    expect(dir).toBe(path.join(tmp, '.claude', 'skills', 'pdf-extract'));
+  });
+
+  it('rejects skill names that would escape the base via assertSkillName', () => {
+    const target = { kind: 'project' as const, projectPath: os.tmpdir() };
+    expect(() => resolveInstallDir(target, '../escape')).toThrow(/Invalid skill name/);
+  });
+
+  it('routes the global target to ~/.claude/skills', () => {
+    const dir = resolveInstallDir({ kind: 'global' }, 'pdf-extract');
+    expect(dir).toBe(path.join(os.homedir(), '.claude', 'skills', 'pdf-extract'));
+  });
+});
+
+describe('resolveChildPath', () => {
+  it('accepts entry names that stay inside the parent', () => {
+    const base = path.join(os.tmpdir(), 'skills-test');
+    expect(resolveChildPath(base, 'README.md')).toBe(path.join(base, 'README.md'));
+    expect(resolveChildPath(base, 'subdir')).toBe(path.join(base, 'subdir'));
+    expect(resolveChildPath(base, '.config')).toBe(path.join(base, '.config'));
+  });
+
+  it('rejects path-traversal entry names', () => {
+    const base = path.join(os.tmpdir(), 'skills-test');
+    // ".." passes ENTRY_NAME_RE (regex allows leading-dot tokens) but the post-resolve
+    // path.relative check still catches it. Belt-and-suspenders.
+    expect(() => resolveChildPath(base, '..')).toThrow(/escapes parent/);
+    // A name containing a slash is caught by ENTRY_NAME_RE.
+    expect(() => resolveChildPath(base, 'foo/bar')).toThrow(/Invalid file\/directory name/);
+    expect(() => resolveChildPath(base, '../escape')).toThrow(/Invalid file\/directory name/);
+  });
+
+  it('rejects null bytes and whitespace', () => {
+    const base = path.join(os.tmpdir(), 'skills-test');
+    expect(() => resolveChildPath(base, 'foo\0bar')).toThrow(/Invalid file\/directory name/);
+    expect(() => resolveChildPath(base, 'foo bar')).toThrow(/Invalid file\/directory name/);
+  });
+});

--- a/src/main/services/skillsCache.ts
+++ b/src/main/services/skillsCache.ts
@@ -1,0 +1,272 @@
+import { app } from 'electron';
+import Database from 'better-sqlite3';
+import path from 'path';
+import { mkdirSync } from 'fs';
+import type { RegistrySkill, SkillsRegistryMeta } from '@shared/types';
+
+const CACHE_FILENAME = 'skills-cache.db';
+
+let db: Database.Database | null = null;
+
+function getDb(): Database.Database {
+  if (db) return db;
+  const dir = app.getPath('userData');
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, CACHE_FILENAME);
+  db = new Database(file);
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+  ensureSchema(db);
+  return db;
+}
+
+function ensureSchema(d: Database.Database): void {
+  d.exec(`
+    CREATE TABLE IF NOT EXISTS skills (
+      repo TEXT NOT NULL,
+      path TEXT NOT NULL,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL,
+      branch TEXT NOT NULL,
+      category TEXT NOT NULL,
+      tags TEXT NOT NULL,
+      stars INTEGER NOT NULL,
+      distribution TEXT,
+      path_segment TEXT NOT NULL,
+      PRIMARY KEY (repo, path)
+    );
+
+    CREATE INDEX IF NOT EXISTS skills_category_idx ON skills(category);
+    CREATE INDEX IF NOT EXISTS skills_distribution_idx ON skills(distribution);
+    CREATE INDEX IF NOT EXISTS skills_stars_idx ON skills(stars DESC);
+
+    -- External-content FTS5: the index points at rowids in the skills table rather than
+    -- duplicating the text columns. Halves the on-disk size, but means writes to the
+    -- skills table do NOT auto-populate FTS — replaceAll must explicitly issue an
+    -- INSERT INTO skills_fts(skills_fts) VALUES("rebuild") after batch inserts.
+    CREATE VIRTUAL TABLE IF NOT EXISTS skills_fts USING fts5(
+      name,
+      description,
+      tags,
+      repo,
+      path_segment,
+      content='skills',
+      content_rowid='rowid',
+      tokenize='unicode61 remove_diacritics 1'
+    );
+
+    CREATE TABLE IF NOT EXISTS meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+  `);
+}
+
+export interface SearchArgs {
+  query: string;
+  category?: string;
+  limit: number;
+  offset: number;
+}
+
+export interface SearchResult {
+  skills: RegistrySkill[];
+  total: number;
+}
+
+interface SkillRow {
+  repo: string;
+  path: string;
+  name: string;
+  description: string;
+  branch: string;
+  category: string;
+  tags: string;
+  stars: number;
+  distribution: string | null;
+  path_segment: string;
+}
+
+function rowToSkill(r: SkillRow): RegistrySkill {
+  let tags: string[] = [];
+  try {
+    const parsed = JSON.parse(r.tags);
+    if (Array.isArray(parsed)) tags = parsed.filter((t): t is string => typeof t === 'string');
+  } catch (err) {
+    // The only writer (replaceAll below) always emits valid JSON, so this catch firing
+    // means schema corruption or a writer regression — log it loudly so we'd notice in
+    // Sentry, but degrade gracefully (tags are search-only, never load-bearing).
+    console.error('[SkillsCache.rowToSkill] invalid tags JSON', {
+      key: `${r.repo}|${r.path}`,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+  const distribution: RegistrySkill['distribution'] =
+    r.distribution === 'compatible' || r.distribution === 'restricted' ? r.distribution : undefined;
+  return {
+    name: r.name,
+    description: r.description,
+    repo: r.repo,
+    path: r.path,
+    branch: r.branch,
+    category: r.category,
+    tags,
+    stars: r.stars,
+    distribution,
+  };
+}
+
+// Last meaningful path segment: ".claude/skills/foo/SKILL.md" → "foo".
+// Used as a search-indexed fallback name for entries the registry labels "unknown".
+export function pathSegment(p: string): string {
+  const segments = p.split('/').filter(Boolean);
+  const last = segments[segments.length - 1] ?? '';
+  if (last.toLowerCase() === 'skill.md') return segments[segments.length - 2] ?? '';
+  return last;
+}
+
+// FTS5 MATCH treats certain characters as syntax. Quote each token so user input like
+// "pdf-extract" or "C++" doesn't blow up the parser; combine with implicit AND.
+function buildFtsQuery(raw: string): string {
+  const tokens = raw
+    .toLowerCase()
+    .split(/\s+/)
+    .map((t) => t.replace(/[^\w-]/g, ''))
+    .filter((t) => t.length > 0);
+  if (tokens.length === 0) return '';
+  return tokens.map((t) => `"${t}"*`).join(' ');
+}
+
+export const SkillsCache = {
+  getMeta(): SkillsRegistryMeta {
+    const d = getDb();
+    const row = d.prepare(`SELECT value FROM meta WHERE key = 'fetchedAt'`).get() as
+      | { value: string }
+      | undefined;
+    const fetchedAt = row ? Number(row.value) : null;
+    const total = d.prepare(`SELECT COUNT(*) as n FROM skills`).get() as { n: number };
+    return { fetchedAt: Number.isFinite(fetchedAt) ? fetchedAt : null, totalCount: total.n };
+  },
+
+  getCategories(): string[] {
+    const d = getDb();
+    const rows = d
+      .prepare(
+        `SELECT DISTINCT category FROM skills WHERE category != '' ORDER BY category COLLATE NOCASE`,
+      )
+      .all() as Array<{ category: string }>;
+    return rows.map((r) => r.category);
+  },
+
+  /** Returns every cached skill row. Used by listInstalled to map filesystem folder names
+   *  back to catalog entries — at 10K rows the load is ~5 ms and beats a per-name SQL
+   *  fuzzy match given the sanitization rules. */
+  allSkills(): RegistrySkill[] {
+    const d = getDb();
+    const rows = d.prepare(`SELECT * FROM skills`).all() as SkillRow[];
+    return rows.map(rowToSkill);
+  },
+
+  search(args: SearchArgs): SearchResult {
+    const d = getDb();
+    const ftsQuery = buildFtsQuery(args.query);
+    const filters: string[] = [];
+    const params: Record<string, unknown> = {
+      limit: args.limit,
+      offset: args.offset,
+    };
+    if (args.category) {
+      filters.push('s.category = @category');
+      params.category = args.category;
+    }
+
+    // Pin anthropics/skills entries first, then by FTS rank (when searching) or stars.
+    const officialOrder = `CASE WHEN s.repo = 'anthropics/skills' THEN 0 ELSE 1 END`;
+
+    let whereSql = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
+    let fromSql = `FROM skills s`;
+    let orderSql = `ORDER BY ${officialOrder}, s.stars DESC`;
+
+    if (ftsQuery) {
+      fromSql = `FROM skills_fts JOIN skills s ON s.rowid = skills_fts.rowid`;
+      const matchClause = `skills_fts MATCH @match`;
+      whereSql =
+        filters.length > 0
+          ? `WHERE ${matchClause} AND ${filters.join(' AND ')}`
+          : `WHERE ${matchClause}`;
+      params.match = ftsQuery;
+      orderSql = `ORDER BY ${officialOrder}, bm25(skills_fts), s.stars DESC`;
+    }
+
+    const totalRow = d.prepare(`SELECT COUNT(*) as n ${fromSql} ${whereSql}`).get(params) as {
+      n: number;
+    };
+    const rows = d
+      .prepare(`SELECT s.* ${fromSql} ${whereSql} ${orderSql} LIMIT @limit OFFSET @offset`)
+      .all(params) as SkillRow[];
+
+    return { skills: rows.map(rowToSkill), total: totalRow.n };
+  },
+
+  /**
+   * Atomic replace: drop all existing rows, insert the new batch in one transaction,
+   * rebuild the FTS index, stamp meta. If the caller throws mid-stream, the transaction
+   * rolls back and the previous cache is preserved.
+   */
+  replaceAll(skills: readonly RegistrySkill[]): { inserted: number } {
+    const d = getDb();
+    const insert = d.prepare(`
+      INSERT OR REPLACE INTO skills
+        (repo, path, name, description, branch, category, tags, stars, distribution, path_segment)
+      VALUES
+        (@repo, @path, @name, @description, @branch, @category, @tags, @stars, @distribution, @path_segment)
+    `);
+
+    const txn = d.transaction((batch: readonly RegistrySkill[]) => {
+      d.exec(`DELETE FROM skills_fts; DELETE FROM skills;`);
+      let count = 0;
+      for (const s of batch) {
+        if (!s.name || !s.repo || !s.path) continue;
+        insert.run({
+          repo: s.repo,
+          path: s.path,
+          name: s.name,
+          description: s.description ?? '',
+          branch: s.branch || 'main',
+          category: s.category ?? '',
+          tags: JSON.stringify(Array.isArray(s.tags) ? s.tags : []),
+          stars: s.stars ?? 0,
+          distribution:
+            s.distribution === 'compatible' || s.distribution === 'restricted'
+              ? s.distribution
+              : null,
+          path_segment: pathSegment(s.path),
+        });
+        count += 1;
+      }
+      d.exec(`INSERT INTO skills_fts(skills_fts) VALUES('rebuild');`);
+      return count;
+    });
+
+    const inserted = txn(skills);
+    // Only stamp fetchedAt on a successful, non-empty refresh. If the upstream payload
+    // ever yields 0 valid rows, leaving fetchedAt unchanged means the next modal open
+    // re-runs the refresh instead of treating an empty cache as "fresh".
+    if (inserted > 0) this.setMeta({ fetchedAt: Date.now() });
+    return { inserted };
+  },
+
+  setMeta(values: Record<string, string | number>): void {
+    const d = getDb();
+    const stmt = d.prepare(`INSERT OR REPLACE INTO meta (key, value) VALUES (@key, @value)`);
+    const txn = d.transaction((entries: Array<[string, string]>) => {
+      for (const [k, v] of entries) stmt.run({ key: k, value: v });
+    });
+    txn(Object.entries(values).map(([k, v]) => [k, String(v)]));
+  },
+
+  // For tests / dev: returns the underlying DB. Not exported through the service.
+  _db(): Database.Database {
+    return getDb();
+  },
+};

--- a/src/main/services/skillsCache.ts
+++ b/src/main/services/skillsCache.ts
@@ -1,23 +1,60 @@
 import { app } from 'electron';
 import Database from 'better-sqlite3';
 import path from 'path';
-import { mkdirSync } from 'fs';
+import { mkdirSync, rmSync } from 'fs';
 import type { RegistrySkill, SkillsRegistryMeta } from '@shared/types';
 
 const CACHE_FILENAME = 'skills-cache.db';
 
 let db: Database.Database | null = null;
 
-function getDb(): Database.Database {
-  if (db) return db;
+function dbFilePath(): string {
   const dir = app.getPath('userData');
   mkdirSync(dir, { recursive: true });
-  const file = path.join(dir, CACHE_FILENAME);
-  db = new Database(file);
+  return path.join(dir, CACHE_FILENAME);
+}
+
+function getDb(): Database.Database {
+  if (db) return db;
+  db = new Database(dbFilePath());
   db.pragma('journal_mode = WAL');
   db.pragma('synchronous = NORMAL');
   ensureSchema(db);
   return db;
+}
+
+function closeDb(): void {
+  if (!db) return;
+  try {
+    db.close();
+  } catch (err) {
+    console.error('[SkillsCache.closeDb] close failed', { message: String(err) });
+  }
+  db = null;
+}
+
+// better-sqlite3 throws a `SqliteError` (extends Error with a `code` like SQLITE_CORRUPT,
+// SQLITE_NOTADB, etc). Match by name/code so we don't swallow unrelated bugs.
+function isSqliteError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === 'SqliteError') return true;
+  return typeof (err as { code?: unknown }).code === 'string';
+}
+
+// SQLite ops that hit corruption leave the memoized handle in a possibly-bad state.
+// Drop it and retry once on the failing op; if it still throws, surface to the caller
+// so the UI can offer the manual `resetCache` affordance.
+function withRetry<T>(op: (d: Database.Database) => T): T {
+  try {
+    return op(getDb());
+  } catch (err) {
+    if (!isSqliteError(err)) throw err;
+    console.error('[SkillsCache.withRetry] sqlite op failed; resetting handle', {
+      message: err instanceof Error ? err.message : String(err),
+    });
+    closeDb();
+    return op(getDb());
+  }
 }
 
 function ensureSchema(d: Database.Database): void {
@@ -137,75 +174,106 @@ function buildFtsQuery(raw: string): string {
   return tokens.map((t) => `"${t}"*`).join(' ');
 }
 
+function searchImpl(d: Database.Database, args: SearchArgs): SearchResult {
+  const ftsQuery = buildFtsQuery(args.query);
+  const filters: string[] = [];
+  const params: Record<string, unknown> = {
+    limit: args.limit,
+    offset: args.offset,
+  };
+  if (args.category) {
+    filters.push('s.category = @category');
+    params.category = args.category;
+  }
+
+  const officialOrder = `CASE WHEN s.repo = 'anthropics/skills' THEN 0 ELSE 1 END`;
+
+  let whereSql = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
+  let fromSql = `FROM skills s`;
+  let orderSql = `ORDER BY ${officialOrder}, s.stars DESC`;
+
+  if (ftsQuery) {
+    fromSql = `FROM skills_fts JOIN skills s ON s.rowid = skills_fts.rowid`;
+    const matchClause = `skills_fts MATCH @match`;
+    whereSql =
+      filters.length > 0
+        ? `WHERE ${matchClause} AND ${filters.join(' AND ')}`
+        : `WHERE ${matchClause}`;
+    params.match = ftsQuery;
+    orderSql = `ORDER BY ${officialOrder}, bm25(skills_fts), s.stars DESC`;
+  }
+
+  const totalRow = d.prepare(`SELECT COUNT(*) as n ${fromSql} ${whereSql}`).get(params) as {
+    n: number;
+  };
+  const rows = d
+    .prepare(`SELECT s.* ${fromSql} ${whereSql} ${orderSql} LIMIT @limit OFFSET @offset`)
+    .all(params) as SkillRow[];
+
+  return { skills: rows.map(rowToSkill), total: totalRow.n };
+}
+
 export const SkillsCache = {
   getMeta(): SkillsRegistryMeta {
-    const d = getDb();
-    const row = d.prepare(`SELECT value FROM meta WHERE key = 'fetchedAt'`).get() as
-      | { value: string }
-      | undefined;
-    const fetchedAt = row ? Number(row.value) : null;
-    const total = d.prepare(`SELECT COUNT(*) as n FROM skills`).get() as { n: number };
-    return { fetchedAt: Number.isFinite(fetchedAt) ? fetchedAt : null, totalCount: total.n };
+    return withRetry((d) => {
+      const row = d.prepare(`SELECT value FROM meta WHERE key = 'fetchedAt'`).get() as
+        | { value: string }
+        | undefined;
+      const rawFetchedAt = row ? Number(row.value) : NaN;
+      const fetchedAt = Number.isFinite(rawFetchedAt) ? rawFetchedAt : null;
+      const total = (d.prepare(`SELECT COUNT(*) as n FROM skills`).get() as { n: number }).n;
+      // The cache is meaningful only when both timestamp and rows are present. Any other
+      // combination (rows without timestamp, timestamp without rows) is treated as
+      // never-fetched; replaceAll guarantees both stamp together on success.
+      if (fetchedAt === null || total === 0) {
+        return { status: 'never-fetched', totalCount: 0, fetchedAt: null };
+      }
+      return { status: 'fresh', totalCount: total, fetchedAt };
+    });
   },
 
   getCategories(): string[] {
-    const d = getDb();
-    const rows = d
-      .prepare(
-        `SELECT DISTINCT category FROM skills WHERE category != '' ORDER BY category COLLATE NOCASE`,
-      )
-      .all() as Array<{ category: string }>;
-    return rows.map((r) => r.category);
+    return withRetry((d) => {
+      const rows = d
+        .prepare(
+          `SELECT DISTINCT category FROM skills WHERE category != '' ORDER BY category COLLATE NOCASE`,
+        )
+        .all() as Array<{ category: string }>;
+      return rows.map((r) => r.category);
+    });
   },
 
   /** Returns every cached skill row. Used by listInstalled to map filesystem folder names
-   *  back to catalog entries — at 10K rows the load is ~5 ms and beats a per-name SQL
-   *  fuzzy match given the sanitization rules. */
+   *  back to catalog entries. */
   allSkills(): RegistrySkill[] {
-    const d = getDb();
-    const rows = d.prepare(`SELECT * FROM skills`).all() as SkillRow[];
-    return rows.map(rowToSkill);
+    return withRetry((d) => {
+      const rows = d.prepare(`SELECT * FROM skills`).all() as SkillRow[];
+      return rows.map(rowToSkill);
+    });
   },
 
   search(args: SearchArgs): SearchResult {
-    const d = getDb();
-    const ftsQuery = buildFtsQuery(args.query);
-    const filters: string[] = [];
-    const params: Record<string, unknown> = {
-      limit: args.limit,
-      offset: args.offset,
-    };
-    if (args.category) {
-      filters.push('s.category = @category');
-      params.category = args.category;
+    return withRetry((d) => searchImpl(d, args));
+  },
+
+  /** Last-resort recovery: close the handle and delete the on-disk cache file plus its
+   *  WAL/SHM siblings. The next call to any SkillsCache method will recreate the schema
+   *  from scratch; the caller is then responsible for refetching the registry. */
+  resetCache(): void {
+    closeDb();
+    const file = dbFilePath();
+    for (const p of [file, `${file}-wal`, `${file}-shm`]) {
+      try {
+        rmSync(p, { force: true });
+      } catch (err) {
+        console.error('[SkillsCache.resetCache] rm failed', { path: p, message: String(err) });
+      }
     }
+  },
 
-    // Pin anthropics/skills entries first, then by FTS rank (when searching) or stars.
-    const officialOrder = `CASE WHEN s.repo = 'anthropics/skills' THEN 0 ELSE 1 END`;
-
-    let whereSql = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
-    let fromSql = `FROM skills s`;
-    let orderSql = `ORDER BY ${officialOrder}, s.stars DESC`;
-
-    if (ftsQuery) {
-      fromSql = `FROM skills_fts JOIN skills s ON s.rowid = skills_fts.rowid`;
-      const matchClause = `skills_fts MATCH @match`;
-      whereSql =
-        filters.length > 0
-          ? `WHERE ${matchClause} AND ${filters.join(' AND ')}`
-          : `WHERE ${matchClause}`;
-      params.match = ftsQuery;
-      orderSql = `ORDER BY ${officialOrder}, bm25(skills_fts), s.stars DESC`;
-    }
-
-    const totalRow = d.prepare(`SELECT COUNT(*) as n ${fromSql} ${whereSql}`).get(params) as {
-      n: number;
-    };
-    const rows = d
-      .prepare(`SELECT s.* ${fromSql} ${whereSql} ${orderSql} LIMIT @limit OFFSET @offset`)
-      .all(params) as SkillRow[];
-
-    return { skills: rows.map(rowToSkill), total: totalRow.n };
+  /** Closes the database handle. Used by tests; also safe to call on app shutdown. */
+  close(): void {
+    closeDb();
   },
 
   /**
@@ -265,7 +333,6 @@ export const SkillsCache = {
     txn(Object.entries(values).map(([k, v]) => [k, String(v)]));
   },
 
-  // For tests / dev: returns the underlying DB. Not exported through the service.
   _db(): Database.Database {
     return getDb();
   },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -11,6 +11,7 @@ import { FileChangesPanel } from './components/FileChangesPanel';
 import { ShellDrawerWrapper } from './components/ShellDrawerWrapper';
 import { DiffViewer } from './components/DiffViewer';
 import { CommitGraphModal } from './components/CommitGraph/CommitGraphModal';
+import { SkillsBrowserModal } from './components/SkillsBrowserModal';
 import { TaskModal } from './components/TaskModal';
 import { AddProjectModal } from './components/AddProjectModal';
 import { DeleteTaskModal } from './components/DeleteTaskModal';
@@ -75,6 +76,7 @@ export function App() {
     project: string;
   } | null>(null);
   const [showSettings, setShowSettings] = useState(false);
+  const [showSkillsBrowser, setShowSkillsBrowser] = useState(false);
   const [settingsInitialTab, setSettingsInitialTab] = useState<string | undefined>();
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
     return (localStorage.getItem('theme') as 'light' | 'dark') || 'dark';
@@ -758,6 +760,9 @@ export function App() {
         } else if (showCommitGraph) {
           e.preventDefault();
           setShowCommitGraph(false);
+        } else if (showSkillsBrowser) {
+          e.preventDefault();
+          setShowSkillsBrowser(false);
         } else if (showSettings) {
           e.preventDefault();
           setShowSettings(false);
@@ -813,6 +818,7 @@ export function App() {
     deleteProjectTarget,
     showDiff,
     showCommitGraph,
+    showSkillsBrowser,
     showSettings,
     showTaskModal,
     showAddProjectModal,
@@ -1502,6 +1508,7 @@ export function App() {
               onRemoveFromRotation={removeFromRotation}
               showActiveTasksSection={showActiveTasksSection}
               onToggleActiveTasksSection={() => setShowActiveTasksSection((v) => !v)}
+              onOpenSkillsBrowser={() => setShowSkillsBrowser(true)}
             />
           </ShellDrawerWrapper>
         </Panel>
@@ -1879,6 +1886,14 @@ export function App() {
             setActiveTaskId(taskId);
             setShowCommitGraph(false);
           }}
+        />
+      )}
+
+      {showSkillsBrowser && (
+        <SkillsBrowserModal
+          projects={projects.map((p) => ({ id: p.id, name: p.name, path: p.path }))}
+          activeProjectId={activeProjectId ?? undefined}
+          onClose={() => setShowSkillsBrowser(false)}
         />
       )}
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -368,6 +368,33 @@ export function App() {
     ? (tasksByProject[activeProjectId] || []).filter((t) => !t.archivedAt)
     : [];
 
+  // Memoized props for SkillsBrowserModal. Without these, App.tsx re-renders (terminal
+  // activity, git polls, PTY events) hand the modal new array references every time,
+  // and the modal's loadInstalled useCallback re-fires its refetch effect — flickering
+  // the list back to a loading state on every unrelated re-render.
+  const skillsModalProjects = useMemo(
+    () => projects.map((p) => ({ id: p.id, name: p.name, path: p.path })),
+    [projects],
+  );
+  const skillsModalActiveTasks = useMemo(
+    () =>
+      projects.flatMap((p) => {
+        const tasks = tasksByProject[p.id] ?? [];
+        // Only worktree-backed, non-archived tasks: a task without a worktree shares the
+        // project root, so installing there would just be a project install.
+        return tasks
+          .filter((t) => t.useWorktree && !t.archivedAt)
+          .map((t) => ({
+            taskId: t.id,
+            taskName: t.name,
+            worktreePath: t.path,
+            projectId: p.id,
+            projectName: p.name,
+          }));
+      }),
+    [projects, tasksByProject],
+  );
+
   // Rotation: all tasks with activity, minus exclusions
   const rotationTasks = React.useMemo(() => {
     const tasks: Task[] = [];
@@ -1891,8 +1918,10 @@ export function App() {
 
       {showSkillsBrowser && (
         <SkillsBrowserModal
-          projects={projects.map((p) => ({ id: p.id, name: p.name, path: p.path }))}
+          projects={skillsModalProjects}
           activeProjectId={activeProjectId ?? undefined}
+          activeTasks={skillsModalActiveTasks}
+          currentTaskId={activeTaskId ?? undefined}
           onClose={() => setShowSkillsBrowser(false)}
         />
       )}

--- a/src/renderer/components/LeftSidebar.tsx
+++ b/src/renderer/components/LeftSidebar.tsx
@@ -14,6 +14,7 @@ import {
   ChevronDown,
   PanelLeftClose,
   PanelLeftOpen,
+  Blocks,
   X,
 } from 'lucide-react';
 import type {
@@ -197,6 +198,7 @@ interface LeftSidebarProps {
   onRemoveFromRotation?: (taskId: string) => void;
   showActiveTasksSection?: boolean;
   onToggleActiveTasksSection?: () => void;
+  onOpenSkillsBrowser?: () => void;
 }
 
 export function LeftSidebar({
@@ -228,6 +230,7 @@ export function LeftSidebar({
   onRemoveFromRotation,
   showActiveTasksSection = true,
   onToggleActiveTasksSection,
+  onOpenSkillsBrowser,
 }: LeftSidebarProps) {
   const [collapsedProjects, setCollapsedProjects] = useState<Set<string>>(new Set());
   const [collapsedArchived, setCollapsedArchived] = useState<Set<string>>(new Set());
@@ -368,6 +371,15 @@ export function LeftSidebar({
         </div>
 
         <div className="w-6 border-t border-border/30 my-1" />
+
+        <Tooltip content="Skills">
+          <button
+            onClick={onOpenSkillsBrowser}
+            className="p-2 rounded-md hover:bg-accent/60 text-muted-foreground hover:text-foreground transition-colors titlebar-no-drag"
+          >
+            <Blocks size={18} strokeWidth={1.5} />
+          </button>
+        </Tooltip>
 
         <Tooltip content="Settings">
           <button
@@ -757,8 +769,15 @@ export function LeftSidebar({
         </div>
       </div>
 
-      {/* Settings */}
-      <div className="px-2 py-2 border-t border-border/30">
+      {/* Skills & Settings */}
+      <div className="px-2 py-2 border-t border-border/30 space-y-0.5">
+        <button
+          onClick={onOpenSkillsBrowser}
+          className="flex items-center gap-2 px-2.5 py-[7px] w-full rounded-md text-sm text-muted-foreground hover:bg-accent/60 hover:text-foreground transition-all duration-150 titlebar-no-drag"
+        >
+          <Blocks size={14} strokeWidth={1.8} />
+          <span>Skills</span>
+        </button>
         <button
           onClick={onOpenSettings}
           className="settings-btn flex items-center gap-2 px-2.5 py-[7px] w-full rounded-md text-sm text-muted-foreground hover:bg-accent/60 hover:text-foreground transition-all duration-150 titlebar-no-drag"

--- a/src/renderer/components/SkillsBrowserModal.tsx
+++ b/src/renderer/components/SkillsBrowserModal.tsx
@@ -556,6 +556,10 @@ export function SkillsBrowserModal({
         const result = await window.electronAPI.skillsCheckInstalled({
           skillName,
           probePaths,
+          // Carry the registry coordinates so main verifies the install marker matches
+          // — without this, a user's custom `<skillName>` folder gets reported as the
+          // registry skill being installed.
+          ref: { repo: skill.repo, branch: skill.branch, path: skill.path },
         });
         if (token !== selectionTokenRef.current) return;
         if (result.success && result.data) {

--- a/src/renderer/components/SkillsBrowserModal.tsx
+++ b/src/renderer/components/SkillsBrowserModal.tsx
@@ -1,0 +1,715 @@
+import React, { useState, useCallback, useEffect, useRef } from 'react';
+import {
+  X,
+  Blocks,
+  Search,
+  Star,
+  Download,
+  RefreshCw,
+  ExternalLink,
+  ChevronDown,
+  Loader2,
+  AlertCircle,
+  Check,
+  FolderOpen,
+  Trash2,
+} from 'lucide-react';
+import type { RegistrySkill, SkillInstallStatus } from '../../shared/types';
+
+interface ProjectInfo {
+  id: string;
+  name: string;
+  path: string;
+}
+
+interface SkillsBrowserModalProps {
+  projects: ProjectInfo[];
+  activeProjectId?: string;
+  onClose: () => void;
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  development: 'Development',
+  testing: 'Testing',
+  data: 'Data',
+  design: 'Design',
+  documents: 'Documents',
+  productivity: 'Productivity',
+  devops: 'DevOps',
+  security: 'Security',
+  marketing: 'Marketing',
+  product: 'Product',
+  communication: 'Communication',
+  creative: 'Creative',
+};
+
+function formatStars(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k`;
+  return String(n);
+}
+
+function CategoryBadge({ category }: { category: string }) {
+  if (!category) return null;
+  return (
+    <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent/60 text-muted-foreground leading-none">
+      {CATEGORY_LABELS[category] || category}
+    </span>
+  );
+}
+
+export function SkillsBrowserModal({
+  projects,
+  activeProjectId,
+  onClose,
+}: SkillsBrowserModalProps) {
+  const [closing, setClosing] = useState(false);
+  const [skills, setSkills] = useState<RegistrySkill[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState<string>('');
+  const [categories, setCategories] = useState<string[]>([]);
+  const [selectedSkill, setSelectedSkill] = useState<RegistrySkill | null>(null);
+  const [skillContent, setSkillContent] = useState<string | null>(null);
+  const [loadingContent, setLoadingContent] = useState(false);
+  const [installing, setInstalling] = useState(false);
+  const [installSuccess, setInstallSuccess] = useState<string | null>(null);
+  const [installError, setInstallError] = useState<string | null>(null);
+  const [showInstallDropdown, setShowInstallDropdown] = useState(false);
+  const [installStatus, setInstallStatus] = useState<SkillInstallStatus | null>(null);
+  const [uninstalling, setUninstalling] = useState(false);
+  const [displayLimit, setDisplayLimit] = useState(50);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const [filteredSkills, setFilteredSkills] = useState<RegistrySkill[]>([]);
+  const [filteredTotal, setFilteredTotal] = useState(0);
+  const [showCategoryDropdown, setShowCategoryDropdown] = useState(false);
+
+  const handleClose = useCallback(() => {
+    setClosing(true);
+  }, []);
+
+  // Escape to close
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') handleClose();
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [handleClose]);
+
+  // Focus search on open
+  useEffect(() => {
+    setTimeout(() => searchRef.current?.focus(), 100);
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchSkills();
+  }, []);
+
+  // Search/filter when query or category changes
+  useEffect(() => {
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    searchTimerRef.current = setTimeout(() => {
+      filterSkills();
+    }, 200);
+    return () => {
+      if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    };
+  }, [query, category, skills]);
+
+  async function fetchSkills(forceRefresh = false) {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await window.electronAPI.skillsFetchRegistry(
+        forceRefresh ? { forceRefresh: true } : undefined,
+      );
+      if (result.success && result.data) {
+        setSkills(result.data);
+        // Extract categories
+        const cats = new Set<string>();
+        for (const s of result.data) {
+          if (s.category) cats.add(s.category);
+        }
+        setCategories(Array.from(cats).sort());
+      } else {
+        setError(result.error || 'Failed to load skills registry');
+      }
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function filterSkills() {
+    const q = query.toLowerCase().trim();
+    let result = skills;
+
+    if (q) {
+      result = result.filter(
+        (s) =>
+          s.name.toLowerCase().includes(q) ||
+          s.description.toLowerCase().includes(q) ||
+          s.tags.some((t) => t.toLowerCase().includes(q)) ||
+          s.repo.toLowerCase().includes(q),
+      );
+    }
+
+    if (category) {
+      result = result.filter((s) => s.category === category);
+    }
+
+    // Pin official skills at the top
+    result.sort((a, b) => {
+      const aOfficial = a.repo === 'anthropics/skills' ? 1 : 0;
+      const bOfficial = b.repo === 'anthropics/skills' ? 1 : 0;
+      if (aOfficial !== bOfficial) return bOfficial - aOfficial;
+      return 0; // Keep original star-based order otherwise
+    });
+
+    setFilteredSkills(result);
+    setFilteredTotal(result.length);
+    setDisplayLimit(50);
+  }
+
+  async function loadSkillContent(skill: RegistrySkill) {
+    setLoadingContent(true);
+    setSkillContent(null);
+    try {
+      const result = await window.electronAPI.skillsGetContent({
+        repo: skill.repo,
+        path: skill.path,
+        branch: skill.branch,
+      });
+      if (result.success && result.data) {
+        setSkillContent(result.data);
+      } else {
+        setSkillContent(`Failed to load: ${result.error || 'Unknown error'}`);
+      }
+    } catch (err) {
+      setSkillContent(`Failed to load: ${err}`);
+    } finally {
+      setLoadingContent(false);
+    }
+  }
+
+  function handleSelectSkill(skill: RegistrySkill) {
+    setSelectedSkill(skill);
+    setSkillContent(null);
+    setInstallSuccess(null);
+    setInstallError(null);
+    setInstallStatus(null);
+    checkInstallStatus(skill);
+  }
+
+  async function checkInstallStatus(skill: RegistrySkill) {
+    const skillName = skill.name.replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-');
+    try {
+      const result = await window.electronAPI.skillsCheckInstalled({
+        skillName,
+        projectPaths: projects.map((p) => p.path),
+      });
+      if (result.success && result.data) {
+        setInstallStatus(result.data);
+      }
+    } catch {
+      // Non-critical
+    }
+  }
+
+  async function handleUninstall(
+    target: 'global' | 'project',
+    projectPath?: string,
+    projectName?: string,
+  ) {
+    if (!selectedSkill) return;
+    setUninstalling(true);
+    setInstallSuccess(null);
+    setInstallError(null);
+
+    const skillName = selectedSkill.name.replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-');
+
+    try {
+      const result = await window.electronAPI.skillsUninstall({
+        skillName,
+        target,
+        projectPath,
+      });
+      if (result.success) {
+        setInstallSuccess(
+          target === 'global'
+            ? `Removed from ~/.claude/skills/${skillName}/`
+            : `Removed from ${projectName || 'project'}`,
+        );
+        checkInstallStatus(selectedSkill);
+      } else {
+        setInstallError(result.error || 'Removal failed');
+      }
+    } catch (err) {
+      setInstallError(String(err));
+    } finally {
+      setUninstalling(false);
+    }
+  }
+
+  async function handleInstall(
+    target: 'global' | 'project',
+    projectPath?: string,
+    projectName?: string,
+  ) {
+    if (!selectedSkill) return;
+    setInstalling(true);
+    setInstallSuccess(null);
+    setInstallError(null);
+    setShowInstallDropdown(false);
+
+    // Derive a clean skill name from the registry name
+    const skillName = selectedSkill.name.replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-');
+
+    try {
+      const result = await window.electronAPI.skillsInstall({
+        repo: selectedSkill.repo,
+        path: selectedSkill.path,
+        branch: selectedSkill.branch,
+        skillName,
+        target,
+        projectPath: target === 'project' ? projectPath : undefined,
+      });
+      if (result.success) {
+        setInstallSuccess(
+          target === 'global'
+            ? `Installed to ~/.claude/skills/${skillName}/`
+            : `Installed to ${projectName || 'project'}/.claude/skills/${skillName}/`,
+        );
+        checkInstallStatus(selectedSkill);
+      } else {
+        setInstallError(result.error || 'Installation failed');
+      }
+    } catch (err) {
+      setInstallError(String(err));
+    } finally {
+      setInstalling(false);
+    }
+  }
+
+  function handleBackdropClick(e: React.MouseEvent) {
+    if (e.target === e.currentTarget) handleClose();
+  }
+
+  const displayedSkills = filteredSkills.slice(0, displayLimit);
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center modal-backdrop ${closing ? 'animate-fade-out' : 'animate-fade-in'}`}
+      onClick={handleBackdropClick}
+      onAnimationEnd={() => {
+        if (closing) onClose();
+      }}
+    >
+      <div
+        className={`bg-card border border-border/60 rounded-xl shadow-2xl shadow-black/40 w-[90vw] max-w-4xl h-[85vh] flex flex-col overflow-hidden ${closing ? 'animate-scale-out' : 'animate-scale-in'}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div
+          className="flex items-center justify-between px-5 h-12 border-b border-border/60 flex-shrink-0"
+          style={{ background: 'hsl(var(--surface-2))' }}
+        >
+          <div className="flex items-center gap-3 min-w-0">
+            <Blocks size={14} className="text-muted-foreground flex-shrink-0" strokeWidth={1.8} />
+            <span className="text-[13px] font-medium text-foreground">Skills Browser</span>
+            {!loading && (
+              <span className="text-[11px] text-muted-foreground">
+                {filteredTotal} skill{filteredTotal !== 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => fetchSkills(true)}
+              disabled={loading}
+              className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-all duration-150 disabled:opacity-40"
+              title="Refresh registry"
+            >
+              <RefreshCw size={13} strokeWidth={2} className={loading ? 'animate-spin' : ''} />
+            </button>
+            <button
+              onClick={handleClose}
+              className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-all duration-150"
+            >
+              <X size={14} strokeWidth={2} />
+            </button>
+          </div>
+        </div>
+
+        {/* Search bar */}
+        <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border/40">
+          <div className="flex-1 flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-background border border-border/60 focus-within:border-primary/40 transition-colors">
+            <Search size={13} className="text-muted-foreground flex-shrink-0" strokeWidth={2} />
+            <input
+              ref={searchRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search skills..."
+              className="flex-1 bg-transparent text-[12px] text-foreground placeholder:text-muted-foreground/60 outline-none"
+            />
+            {query && (
+              <button
+                onClick={() => setQuery('')}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <X size={11} strokeWidth={2} />
+              </button>
+            )}
+          </div>
+
+          {/* Category filter */}
+          <div className="relative">
+            <button
+              onClick={() => setShowCategoryDropdown(!showCategoryDropdown)}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-background border border-border/60 text-[12px] text-foreground hover:border-primary/40 transition-colors min-w-[120px]"
+            >
+              <span className="truncate">
+                {category ? CATEGORY_LABELS[category] || category : 'All categories'}
+              </span>
+              <ChevronDown size={11} className="text-muted-foreground flex-shrink-0" />
+            </button>
+
+            {showCategoryDropdown && (
+              <>
+                <div
+                  className="fixed inset-0 z-10"
+                  onClick={() => setShowCategoryDropdown(false)}
+                />
+                <div className="absolute right-0 top-full mt-1 z-20 bg-card border border-border/60 rounded-lg shadow-xl py-1 min-w-[160px] max-h-[300px] overflow-y-auto">
+                  <button
+                    onClick={() => {
+                      setCategory('');
+                      setShowCategoryDropdown(false);
+                    }}
+                    className={`w-full text-left px-3 py-1.5 text-[12px] hover:bg-accent/60 transition-colors ${!category ? 'text-primary font-medium' : 'text-foreground'}`}
+                  >
+                    All categories
+                  </button>
+                  {categories.map((cat) => (
+                    <button
+                      key={cat}
+                      onClick={() => {
+                        setCategory(cat);
+                        setShowCategoryDropdown(false);
+                      }}
+                      className={`w-full text-left px-3 py-1.5 text-[12px] hover:bg-accent/60 transition-colors ${category === cat ? 'text-primary font-medium' : 'text-foreground'}`}
+                    >
+                      {CATEGORY_LABELS[cat] || cat}
+                    </button>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 flex overflow-hidden">
+          {/* Skill list */}
+          <div className="w-[55%] border-r border-border/40 overflow-y-auto">
+            {loading ? (
+              <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground">
+                <Loader2 size={20} className="animate-spin" />
+                <span className="text-[12px]">Loading skills registry...</span>
+              </div>
+            ) : error ? (
+              <div className="flex flex-col items-center justify-center h-full gap-3 px-8">
+                <AlertCircle size={20} className="text-destructive" />
+                <span className="text-[12px] text-destructive text-center">{error}</span>
+                <button
+                  onClick={() => fetchSkills(true)}
+                  className="px-3 py-1.5 rounded-md text-[12px] bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+                >
+                  Retry
+                </button>
+              </div>
+            ) : displayedSkills.length === 0 ? (
+              <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground">
+                <Search size={20} />
+                <span className="text-[12px]">No skills found</span>
+              </div>
+            ) : (
+              <div className="divide-y divide-border/30">
+                {displayedSkills.map((skill) => (
+                  <button
+                    key={`${skill.repo}-${skill.name}`}
+                    onClick={() => handleSelectSkill(skill)}
+                    className={`w-full text-left px-4 py-3 hover:bg-accent/40 transition-colors ${
+                      selectedSkill?.name === skill.name && selectedSkill?.repo === skill.repo
+                        ? 'bg-accent/60'
+                        : ''
+                    }`}
+                  >
+                    <div className="flex items-start gap-2">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-0.5">
+                          <span className="text-[12px] font-medium text-foreground truncate">
+                            {skill.name}
+                          </span>
+                          {skill.repo === 'anthropics/skills' && (
+                            <span className="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-primary/15 text-primary leading-none flex-shrink-0">
+                              Official
+                            </span>
+                          )}
+                          <CategoryBadge category={skill.category} />
+                        </div>
+                        <p className="text-[11px] text-muted-foreground line-clamp-2 leading-relaxed">
+                          {skill.description}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-1 text-[11px] text-muted-foreground flex-shrink-0 pt-0.5">
+                        <Star size={10} strokeWidth={2} />
+                        <span>{formatStars(skill.stars)}</span>
+                      </div>
+                    </div>
+                  </button>
+                ))}
+
+                {displayLimit < filteredTotal && (
+                  <div className="px-4 py-3">
+                    <button
+                      onClick={() => setDisplayLimit((l) => l + 50)}
+                      className="w-full py-2 rounded-md text-[12px] text-muted-foreground hover:text-foreground hover:bg-accent/40 transition-colors border border-border/40"
+                    >
+                      Load more ({filteredTotal - displayLimit} remaining)
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Detail panel */}
+          <div className="w-[45%] overflow-y-auto">
+            {selectedSkill ? (
+              <div className="flex flex-col h-full">
+                {/* Detail header */}
+                <div className="px-5 pt-4 pb-3 border-b border-border/40">
+                  <div className="flex items-center gap-2 mb-2">
+                    <h3 className="text-[14px] font-semibold text-foreground">
+                      {selectedSkill.name}
+                    </h3>
+                    {selectedSkill.repo === 'anthropics/skills' && (
+                      <span className="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-primary/15 text-primary leading-none">
+                        Official
+                      </span>
+                    )}
+                  </div>
+
+                  <p className="text-[12px] text-muted-foreground leading-relaxed mb-3">
+                    {selectedSkill.description}
+                  </p>
+
+                  <div className="flex items-center gap-4 text-[11px] text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      <Star size={10} strokeWidth={2} />
+                      {formatStars(selectedSkill.stars)} stars
+                    </span>
+                    {selectedSkill.category && <CategoryBadge category={selectedSkill.category} />}
+                    <button
+                      onClick={() =>
+                        window.electronAPI.openExternal(`https://github.com/${selectedSkill.repo}`)
+                      }
+                      className="flex items-center gap-1 hover:text-foreground transition-colors"
+                    >
+                      <ExternalLink size={10} strokeWidth={2} />
+                      {selectedSkill.repo}
+                    </button>
+                  </div>
+                </div>
+
+                {/* SKILL.md content */}
+                <div className="flex-1 overflow-y-auto px-5 py-3">
+                  {skillContent === null && !loadingContent ? (
+                    <button
+                      onClick={() => loadSkillContent(selectedSkill)}
+                      className="flex items-center gap-2 px-3 py-2 rounded-md text-[12px] text-muted-foreground hover:text-foreground hover:bg-accent/40 transition-colors border border-border/40"
+                    >
+                      <FolderOpen size={12} strokeWidth={2} />
+                      View SKILL.md
+                    </button>
+                  ) : loadingContent ? (
+                    <div className="flex items-center gap-2 text-muted-foreground py-4">
+                      <Loader2 size={14} className="animate-spin" />
+                      <span className="text-[12px]">Loading...</span>
+                    </div>
+                  ) : (
+                    <pre className="text-[11px] text-foreground/90 whitespace-pre-wrap break-words font-mono leading-relaxed">
+                      {skillContent}
+                    </pre>
+                  )}
+                </div>
+
+                {/* Installed status */}
+                {installStatus &&
+                  (installStatus.global || installStatus.projectPaths.length > 0) && (
+                    <div className="px-5 py-2 border-t border-border/40 flex-shrink-0">
+                      <div className="text-[11px] font-medium text-muted-foreground mb-1.5">
+                        Installed in
+                      </div>
+                      <div className="space-y-1">
+                        {installStatus.global && (
+                          <div className="flex items-center justify-between gap-2 py-1 px-2 rounded-md bg-accent/30">
+                            <div className="flex items-center gap-1.5 text-[11px] text-foreground min-w-0">
+                              <Check
+                                size={11}
+                                strokeWidth={2}
+                                className="text-[hsl(var(--git-added))] flex-shrink-0"
+                              />
+                              <span className="truncate">Global (~/.claude/skills/)</span>
+                            </div>
+                            <button
+                              onClick={() => handleUninstall('global')}
+                              disabled={uninstalling}
+                              className="p-1 rounded hover:bg-destructive/15 text-muted-foreground hover:text-destructive transition-colors flex-shrink-0 disabled:opacity-40"
+                              title="Remove"
+                            >
+                              <Trash2 size={11} strokeWidth={2} />
+                            </button>
+                          </div>
+                        )}
+                        {installStatus.projectPaths.map((pp) => {
+                          const proj = projects.find((p) => p.path === pp);
+                          return (
+                            <div
+                              key={pp}
+                              className="flex items-center justify-between gap-2 py-1 px-2 rounded-md bg-accent/30"
+                            >
+                              <div className="flex items-center gap-1.5 text-[11px] text-foreground min-w-0">
+                                <Check
+                                  size={11}
+                                  strokeWidth={2}
+                                  className="text-[hsl(var(--git-added))] flex-shrink-0"
+                                />
+                                <span className="truncate">{proj?.name || pp}</span>
+                              </div>
+                              <button
+                                onClick={() => handleUninstall('project', pp, proj?.name)}
+                                disabled={uninstalling}
+                                className="p-1 rounded hover:bg-destructive/15 text-muted-foreground hover:text-destructive transition-colors flex-shrink-0 disabled:opacity-40"
+                                title="Remove"
+                              >
+                                <Trash2 size={11} strokeWidth={2} />
+                              </button>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+
+                {/* Install actions */}
+                <div className="px-5 py-3 border-t border-border/40 flex-shrink-0">
+                  {installSuccess && (
+                    <div className="flex items-center gap-2 mb-2 text-[11px] text-[hsl(var(--git-added))]">
+                      <Check size={12} strokeWidth={2} />
+                      {installSuccess}
+                    </div>
+                  )}
+                  {installError && (
+                    <div className="flex items-center gap-2 mb-2 text-[11px] text-destructive">
+                      <AlertCircle size={12} strokeWidth={2} />
+                      {installError}
+                    </div>
+                  )}
+
+                  <div className="relative flex items-center gap-2">
+                    {installing || uninstalling ? (
+                      <div className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-muted-foreground">
+                        <Loader2 size={12} className="animate-spin" />
+                        {uninstalling ? 'Removing...' : 'Installing...'}
+                      </div>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() => setShowInstallDropdown(!showInstallDropdown)}
+                          className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[12px] font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+                        >
+                          <Download size={12} strokeWidth={2} />
+                          Install
+                          <ChevronDown size={11} />
+                        </button>
+
+                        {showInstallDropdown && (
+                          <>
+                            <div
+                              className="fixed inset-0 z-10"
+                              onClick={() => setShowInstallDropdown(false)}
+                            />
+                            <div className="absolute left-0 bottom-full mb-1 z-20 bg-card border border-border/60 rounded-lg shadow-xl py-1 min-w-[220px]">
+                              <button
+                                onClick={() => handleInstall('global')}
+                                className="w-full text-left px-3 py-2 text-[12px] hover:bg-accent/60 transition-colors text-foreground flex items-center gap-2"
+                              >
+                                <Download
+                                  size={12}
+                                  strokeWidth={2}
+                                  className="text-muted-foreground flex-shrink-0"
+                                />
+                                <div>
+                                  <div className="font-medium">Global</div>
+                                  <div className="text-[10px] text-muted-foreground">
+                                    ~/.claude/skills/
+                                  </div>
+                                </div>
+                              </button>
+
+                              {projects.length > 0 && (
+                                <div className="border-t border-border/30 mt-1 pt-1">
+                                  <div className="px-3 py-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+                                    Projects
+                                  </div>
+                                  {projects.map((p) => (
+                                    <button
+                                      key={p.id}
+                                      onClick={() => handleInstall('project', p.path, p.name)}
+                                      className={`w-full text-left px-3 py-2 text-[12px] hover:bg-accent/60 transition-colors text-foreground flex items-center gap-2 ${p.id === activeProjectId ? 'bg-accent/30' : ''}`}
+                                    >
+                                      <FolderOpen
+                                        size={12}
+                                        strokeWidth={2}
+                                        className="text-muted-foreground flex-shrink-0"
+                                      />
+                                      <div className="min-w-0">
+                                        <div className="font-medium truncate">{p.name}</div>
+                                        <div className="text-[10px] text-muted-foreground truncate">
+                                          {p.path}
+                                        </div>
+                                      </div>
+                                    </button>
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                          </>
+                        )}
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground px-8">
+                <Blocks size={24} strokeWidth={1.5} />
+                <p className="text-[12px] text-center leading-relaxed">
+                  Select a skill to view details and install
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/SkillsBrowserModal.tsx
+++ b/src/renderer/components/SkillsBrowserModal.tsx
@@ -207,6 +207,10 @@ interface LocationChipsProps {
   activeTasks: ActiveTaskInfo[];
 }
 
+// Cap on chips before collapsing the tail into a "+N others" badge. Three is enough to
+// convey common scopes (global + project + task) without crowding out the skill name.
+const LOCATION_CHIP_LIMIT = 3;
+
 function LocationChips({ entry, projects, activeTasks }: LocationChipsProps) {
   type Chip = { key: string; kind: 'global' | 'project' | 'task'; label: string };
   const chips: Chip[] = [];
@@ -221,9 +225,14 @@ function LocationChips({ entry, projects, activeTasks }: LocationChipsProps) {
     chips.push({ key: pp, kind: 'project', label: matchedProject?.name ?? pp });
   }
   if (chips.length === 0) return null;
+
+  const visible = chips.slice(0, LOCATION_CHIP_LIMIT);
+  const overflow = chips.slice(LOCATION_CHIP_LIMIT);
+  const overflowTooltip = overflow.map((c) => c.label).join(', ');
+
   return (
     <div className="flex items-center gap-1 flex-wrap mt-1">
-      {chips.map((c) => (
+      {visible.map((c) => (
         <span
           key={c.key}
           className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent/60 text-muted-foreground leading-none"
@@ -236,6 +245,13 @@ function LocationChips({ entry, projects, activeTasks }: LocationChipsProps) {
           <span className="truncate max-w-[140px]">{c.label}</span>
         </span>
       ))}
+      {overflow.length > 0 && (
+        <Tooltip content={overflowTooltip}>
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent/60 text-muted-foreground leading-none">
+            +{overflow.length} {overflow.length === 1 ? 'other' : 'others'}
+          </span>
+        </Tooltip>
+      )}
     </div>
   );
 }
@@ -545,6 +561,10 @@ export function SkillsBrowserModal({
         setInstallStatus(null);
         return;
       }
+      // Custom stub: no remote ref to verify against, install status is already
+      // synthesized by handleSelectCustom. Calling main with an empty ref would trip
+      // assertRef and surface a confusing "Invalid repo: \"\"" message to the user.
+      if (!skill.repo) return;
       // Include every active worktree task path so the "Installed in" section can show
       // task-scoped installs alongside global/project ones. The backend just probes paths;
       // the renderer figures out which is which when rendering.
@@ -648,6 +668,7 @@ export function SkillsBrowserModal({
       global: entry.globalInstalled,
       installedPaths: entry.installedPaths,
     });
+    setInstallStatusError(null);
     setLocalReadTarget(target);
     setCustomInstalled(entry);
     // setState is async; pass the target explicitly so the fetch doesn't see a null
@@ -709,7 +730,26 @@ export function SkillsBrowserModal({
       const result = await window.electronAPI.skillsUninstall({ skillName, target });
       if (result.success) {
         setInstallSuccess(`Removed from ${targetLabel(target, skillName, label)}`);
-        checkInstallStatus(selectedSkill);
+        if (customInstalled) {
+          // Custom skill: re-derive install status locally instead of round-tripping to
+          // checkInstalled with the synthetic stub (which has no real repo and would
+          // trip assertRef on the main side).
+          setInstallStatus((prev) => {
+            if (!prev) return null;
+            const next: SkillInstallStatus = {
+              global: target.kind === 'global' ? false : prev.global,
+              installedPaths: prev.installedPaths.filter((p) => {
+                if (target.kind === 'project') return p !== target.projectPath;
+                if (target.kind === 'task') return p !== target.worktreePath;
+                return true;
+              }),
+            };
+            if (prev.probeFailures) next.probeFailures = prev.probeFailures;
+            return next;
+          });
+        } else {
+          checkInstallStatus(selectedSkill);
+        }
         // Keep the Installed list in sync so the just-removed card disappears immediately.
         if (view === 'installed') loadInstalled();
       } else {
@@ -1057,13 +1097,10 @@ export function SkillsBrowserModal({
                     </span>
                   </div>
                 ) : (
-                  <div className="divide-y divide-border/30">
+                  <div className="flex flex-col gap-2 px-3 py-3">
                     {filteredInstalled.map((entry) => {
                       const cat = entry.catalog;
                       const isCustom = !cat;
-                      // Selection match: registry skills compare by skillKey; custom skills
-                      // are tracked separately via customInstalled.skillName so we can highlight
-                      // the right row even though the synthetic stub has no real repo+path.
                       const isSelected = isCustom
                         ? customInstalled?.skillName === entry.skillName
                         : selectedSkill !== null && skillKey(cat) === skillKey(selectedSkill);
@@ -1074,13 +1111,15 @@ export function SkillsBrowserModal({
                             if (cat) handleSelectSkill(cat);
                             else handleSelectCustom(entry);
                           }}
-                          // Precedence: selection > custom > default. The selection class is
-                          // applied last so it wins over the custom-row tint when both apply.
-                          // Custom rows get full surface-3 (not 40%) so the tint is actually
-                          // visible against the card body.
-                          className={`w-full text-left px-4 py-3 transition-colors hover:bg-accent/40 ${
-                            isCustom ? 'bg-[hsl(var(--surface-3))]' : ''
-                          } ${isSelected ? 'bg-accent/60' : ''}`}
+                          // Card-style row: each install gets its own bordered surface so
+                          // adjacent rows don't blur together. Selection > custom > default
+                          // for the bg, applied last so selection wins. The wrapper uses
+                          // gap-2 instead of divide-y to give every row distinct edges.
+                          className={`w-full text-left px-3 py-2.5 rounded-md border border-border/40 transition-colors hover:bg-accent/40 hover:border-border/70 ${
+                            isCustom
+                              ? 'bg-[hsl(var(--surface-2))]/50'
+                              : 'bg-[hsl(var(--surface-1))]/40'
+                          } ${isSelected ? 'bg-accent/60 border-primary/50' : ''}`}
                         >
                           <div className="flex flex-col min-w-0">
                             <div className="flex items-center gap-2 mb-0.5">

--- a/src/renderer/components/SkillsBrowserModal.tsx
+++ b/src/renderer/components/SkillsBrowserModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import {
   X,
   Blocks,
@@ -21,6 +21,7 @@ import type {
   SkillInstallTarget,
   SkillsRegistryMeta,
   InstalledSkill,
+  ProbeFailure,
 } from '../../shared/types';
 import { Tooltip } from './ui/Tooltip';
 
@@ -102,7 +103,9 @@ function friendlyError(raw: string | undefined, fallback: string): string {
   ) {
     return 'Network error reaching GitHub.';
   }
-  if (lower.includes('invalid')) return raw;
+  // Whitelist specific user-actionable validation messages instead of returning every
+  // 'invalid' error verbatim — the latter leaks internal paths/JSON snippets.
+  if (lower.includes('invalid skill name') || lower.includes('invalid repo')) return raw;
   return fallback;
 }
 
@@ -172,7 +175,9 @@ function categorySlot(category: string): number {
   for (let i = 0; i < category.length; i++) {
     h = ((h << 5) + h) ^ category.charCodeAt(i);
   }
-  return Math.abs(h) % CATEGORY_PALETTE.length;
+  // `>>> 0` coerces to unsigned 32-bit so the modulo is non-negative even on the
+  // INT32_MIN boundary where Math.abs(-2147483648) is still negative.
+  return (h >>> 0) % CATEGORY_PALETTE.length;
 }
 
 function CategoryBadge({ category }: { category: string }) {
@@ -202,9 +207,6 @@ interface LocationChipsProps {
   activeTasks: ActiveTaskInfo[];
 }
 
-// Renders one chip per install location for an installed skill row. Each chip carries
-// an icon hinting the scope (global / project / task) and a label, so users can see
-// at a glance where a skill lives without opening the detail pane.
 function LocationChips({ entry, projects, activeTasks }: LocationChipsProps) {
   type Chip = { key: string; kind: 'global' | 'project' | 'task'; label: string };
   const chips: Chip[] = [];
@@ -252,22 +254,25 @@ export function SkillsBrowserModal({
   const [resultTotal, setResultTotal] = useState(0);
   const [pageOffset, setPageOffset] = useState(0);
   const [searching, setSearching] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Split per surface so a successful search doesn't clear an installed-list error
+  // (and vice versa). searchError covers the "all" view's runSearch/refresh/reset/open
+  // lifecycle; installedError covers loadInstalled and the installed-view click handler.
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [installedError, setInstalledError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<string>('');
-  // 'all' searches the registry cache; 'installed' lists only what's on disk and joins
-  // back to the cache for metadata.
   const [view, setView] = useState<'all' | 'installed'>('all');
   const [installedList, setInstalledList] = useState<InstalledSkill[]>([]);
+  const [installedProbeFailures, setInstalledProbeFailures] = useState<ProbeFailure[]>([]);
   const [loadingInstalled, setLoadingInstalled] = useState(false);
   const [categories, setCategories] = useState<string[]>([]);
+  const [categoriesError, setCategoriesError] = useState<string | null>(null);
   const [selectedSkill, setSelectedSkill] = useState<RegistrySkill | null>(null);
   // When non-null, the currently-selected skill is a local-only install (no catalog entry),
   // so SKILL.md must be read from this on-disk location instead of fetched from GitHub.
-  // Carries 'global' or an absolute project/worktree path — same shape skills:readLocalSkillMd
-  // expects on the IPC. The companion `customInstalled` keeps the original entry around so
-  // we can render the "Installed in" panel correctly without re-running checkInstalled.
-  const [localReadLocation, setLocalReadLocation] = useState<string | null>(null);
+  // The companion `customInstalled` keeps the original entry around so we can render the
+  // "Installed in" panel correctly without re-running checkInstalled.
+  const [localReadTarget, setLocalReadTarget] = useState<SkillInstallTarget | null>(null);
   const [customInstalled, setCustomInstalled] = useState<InstalledSkill | null>(null);
   const [skillContent, setSkillContent] = useState<string | null>(null);
   const [skillContentError, setSkillContentError] = useState<string | null>(null);
@@ -277,6 +282,10 @@ export function SkillsBrowserModal({
   const [installError, setInstallError] = useState<string | null>(null);
   const [showInstallDropdown, setShowInstallDropdown] = useState(false);
   const [installStatus, setInstallStatus] = useState<SkillInstallStatus | null>(null);
+  // Distinct from probeFailures inside installStatus: this is the "we couldn't even ask"
+  // state, signalling the user can't trust the absence of an "Installed in" panel as
+  // proof the skill isn't installed.
+  const [installStatusError, setInstallStatusError] = useState<string | null>(null);
   const [uninstalling, setUninstalling] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -293,7 +302,6 @@ export function SkillsBrowserModal({
     setClosing(true);
   }, []);
 
-  // Escape to close
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
       if (e.key === 'Escape') handleClose();
@@ -302,7 +310,6 @@ export function SkillsBrowserModal({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [handleClose]);
 
-  // Focus search on open
   useEffect(() => {
     setTimeout(() => searchRef.current?.focus(), 100);
   }, []);
@@ -316,7 +323,7 @@ export function SkillsBrowserModal({
     ): Promise<void> => {
       const token = ++searchTokenRef.current;
       setSearching(true);
-      setError(null);
+      setSearchError(null);
       try {
         const result = await window.electronAPI.skillsSearch({
           query: nextQuery,
@@ -331,12 +338,12 @@ export function SkillsBrowserModal({
           setPageOffset(offset);
         } else {
           console.error('[SkillsBrowserModal.runSearch] failed', { error: result.error });
-          setError(friendlyError(result.error, 'Search failed'));
+          setSearchError(friendlyError(result.error, 'Search failed'));
         }
       } catch (err) {
         if (token !== searchTokenRef.current) return;
         console.error('[SkillsBrowserModal.runSearch] threw', err);
-        setError(friendlyError(String(err), 'Search failed'));
+        setSearchError(friendlyError(String(err), 'Search failed'));
       } finally {
         if (token === searchTokenRef.current) setSearching(false);
       }
@@ -347,7 +354,7 @@ export function SkillsBrowserModal({
   const refreshRegistry = useCallback(
     async (force: boolean): Promise<SkillsRegistryMeta | null> => {
       setRefreshing(true);
-      setError(null);
+      setSearchError(null);
       try {
         const result = await window.electronAPI.skillsRefresh(force ? { force: true } : undefined);
         if (result.success && result.data) {
@@ -355,11 +362,11 @@ export function SkillsBrowserModal({
           return result.data;
         }
         console.error('[SkillsBrowserModal.refreshRegistry] failed', { error: result.error });
-        setError(friendlyError(result.error, 'Failed to refresh skills registry'));
+        setSearchError(friendlyError(result.error, 'Failed to refresh skills registry'));
         return null;
       } catch (err) {
         console.error('[SkillsBrowserModal.refreshRegistry] threw', err);
-        setError(friendlyError(String(err), 'Failed to refresh skills registry'));
+        setSearchError(friendlyError(String(err), 'Failed to refresh skills registry'));
         return null;
       } finally {
         setRefreshing(false);
@@ -368,24 +375,45 @@ export function SkillsBrowserModal({
     [],
   );
 
+  const handleResetCache = useCallback(async () => {
+    setRefreshing(true);
+    setSearchError(null);
+    try {
+      const result = await window.electronAPI.skillsResetCache();
+      if (result.success && result.data) {
+        setMeta(result.data);
+        await runSearch(query, category, 0, false);
+      } else {
+        console.error('[SkillsBrowserModal.handleResetCache] failed', { error: result.error });
+        setSearchError(friendlyError(result.error, 'Failed to reset skills cache'));
+      }
+    } catch (err) {
+      console.error('[SkillsBrowserModal.handleResetCache] threw', err);
+      setSearchError(friendlyError(String(err), 'Failed to reset skills cache'));
+    } finally {
+      setRefreshing(false);
+    }
+  }, [query, category, runSearch]);
+
   const loadCategories = useCallback(async () => {
     try {
       const result = await window.electronAPI.skillsGetCategories();
       if (result.success && result.data) {
         setCategories(result.data);
+        setCategoriesError(null);
       } else {
-        // Non-fatal: dropdown shows only "All categories" if this fails. Log so we'd
-        // notice the regression rather than silently shipping a broken filter list.
         console.error('[SkillsBrowserModal.loadCategories] failed', { error: result.error });
+        setCategoriesError(friendlyError(result.error, 'Could not load categories'));
       }
     } catch (err) {
       console.error('[SkillsBrowserModal.loadCategories] threw', err);
+      setCategoriesError('Could not load categories');
     }
   }, []);
 
   const loadInstalled = useCallback(async () => {
     setLoadingInstalled(true);
-    setError(null);
+    setInstalledError(null);
     try {
       const probePaths = [
         ...projects.map((p) => p.path),
@@ -393,14 +421,17 @@ export function SkillsBrowserModal({
       ];
       const result = await window.electronAPI.skillsListInstalled({ probePaths });
       if (result.success && result.data) {
-        setInstalledList(result.data);
+        setInstalledList(result.data.skills);
+        setInstalledProbeFailures(result.data.probeFailures);
       } else {
+        // Don't yank the prior list on failure — keep showing what we had and surface
+        // the error as a banner so the user keeps their context.
         console.error('[SkillsBrowserModal.loadInstalled] failed', { error: result.error });
-        setError(friendlyError(result.error, 'Failed to list installed skills'));
+        setInstalledError(friendlyError(result.error, 'Failed to list installed skills'));
       }
     } catch (err) {
       console.error('[SkillsBrowserModal.loadInstalled] threw', err);
-      setError(friendlyError(String(err), 'Failed to list installed skills'));
+      setInstalledError(friendlyError(String(err), 'Failed to list installed skills'));
     } finally {
       setLoadingInstalled(false);
     }
@@ -413,7 +444,6 @@ export function SkillsBrowserModal({
     loadInstalled();
   }, [view, loadInstalled]);
 
-  // First-open lifecycle: read meta, refresh if missing/stale, then load categories + run an empty search.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -423,9 +453,8 @@ export function SkillsBrowserModal({
         const current = metaResp.success && metaResp.data ? metaResp.data : null;
         const stale =
           !current ||
-          current.totalCount === 0 ||
-          current.fetchedAt === null ||
-          Date.now() - current.fetchedAt > STALE_AFTER_MS;
+          current.status === 'never-fetched' ||
+          (current.status === 'fresh' && Date.now() - current.fetchedAt > STALE_AFTER_MS);
         const metaToUse = stale ? await refreshRegistry(false) : current;
         if (cancelled) return;
         if (metaToUse) setMeta(metaToUse);
@@ -438,7 +467,7 @@ export function SkillsBrowserModal({
         // (e.g. preload mis-binding) so the modal isn't left wedged in `refreshing` state.
         if (cancelled) return;
         console.error('[SkillsBrowserModal] open-lifecycle threw', err);
-        setError(friendlyError(String(err), 'Failed to open Skills Browser'));
+        setSearchError(friendlyError(String(err), 'Failed to open Skills Browser'));
         setRefreshing(false);
       }
     })();
@@ -479,13 +508,13 @@ export function SkillsBrowserModal({
     setSkillContentError(null);
     try {
       // Custom (local-only) skills aren't in the registry and have no repo to fetch from —
-      // read the SKILL.md off the local filesystem instead. localReadLocation is captured
-      // up-front so a switch-back to a registry skill mid-await is still tied to the right token.
-      const localLoc = localReadLocation;
-      const result = localLoc
+      // read the SKILL.md off the local filesystem instead. The target is captured up-front
+      // so a switch-back to a registry skill mid-await is still tied to the right token.
+      const target = localReadTarget;
+      const result = target
         ? await window.electronAPI.skillsReadLocalSkillMd({
             skillName: deriveInstallSkillName(skill) || skill.name,
-            installLocation: localLoc,
+            target,
           })
         : await window.electronAPI.skillsGetContent({
             repo: skill.repo,
@@ -531,16 +560,21 @@ export function SkillsBrowserModal({
         if (token !== selectionTokenRef.current) return;
         if (result.success && result.data) {
           setInstallStatus(result.data);
+          setInstallStatusError(null);
         } else {
           console.error('[SkillsBrowserModal.checkInstallStatus] failed', {
             error: result.error,
           });
           setInstallStatus(null);
+          setInstallStatusError(
+            friendlyError(result.error, 'Could not check whether this skill is installed'),
+          );
         }
       } catch (err) {
         if (token !== selectionTokenRef.current) return;
         console.error('[SkillsBrowserModal.checkInstallStatus] threw', err);
         setInstallStatus(null);
+        setInstallStatusError('Could not check whether this skill is installed');
       }
     },
     [projects, activeTasks],
@@ -556,7 +590,8 @@ export function SkillsBrowserModal({
     setInstallSuccess(null);
     setInstallError(null);
     setInstallStatus(null);
-    setLocalReadLocation(null);
+    setInstallStatusError(null);
+    setLocalReadTarget(null);
     setCustomInstalled(null);
     checkInstallStatus(skill);
   }
@@ -566,13 +601,28 @@ export function SkillsBrowserModal({
   // GitHub, and skip the registry-driven install flow (the skill is already on disk).
   function handleSelectCustom(entry: InstalledSkill) {
     selectionTokenRef.current += 1;
-    // Pick a deterministic location to read from: prefer global, otherwise the first
-    // probe path we know it's installed in. Both reads return the same SKILL.md content
-    // unless the user has divergent copies — acceptable trade-off vs. UI complexity.
-    const installLocation = entry.globalInstalled ? 'global' : entry.installedPaths[0];
-    if (!installLocation) {
-      // Defensive: listInstalled wouldn't surface an entry with neither global nor
-      // probe-path installs, but a stale render could. Skip silently.
+    // Pick a deterministic location: prefer global, otherwise the first probe path we
+    // know it's installed in, mapped back to the right kind by matching against the
+    // projects/activeTasks props. A path that matches neither means the install lives
+    // outside any known scope — refuse to read rather than guess.
+    const target: SkillInstallTarget | null = entry.globalInstalled
+      ? { kind: 'global' }
+      : (() => {
+          const p = entry.installedPaths[0];
+          if (!p) return null;
+          if (projects.some((proj) => proj.path === p)) {
+            return { kind: 'project', projectPath: p };
+          }
+          if (activeTasks.some((t) => t.worktreePath === p)) {
+            return { kind: 'task', worktreePath: p };
+          }
+          return null;
+        })();
+    if (!target) {
+      console.error('[SkillsBrowserModal.handleSelectCustom] entry has no resolvable target', {
+        skillName: entry.skillName,
+      });
+      setInstalledError('Skill data is stale. Refresh the installed list and try again.');
       return;
     }
     const stub: RegistrySkill = {
@@ -590,24 +640,18 @@ export function SkillsBrowserModal({
     setSkillContentError(null);
     setInstallSuccess(null);
     setInstallError(null);
-    // Synthesize the install status from the entry we already have — no IPC needed.
     setInstallStatus({
       global: entry.globalInstalled,
       installedPaths: entry.installedPaths,
     });
-    setLocalReadLocation(installLocation);
+    setLocalReadTarget(target);
     setCustomInstalled(entry);
-    // Custom skills have no description/stars/repo — the SKILL.md body is the only useful
-    // surface. Kick off the read immediately so users don't have to click "View SKILL.md".
-    // Note: loadSkillContent reads localReadLocation off state at call time, so we pass the
-    // synthesized location explicitly via a closure-captured variable to avoid the stale-state
-    // race (setState is async; the fetch would otherwise see localReadLocation=null).
-    void loadSkillContentFromLocal(stub, installLocation);
+    // setState is async; pass the target explicitly so the fetch doesn't see a null
+    // localReadTarget on the first render after click.
+    void loadSkillContentFromLocal(stub, target);
   }
 
-  // Twin of loadSkillContent that takes the install location as an explicit arg, used by
-  // handleSelectCustom to avoid waiting for setLocalReadLocation to flush before reading.
-  async function loadSkillContentFromLocal(skill: RegistrySkill, installLocation: string) {
+  async function loadSkillContentFromLocal(skill: RegistrySkill, target: SkillInstallTarget) {
     const token = selectionTokenRef.current;
     setLoadingContent(true);
     setSkillContent(null);
@@ -615,7 +659,7 @@ export function SkillsBrowserModal({
     try {
       const result = await window.electronAPI.skillsReadLocalSkillMd({
         skillName: deriveInstallSkillName(skill) || skill.name,
-        installLocation,
+        target,
       });
       if (token !== selectionTokenRef.current) return;
       if (result.success && result.data) {
@@ -635,7 +679,6 @@ export function SkillsBrowserModal({
     }
   }
 
-  // Human-readable destination label for install/uninstall toasts.
   function targetLabel(target: SkillInstallTarget, skillName: string, label?: string): string {
     switch (target.kind) {
       case 'global':
@@ -663,8 +706,7 @@ export function SkillsBrowserModal({
       if (result.success) {
         setInstallSuccess(`Removed from ${targetLabel(target, skillName, label)}`);
         checkInstallStatus(selectedSkill);
-        // Keep the Installed list in sync when the user is viewing it; otherwise the
-        // card they just removed would linger until they switch tabs.
+        // Keep the Installed list in sync so the just-removed card disappears immediately.
         if (view === 'installed') loadInstalled();
       } else {
         setInstallError(friendlyError(result.error, 'Removal failed'));
@@ -702,8 +744,7 @@ export function SkillsBrowserModal({
       if (result.success) {
         setInstallSuccess(`Installed to ${targetLabel(target, skillName, label)}`);
         checkInstallStatus(selectedSkill);
-        // Keep the Installed list in sync when the user is viewing it; otherwise the
-        // card they just removed would linger until they switch tabs.
+        // Keep the Installed list in sync so the card just installed appears immediately.
         if (view === 'installed') loadInstalled();
       } else {
         setInstallError(friendlyError(result.error, 'Installation failed'));
@@ -725,10 +766,10 @@ export function SkillsBrowserModal({
   const isInitialLoad = refreshing && results.length === 0;
   const hasActiveFilter = query.trim().length > 0 || category.length > 0;
 
-  // Client-side filter for the Installed view. The list is small (anything a user has
-  // actually installed) so doing this in JS is fine and avoids round-tripping to main
-  // for every keystroke.
-  const filteredInstalled = (() => {
+  // Client-side filter for the Installed view. Memoized because the IIFE form ran on
+  // every render — even unrelated state churn (PTY/git ticks bubbling via context) —
+  // and the list is read by both the count chip and the row map.
+  const filteredInstalled = useMemo(() => {
     if (view !== 'installed') return [];
     const q = query.trim().toLowerCase();
     return installedList.filter((entry) => {
@@ -743,7 +784,7 @@ export function SkillsBrowserModal({
       ];
       return haystacks.some((h) => typeof h === 'string' && h.toLowerCase().includes(q));
     });
-  })();
+  }, [view, query, category, installedList]);
 
   return (
     <div
@@ -826,13 +867,13 @@ export function SkillsBrowserModal({
         </div>
 
         {/* Stale-cache banner */}
-        {meta?.stale && meta.totalCount > 0 && (
+        {meta?.status === 'stale' && (
           <div className="flex items-center gap-2 px-4 py-2 border-b border-border/40 bg-destructive/10 text-[11px] text-destructive">
             <AlertCircle size={ICON_SIZE} strokeWidth={ICON_STROKE} className="flex-shrink-0" />
             <span className="flex-1">
-              Refresh failed; showing cached results
-              {meta.fetchedAt ? ` from ${new Date(meta.fetchedAt).toLocaleString()}` : ''}.
-              {meta.refreshError ? ` (${friendlyError(meta.refreshError, 'Network error')})` : ''}
+              Refresh failed; showing cached results from{' '}
+              {new Date(meta.fetchedAt).toLocaleString()} (
+              {friendlyError(meta.refreshError, 'Network error')}).
             </span>
             <button
               onClick={handleManualRefresh}
@@ -870,7 +911,7 @@ export function SkillsBrowserModal({
             )}
           </div>
 
-          {/* View toggle: All catalog vs only what's installed on disk */}
+          {/* View toggle */}
           <div className="flex rounded-lg border border-border/60 overflow-hidden text-[12px]">
             <button
               onClick={() => setView('all')}
@@ -903,11 +944,21 @@ export function SkillsBrowserModal({
               <span className="truncate">
                 {category ? CATEGORY_LABELS[category] || category : 'All categories'}
               </span>
-              <ChevronDown
-                size={ICON_SIZE}
-                strokeWidth={ICON_STROKE}
-                className="text-muted-foreground flex-shrink-0"
-              />
+              {categoriesError ? (
+                <Tooltip content={categoriesError}>
+                  <AlertCircle
+                    size={ICON_SIZE}
+                    strokeWidth={ICON_STROKE}
+                    className="text-destructive flex-shrink-0"
+                  />
+                </Tooltip>
+              ) : (
+                <ChevronDown
+                  size={ICON_SIZE}
+                  strokeWidth={ICON_STROKE}
+                  className="text-muted-foreground flex-shrink-0"
+                />
+              )}
             </button>
 
             {showCategoryDropdown && (
@@ -949,111 +1000,147 @@ export function SkillsBrowserModal({
           {/* Skill list */}
           <div className="w-[55%] border-r border-border/40 overflow-y-auto">
             {view === 'installed' ? (
-              loadingInstalled ? (
-                <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground">
-                  <Loader2 size={20} className="animate-spin" />
-                  <span className="text-[12px]">Scanning installed skills...</span>
-                </div>
-              ) : error ? (
-                <div className="flex flex-col items-center justify-center h-full gap-3 px-8">
-                  <AlertCircle size={20} strokeWidth={ICON_STROKE} className="text-destructive" />
-                  <span className="text-[12px] text-destructive text-center">{error}</span>
-                  <button
-                    onClick={loadInstalled}
-                    className="px-3 py-1.5 rounded-md text-[12px] bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-                  >
-                    Retry
-                  </button>
-                </div>
-              ) : filteredInstalled.length === 0 ? (
-                <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground px-8 text-center">
-                  <Search size={20} strokeWidth={ICON_STROKE} />
-                  <span className="text-[12px]">
-                    {installedList.length === 0
-                      ? 'No skills installed yet. Switch to All to browse and install one.'
-                      : 'No installed skills match your filters.'}
-                  </span>
-                </div>
-              ) : (
-                <div className="divide-y divide-border/30">
-                  {filteredInstalled.map((entry) => {
-                    const cat = entry.catalog;
-                    const isCustom = !cat;
-                    // Selection match: registry skills compare by skillKey; custom skills
-                    // are tracked separately via customInstalled.skillName so we can highlight
-                    // the right row even though the synthetic stub has no real repo+path.
-                    const isSelected = isCustom
-                      ? customInstalled?.skillName === entry.skillName
-                      : selectedSkill !== null && skillKey(cat) === skillKey(selectedSkill);
-                    return (
-                      <button
-                        key={entry.skillName}
-                        onClick={() => {
-                          if (cat) handleSelectSkill(cat);
-                          else handleSelectCustom(entry);
-                        }}
-                        // Precedence: selection > custom > default. The selection class is
-                        // applied last so it wins over the custom-row tint when both apply.
-                        // Custom rows get full surface-3 (not 40%) so the tint is actually
-                        // visible against the card body.
-                        className={`w-full text-left px-4 py-3 transition-colors hover:bg-accent/40 ${
-                          isCustom ? 'bg-[hsl(var(--surface-3))]' : ''
-                        } ${isSelected ? 'bg-accent/60' : ''}`}
-                      >
-                        <div className="flex flex-col min-w-0">
-                          <div className="flex items-center gap-2 mb-0.5">
-                            <span className="text-[12px] font-medium text-foreground truncate">
-                              {cat ? displaySkillName(cat) : entry.skillName}
-                            </span>
-                            {cat?.repo === 'anthropics/skills' && (
-                              <span className="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-primary/15 text-primary leading-none flex-shrink-0">
-                                Official
+              <>
+                {/* Installed view: error/probe-failure banners ride above the list so a
+                    fresh failure doesn't blow away the data the user was looking at. */}
+                {installedError && (
+                  <div className="flex items-center gap-2 px-4 py-2 border-b border-border/40 bg-destructive/10 text-[11px] text-destructive">
+                    <AlertCircle
+                      size={ICON_SIZE}
+                      strokeWidth={ICON_STROKE}
+                      className="flex-shrink-0"
+                    />
+                    <span className="flex-1">{installedError}</span>
+                    <button
+                      onClick={loadInstalled}
+                      className="px-2 py-0.5 rounded text-[11px] font-medium bg-destructive/15 hover:bg-destructive/25 transition-colors"
+                    >
+                      Retry
+                    </button>
+                  </div>
+                )}
+                {installedProbeFailures.length > 0 && (
+                  <div className="flex items-start gap-2 px-4 py-2 border-b border-border/40 bg-destructive/10 text-[11px] text-destructive">
+                    <AlertCircle
+                      size={ICON_SIZE}
+                      strokeWidth={ICON_STROKE}
+                      className="flex-shrink-0 mt-px"
+                    />
+                    <div className="flex-1">
+                      <div className="font-medium">List may be incomplete:</div>
+                      <ul className="mt-0.5 space-y-0.5">
+                        {installedProbeFailures.map((f) => (
+                          <li key={`${f.scope}|${f.code}`} className="font-mono">
+                            {f.scope === 'global' ? '~/.claude/skills' : f.scope} ({f.code})
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                )}
+                {loadingInstalled ? (
+                  <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground">
+                    <Loader2 size={20} className="animate-spin" />
+                    <span className="text-[12px]">Scanning installed skills...</span>
+                  </div>
+                ) : filteredInstalled.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground px-8 text-center">
+                    <Search size={20} strokeWidth={ICON_STROKE} />
+                    <span className="text-[12px]">
+                      {installedList.length === 0
+                        ? 'No skills installed yet. Switch to All to browse and install one.'
+                        : 'No installed skills match your filters.'}
+                    </span>
+                  </div>
+                ) : (
+                  <div className="divide-y divide-border/30">
+                    {filteredInstalled.map((entry) => {
+                      const cat = entry.catalog;
+                      const isCustom = !cat;
+                      // Selection match: registry skills compare by skillKey; custom skills
+                      // are tracked separately via customInstalled.skillName so we can highlight
+                      // the right row even though the synthetic stub has no real repo+path.
+                      const isSelected = isCustom
+                        ? customInstalled?.skillName === entry.skillName
+                        : selectedSkill !== null && skillKey(cat) === skillKey(selectedSkill);
+                      return (
+                        <button
+                          key={entry.skillName}
+                          onClick={() => {
+                            if (cat) handleSelectSkill(cat);
+                            else handleSelectCustom(entry);
+                          }}
+                          // Precedence: selection > custom > default. The selection class is
+                          // applied last so it wins over the custom-row tint when both apply.
+                          // Custom rows get full surface-3 (not 40%) so the tint is actually
+                          // visible against the card body.
+                          className={`w-full text-left px-4 py-3 transition-colors hover:bg-accent/40 ${
+                            isCustom ? 'bg-[hsl(var(--surface-3))]' : ''
+                          } ${isSelected ? 'bg-accent/60' : ''}`}
+                        >
+                          <div className="flex flex-col min-w-0">
+                            <div className="flex items-center gap-2 mb-0.5">
+                              <span className="text-[12px] font-medium text-foreground truncate">
+                                {cat ? displaySkillName(cat) : entry.skillName}
                               </span>
-                            )}
-                            {cat && <RestrictedBadge skill={cat} />}
-                            {cat?.category && <CategoryBadge category={cat.category} />}
-                            {isCustom && (
-                              <Tooltip content="Installed locally but not present in the cached registry. Refresh, or it may live outside the top 10K by stars.">
-                                <span className="px-1.5 py-0.5 rounded text-[9px] font-medium bg-accent/60 text-muted-foreground leading-none flex-shrink-0">
-                                  Custom
+                              {cat?.repo === 'anthropics/skills' && (
+                                <span className="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-primary/15 text-primary leading-none flex-shrink-0">
+                                  Official
                                 </span>
-                              </Tooltip>
+                              )}
+                              {cat && <RestrictedBadge skill={cat} />}
+                              {cat?.category && <CategoryBadge category={cat.category} />}
+                              {isCustom && (
+                                <Tooltip content="Installed locally but not present in the cached registry. Refresh, or it may live outside the top 10K by stars.">
+                                  <span className="px-1.5 py-0.5 rounded text-[9px] font-medium bg-accent/60 text-muted-foreground leading-none flex-shrink-0">
+                                    Custom
+                                  </span>
+                                </Tooltip>
+                              )}
+                            </div>
+                            {cat?.description && (
+                              <p className="text-[11px] text-muted-foreground line-clamp-2 leading-relaxed">
+                                {cat.description}
+                              </p>
                             )}
-                          </div>
-                          {cat?.description && (
-                            <p className="text-[11px] text-muted-foreground line-clamp-2 leading-relaxed">
-                              {cat.description}
-                            </p>
-                          )}
-                          {/* Location chips replace the old right-side count + the
+                            {/* Location chips replace the old right-side count + the
                               "Installed in N locations" fallback text — now you can see
                               where the skill lives at a glance, including for custom ones. */}
-                          <LocationChips
-                            entry={entry}
-                            projects={projects}
-                            activeTasks={activeTasks}
-                          />
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              )
+                            <LocationChips
+                              entry={entry}
+                              projects={projects}
+                              activeTasks={activeTasks}
+                            />
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </>
             ) : isInitialLoad ? (
               <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground">
                 <Loader2 size={20} className="animate-spin" />
                 <span className="text-[12px]">Building skills index...</span>
               </div>
-            ) : error ? (
+            ) : searchError ? (
               <div className="flex flex-col items-center justify-center h-full gap-3 px-8">
                 <AlertCircle size={20} strokeWidth={ICON_STROKE} className="text-destructive" />
-                <span className="text-[12px] text-destructive text-center">{error}</span>
-                <button
-                  onClick={handleManualRefresh}
-                  className="px-3 py-1.5 rounded-md text-[12px] bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-                >
-                  Retry
-                </button>
+                <span className="text-[12px] text-destructive text-center">{searchError}</span>
+                <div className="flex flex-col items-center gap-2">
+                  <button
+                    onClick={handleManualRefresh}
+                    className="px-3 py-1.5 rounded-md text-[12px] bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+                  >
+                    Retry
+                  </button>
+                  <button
+                    onClick={handleResetCache}
+                    className="text-[11px] text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors"
+                  >
+                    Reset cache and refetch
+                  </button>
+                </div>
               </div>
             ) : results.length === 0 ? (
               <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground">
@@ -1211,9 +1298,9 @@ export function SkillsBrowserModal({
                   )}
                 </div>
 
-                {/* Probe error: at least one path couldn't be read (e.g. EACCES). The user
+                {/* Probe failures: paths that couldn't be read (e.g. EACCES). The user
                     should know their "not installed" view may be a false negative. */}
-                {installStatus?.probeError && (
+                {installStatus?.probeFailures && installStatus.probeFailures.length > 0 && (
                   <div className="px-5 py-2 border-t border-border/40 flex-shrink-0">
                     <div className="flex items-start gap-1.5 text-[11px] text-destructive">
                       <AlertCircle
@@ -1221,7 +1308,31 @@ export function SkillsBrowserModal({
                         strokeWidth={ICON_STROKE}
                         className="flex-shrink-0 mt-px"
                       />
-                      <span>{installStatus.probeError}</span>
+                      <div className="flex-1">
+                        <div className="font-medium">Could not check install status:</div>
+                        <ul className="mt-0.5 space-y-0.5">
+                          {installStatus.probeFailures.map((f) => (
+                            <li key={`${f.scope}|${f.code}`} className="font-mono">
+                              {f.scope === 'global' ? '~/.claude/skills' : f.scope} ({f.code})
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* IPC-level failure on the install check itself: distinct from per-path
+                    probe failures, because here we don't even have a status to show. */}
+                {installStatusError && (
+                  <div className="px-5 py-2 border-t border-border/40 flex-shrink-0">
+                    <div className="flex items-start gap-1.5 text-[11px] text-destructive">
+                      <AlertCircle
+                        size={ICON_SIZE}
+                        strokeWidth={ICON_STROKE}
+                        className="flex-shrink-0 mt-px"
+                      />
+                      <span className="flex-1">{installStatusError}</span>
                     </div>
                   </div>
                 )}
@@ -1386,12 +1497,11 @@ export function SkillsBrowserModal({
                                 <div className="border-t border-border/30 mt-1 pt-1">
                                   <div className="px-3 py-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider flex items-center justify-between">
                                     <span>Tasks</span>
-                                    <span
-                                      className="font-normal normal-case tracking-normal text-muted-foreground/70"
-                                      title="Files written here are uncommitted changes in the task's worktree."
-                                    >
-                                      uncommitted
-                                    </span>
+                                    <Tooltip content="Files written here are uncommitted changes in the task's worktree.">
+                                      <span className="font-normal normal-case tracking-normal text-muted-foreground/70">
+                                        uncommitted
+                                      </span>
+                                    </Tooltip>
                                   </div>
                                   {activeTasks.map((t) => (
                                     <button

--- a/src/renderer/components/SkillsBrowserModal.tsx
+++ b/src/renderer/components/SkillsBrowserModal.tsx
@@ -23,6 +23,7 @@ import type {
   InstalledSkill,
   ProbeFailure,
 } from '../../shared/types';
+import { deriveSkillFolderName } from '../../shared/skills';
 import { Tooltip } from './ui/Tooltip';
 
 const ICON_SIZE = 14;
@@ -109,6 +110,14 @@ function friendlyError(raw: string | undefined, fallback: string): string {
   return fallback;
 }
 
+function probeFailureKey(f: ProbeFailure): string {
+  return f.scope === 'global' ? `global|${f.code}` : `${f.path}|${f.code}`;
+}
+
+function probeFailureLabel(f: ProbeFailure): string {
+  return f.scope === 'global' ? '~/.claude/skills' : f.path;
+}
+
 function pathSegmentName(skillPath: string): string {
   const segments = skillPath.split('/').filter(Boolean);
   const last = segments[segments.length - 1] ?? '';
@@ -116,29 +125,11 @@ function pathSegmentName(skillPath: string): string {
   return last;
 }
 
-function sanitizeForFilesystem(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9-]/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
-
 function displaySkillName(skill: RegistrySkill): string {
   const raw = (skill.name ?? '').trim();
   if (raw && raw.toLowerCase() !== 'unknown') return raw;
   const fromPath = pathSegmentName(skill.path);
   return fromPath || raw || '(unnamed skill)';
-}
-
-function deriveInstallSkillName(skill: RegistrySkill): string {
-  const candidates = [skill.name, pathSegmentName(skill.path)];
-  for (const c of candidates) {
-    if (!c) continue;
-    const sanitized = sanitizeForFilesystem(c);
-    if (sanitized && sanitized !== 'unknown' && /^[a-z0-9]/.test(sanitized)) return sanitized;
-  }
-  return '';
 }
 
 function skillKey(skill: RegistrySkill): string {
@@ -529,7 +520,7 @@ export function SkillsBrowserModal({
       const target = localReadTarget;
       const result = target
         ? await window.electronAPI.skillsReadLocalSkillMd({
-            skillName: deriveInstallSkillName(skill) || skill.name,
+            skillName: deriveSkillFolderName(skill) || skill.name,
             target,
           })
         : await window.electronAPI.skillsGetContent({
@@ -538,7 +529,10 @@ export function SkillsBrowserModal({
             branch: skill.branch,
           });
       if (token !== selectionTokenRef.current) return;
-      if (result.success && result.data) {
+      // Empty SKILL.md is a legitimate (if unusual) result; checking for `result.data`
+      // truthily would route the empty-string case into the error branch with no error
+      // to display.
+      if (result.success && typeof result.data === 'string') {
         setSkillContent(result.data);
       } else {
         console.error('[SkillsBrowserModal.loadSkillContent] failed', { error: result.error });
@@ -556,7 +550,7 @@ export function SkillsBrowserModal({
   const checkInstallStatus = useCallback(
     async (skill: RegistrySkill) => {
       const token = selectionTokenRef.current;
-      const skillName = deriveInstallSkillName(skill);
+      const skillName = deriveSkillFolderName(skill);
       if (!skillName) {
         setInstallStatus(null);
         return;
@@ -683,11 +677,12 @@ export function SkillsBrowserModal({
     setSkillContentError(null);
     try {
       const result = await window.electronAPI.skillsReadLocalSkillMd({
-        skillName: deriveInstallSkillName(skill) || skill.name,
+        skillName: deriveSkillFolderName(skill) || skill.name,
         target,
       });
       if (token !== selectionTokenRef.current) return;
-      if (result.success && result.data) {
+      // Empty SKILL.md is legal — see loadSkillContent for the same rationale.
+      if (result.success && typeof result.data === 'string') {
         setSkillContent(result.data);
       } else {
         console.error('[SkillsBrowserModal.loadSkillContentFromLocal] failed', {
@@ -717,7 +712,7 @@ export function SkillsBrowserModal({
 
   async function handleUninstall(target: SkillInstallTarget, label?: string) {
     if (!selectedSkill) return;
-    const skillName = deriveInstallSkillName(selectedSkill);
+    const skillName = deriveSkillFolderName(selectedSkill);
     if (!skillName) {
       setInstallError('Cannot derive a valid skill name to remove.');
       return;
@@ -765,7 +760,7 @@ export function SkillsBrowserModal({
 
   async function handleInstall(target: SkillInstallTarget, label?: string) {
     if (!selectedSkill) return;
-    const skillName = deriveInstallSkillName(selectedSkill);
+    const skillName = deriveSkillFolderName(selectedSkill);
     if (!skillName) {
       setInstallError('Cannot derive a valid skill name to install.');
       return;
@@ -1074,8 +1069,8 @@ export function SkillsBrowserModal({
                       <div className="font-medium">List may be incomplete:</div>
                       <ul className="mt-0.5 space-y-0.5">
                         {installedProbeFailures.map((f) => (
-                          <li key={`${f.scope}|${f.code}`} className="font-mono">
-                            {f.scope === 'global' ? '~/.claude/skills' : f.scope} ({f.code})
+                          <li key={probeFailureKey(f)} className="font-mono">
+                            {probeFailureLabel(f)} ({f.code})
                           </li>
                         ))}
                       </ul>
@@ -1146,9 +1141,6 @@ export function SkillsBrowserModal({
                                 {cat.description}
                               </p>
                             )}
-                            {/* Location chips replace the old right-side count + the
-                              "Installed in N locations" fallback text — now you can see
-                              where the skill lives at a glance, including for custom ones. */}
                             <LocationChips
                               entry={entry}
                               projects={projects}
@@ -1355,8 +1347,8 @@ export function SkillsBrowserModal({
                         <div className="font-medium">Could not check install status:</div>
                         <ul className="mt-0.5 space-y-0.5">
                           {installStatus.probeFailures.map((f) => (
-                            <li key={`${f.scope}|${f.code}`} className="font-mono">
-                              {f.scope === 'global' ? '~/.claude/skills' : f.scope} ({f.code})
+                            <li key={probeFailureKey(f)} className="font-mono">
+                              {probeFailureLabel(f)} ({f.code})
                             </li>
                           ))}
                         </ul>

--- a/src/renderer/components/SkillsBrowserModal.tsx
+++ b/src/renderer/components/SkillsBrowserModal.tsx
@@ -12,9 +12,24 @@ import {
   AlertCircle,
   Check,
   FolderOpen,
+  GitBranch,
   Trash2,
 } from 'lucide-react';
-import type { RegistrySkill, SkillInstallStatus } from '../../shared/types';
+import type {
+  RegistrySkill,
+  SkillInstallStatus,
+  SkillInstallTarget,
+  SkillsRegistryMeta,
+  InstalledSkill,
+} from '../../shared/types';
+import { Tooltip } from './ui/Tooltip';
+
+const ICON_SIZE = 14;
+const ICON_STROKE = 1.8;
+const PAGE_SIZE = 50;
+const SEARCH_DEBOUNCE_MS = 200;
+// 24 hours; matches main-process TTL. We use this only to decide whether to auto-refresh on open.
+const STALE_AFTER_MS = 24 * 60 * 60 * 1000;
 
 interface ProjectInfo {
   id: string;
@@ -22,9 +37,22 @@ interface ProjectInfo {
   path: string;
 }
 
+interface ActiveTaskInfo {
+  taskId: string;
+  taskName: string;
+  worktreePath: string;
+  projectId: string;
+  projectName: string;
+}
+
 interface SkillsBrowserModalProps {
   projects: ProjectInfo[];
   activeProjectId?: string;
+  /** Every worktree-backed, non-archived task across all projects. Shown in the install
+   *  dropdown so users can scope a skill to any specific task, not just the current one. */
+  activeTasks: ActiveTaskInfo[];
+  /** ID of the task currently focused in the main UI; used to highlight it in the list. */
+  currentTaskId?: string;
   onClose: () => void;
 }
 
@@ -48,29 +76,201 @@ function formatStars(n: number): string {
   return String(n);
 }
 
+// Uppercase K to match GitHub's UI; lowercase k is reserved for the star count below.
+function formatCount(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}K`;
+  return String(n);
+}
+
+// Map known failure modes to actionable user-facing messages. Raw errors still go to the logs.
+function friendlyError(raw: string | undefined, fallback: string): string {
+  if (!raw) return fallback;
+  const lower = raw.toLowerCase();
+  if (lower.includes('aborterror') || lower.includes('aborted'))
+    return 'Request timed out. Try again.';
+  if (lower.includes('rate limit') || lower.includes('403')) {
+    return 'GitHub rate limit hit. Try again later.';
+  }
+  if (lower.includes('eacces') || lower.includes('permission denied')) {
+    return 'Permission denied writing to the install directory.';
+  }
+  if (lower.includes('enospc')) return 'Not enough disk space.';
+  if (
+    lower.includes('failed to fetch') ||
+    lower.includes('econnrefused') ||
+    lower.includes('enotfound')
+  ) {
+    return 'Network error reaching GitHub.';
+  }
+  if (lower.includes('invalid')) return raw;
+  return fallback;
+}
+
+function pathSegmentName(skillPath: string): string {
+  const segments = skillPath.split('/').filter(Boolean);
+  const last = segments[segments.length - 1] ?? '';
+  if (last.toLowerCase() === 'skill.md') return segments[segments.length - 2] ?? '';
+  return last;
+}
+
+function sanitizeForFilesystem(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function displaySkillName(skill: RegistrySkill): string {
+  const raw = (skill.name ?? '').trim();
+  if (raw && raw.toLowerCase() !== 'unknown') return raw;
+  const fromPath = pathSegmentName(skill.path);
+  return fromPath || raw || '(unnamed skill)';
+}
+
+function deriveInstallSkillName(skill: RegistrySkill): string {
+  const candidates = [skill.name, pathSegmentName(skill.path)];
+  for (const c of candidates) {
+    if (!c) continue;
+    const sanitized = sanitizeForFilesystem(c);
+    if (sanitized && sanitized !== 'unknown' && /^[a-z0-9]/.test(sanitized)) return sanitized;
+  }
+  return '';
+}
+
+function skillKey(skill: RegistrySkill): string {
+  return `${skill.repo}|${skill.path}`;
+}
+
+function skillGithubUrl(skill: RegistrySkill): string {
+  // The slim cache doesn't persist a deep link, so synthesize one from repo+branch+path
+  // when path looks like a real file/folder. Falls back to the repo root.
+  const cleanPath = skill.path.replace(/\/+$/, '');
+  if (cleanPath) {
+    return `https://github.com/${skill.repo}/blob/${skill.branch}/${cleanPath}`;
+  }
+  return `https://github.com/${skill.repo}`;
+}
+
+// Literal Tailwind classes so the JIT scanner picks them up at build time. Each slot
+// references one of the --cat-1..8 tokens defined in index.css (light + dark variants).
+const CATEGORY_PALETTE = [
+  'bg-[hsl(var(--cat-1)/0.16)] text-[hsl(var(--cat-1))]',
+  'bg-[hsl(var(--cat-2)/0.16)] text-[hsl(var(--cat-2))]',
+  'bg-[hsl(var(--cat-3)/0.16)] text-[hsl(var(--cat-3))]',
+  'bg-[hsl(var(--cat-4)/0.16)] text-[hsl(var(--cat-4))]',
+  'bg-[hsl(var(--cat-5)/0.16)] text-[hsl(var(--cat-5))]',
+  'bg-[hsl(var(--cat-6)/0.16)] text-[hsl(var(--cat-6))]',
+  'bg-[hsl(var(--cat-7)/0.16)] text-[hsl(var(--cat-7))]',
+  'bg-[hsl(var(--cat-8)/0.16)] text-[hsl(var(--cat-8))]',
+] as const;
+
+// djb2 hash → slot. Same category always lands on the same slot, so the badge color
+// is consistent everywhere the same category appears (cards, detail header, future filters).
+function categorySlot(category: string): number {
+  let h = 5381;
+  for (let i = 0; i < category.length; i++) {
+    h = ((h << 5) + h) ^ category.charCodeAt(i);
+  }
+  return Math.abs(h) % CATEGORY_PALETTE.length;
+}
+
 function CategoryBadge({ category }: { category: string }) {
   if (!category) return null;
+  const colorClasses = CATEGORY_PALETTE[categorySlot(category)];
   return (
-    <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent/60 text-muted-foreground leading-none">
+    <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium leading-none ${colorClasses}`}>
       {CATEGORY_LABELS[category] || category}
     </span>
+  );
+}
+
+function RestrictedBadge({ skill }: { skill: RegistrySkill }) {
+  if (skill.distribution !== 'restricted') return null;
+  return (
+    <Tooltip content="Restricted license — verify upstream terms on GitHub before reuse.">
+      <span className="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-destructive/15 text-destructive leading-none flex-shrink-0">
+        Restricted
+      </span>
+    </Tooltip>
+  );
+}
+
+interface LocationChipsProps {
+  entry: InstalledSkill;
+  projects: ProjectInfo[];
+  activeTasks: ActiveTaskInfo[];
+}
+
+// Renders one chip per install location for an installed skill row. Each chip carries
+// an icon hinting the scope (global / project / task) and a label, so users can see
+// at a glance where a skill lives without opening the detail pane.
+function LocationChips({ entry, projects, activeTasks }: LocationChipsProps) {
+  type Chip = { key: string; kind: 'global' | 'project' | 'task'; label: string };
+  const chips: Chip[] = [];
+  if (entry.globalInstalled) chips.push({ key: 'global', kind: 'global', label: 'Global' });
+  for (const pp of entry.installedPaths) {
+    const matchedTask = activeTasks.find((t) => t.worktreePath === pp);
+    if (matchedTask) {
+      chips.push({ key: pp, kind: 'task', label: matchedTask.taskName });
+      continue;
+    }
+    const matchedProject = projects.find((p) => p.path === pp);
+    chips.push({ key: pp, kind: 'project', label: matchedProject?.name ?? pp });
+  }
+  if (chips.length === 0) return null;
+  return (
+    <div className="flex items-center gap-1 flex-wrap mt-1">
+      {chips.map((c) => (
+        <span
+          key={c.key}
+          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent/60 text-muted-foreground leading-none"
+        >
+          {c.kind === 'task' ? (
+            <GitBranch size={10} strokeWidth={ICON_STROKE} />
+          ) : c.kind === 'project' ? (
+            <FolderOpen size={10} strokeWidth={ICON_STROKE} />
+          ) : null}
+          <span className="truncate max-w-[140px]">{c.label}</span>
+        </span>
+      ))}
+    </div>
   );
 }
 
 export function SkillsBrowserModal({
   projects,
   activeProjectId,
+  activeTasks,
+  currentTaskId,
   onClose,
 }: SkillsBrowserModalProps) {
   const [closing, setClosing] = useState(false);
-  const [skills, setSkills] = useState<RegistrySkill[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [meta, setMeta] = useState<SkillsRegistryMeta | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [results, setResults] = useState<RegistrySkill[]>([]);
+  const [resultTotal, setResultTotal] = useState(0);
+  const [pageOffset, setPageOffset] = useState(0);
+  const [searching, setSearching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<string>('');
+  // 'all' searches the registry cache; 'installed' lists only what's on disk and joins
+  // back to the cache for metadata.
+  const [view, setView] = useState<'all' | 'installed'>('all');
+  const [installedList, setInstalledList] = useState<InstalledSkill[]>([]);
+  const [loadingInstalled, setLoadingInstalled] = useState(false);
   const [categories, setCategories] = useState<string[]>([]);
   const [selectedSkill, setSelectedSkill] = useState<RegistrySkill | null>(null);
+  // When non-null, the currently-selected skill is a local-only install (no catalog entry),
+  // so SKILL.md must be read from this on-disk location instead of fetched from GitHub.
+  // Carries 'global' or an absolute project/worktree path — same shape skills:readLocalSkillMd
+  // expects on the IPC. The companion `customInstalled` keeps the original entry around so
+  // we can render the "Installed in" panel correctly without re-running checkInstalled.
+  const [localReadLocation, setLocalReadLocation] = useState<string | null>(null);
+  const [customInstalled, setCustomInstalled] = useState<InstalledSkill | null>(null);
   const [skillContent, setSkillContent] = useState<string | null>(null);
+  const [skillContentError, setSkillContentError] = useState<string | null>(null);
   const [loadingContent, setLoadingContent] = useState(false);
   const [installing, setInstalling] = useState(false);
   const [installSuccess, setInstallSuccess] = useState<string | null>(null);
@@ -78,11 +278,15 @@ export function SkillsBrowserModal({
   const [showInstallDropdown, setShowInstallDropdown] = useState(false);
   const [installStatus, setInstallStatus] = useState<SkillInstallStatus | null>(null);
   const [uninstalling, setUninstalling] = useState(false);
-  const [displayLimit, setDisplayLimit] = useState(50);
   const searchRef = useRef<HTMLInputElement>(null);
-  const searchTimerRef = useRef<ReturnType<typeof setTimeout>>();
-  const [filteredSkills, setFilteredSkills] = useState<RegistrySkill[]>([]);
-  const [filteredTotal, setFilteredTotal] = useState(0);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  // Each search bumps a token; results from earlier (slower) searches are discarded if a newer one finished first.
+  const searchTokenRef = useRef(0);
+  // Same idea, but for the detail panel: rapidly clicking between skills must not let
+  // a slower per-skill IPC (skillsCheckInstalled / skillsGetContent) land after a newer
+  // selection and overwrite state for the wrong skill — the trash buttons on "Installed in"
+  // would then point at the wrong target.
+  const selectionTokenRef = useRef(0);
   const [showCategoryDropdown, setShowCategoryDropdown] = useState(false);
 
   const handleClose = useCallback(() => {
@@ -103,193 +307,410 @@ export function SkillsBrowserModal({
     setTimeout(() => searchRef.current?.focus(), 100);
   }, []);
 
-  // Initial fetch
-  useEffect(() => {
-    fetchSkills();
-  }, []);
-
-  // Search/filter when query or category changes
-  useEffect(() => {
-    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
-    searchTimerRef.current = setTimeout(() => {
-      filterSkills();
-    }, 200);
-    return () => {
-      if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
-    };
-  }, [query, category, skills]);
-
-  async function fetchSkills(forceRefresh = false) {
-    setLoading(true);
-    setError(null);
-    try {
-      const result = await window.electronAPI.skillsFetchRegistry(
-        forceRefresh ? { forceRefresh: true } : undefined,
-      );
-      if (result.success && result.data) {
-        setSkills(result.data);
-        // Extract categories
-        const cats = new Set<string>();
-        for (const s of result.data) {
-          if (s.category) cats.add(s.category);
+  const runSearch = useCallback(
+    async (
+      nextQuery: string,
+      nextCategory: string,
+      offset: number,
+      append: boolean,
+    ): Promise<void> => {
+      const token = ++searchTokenRef.current;
+      setSearching(true);
+      setError(null);
+      try {
+        const result = await window.electronAPI.skillsSearch({
+          query: nextQuery,
+          category: nextCategory || undefined,
+          limit: PAGE_SIZE,
+          offset,
+        });
+        if (token !== searchTokenRef.current) return;
+        if (result.success && result.data) {
+          setResults((prev) => (append ? [...prev, ...result.data!.skills] : result.data!.skills));
+          setResultTotal(result.data.total);
+          setPageOffset(offset);
+        } else {
+          console.error('[SkillsBrowserModal.runSearch] failed', { error: result.error });
+          setError(friendlyError(result.error, 'Search failed'));
         }
-        setCategories(Array.from(cats).sort());
+      } catch (err) {
+        if (token !== searchTokenRef.current) return;
+        console.error('[SkillsBrowserModal.runSearch] threw', err);
+        setError(friendlyError(String(err), 'Search failed'));
+      } finally {
+        if (token === searchTokenRef.current) setSearching(false);
+      }
+    },
+    [],
+  );
+
+  const refreshRegistry = useCallback(
+    async (force: boolean): Promise<SkillsRegistryMeta | null> => {
+      setRefreshing(true);
+      setError(null);
+      try {
+        const result = await window.electronAPI.skillsRefresh(force ? { force: true } : undefined);
+        if (result.success && result.data) {
+          setMeta(result.data);
+          return result.data;
+        }
+        console.error('[SkillsBrowserModal.refreshRegistry] failed', { error: result.error });
+        setError(friendlyError(result.error, 'Failed to refresh skills registry'));
+        return null;
+      } catch (err) {
+        console.error('[SkillsBrowserModal.refreshRegistry] threw', err);
+        setError(friendlyError(String(err), 'Failed to refresh skills registry'));
+        return null;
+      } finally {
+        setRefreshing(false);
+      }
+    },
+    [],
+  );
+
+  const loadCategories = useCallback(async () => {
+    try {
+      const result = await window.electronAPI.skillsGetCategories();
+      if (result.success && result.data) {
+        setCategories(result.data);
       } else {
-        setError(result.error || 'Failed to load skills registry');
+        // Non-fatal: dropdown shows only "All categories" if this fails. Log so we'd
+        // notice the regression rather than silently shipping a broken filter list.
+        console.error('[SkillsBrowserModal.loadCategories] failed', { error: result.error });
       }
     } catch (err) {
-      setError(String(err));
+      console.error('[SkillsBrowserModal.loadCategories] threw', err);
+    }
+  }, []);
+
+  const loadInstalled = useCallback(async () => {
+    setLoadingInstalled(true);
+    setError(null);
+    try {
+      const probePaths = [
+        ...projects.map((p) => p.path),
+        ...activeTasks.map((t) => t.worktreePath),
+      ];
+      const result = await window.electronAPI.skillsListInstalled({ probePaths });
+      if (result.success && result.data) {
+        setInstalledList(result.data);
+      } else {
+        console.error('[SkillsBrowserModal.loadInstalled] failed', { error: result.error });
+        setError(friendlyError(result.error, 'Failed to list installed skills'));
+      }
+    } catch (err) {
+      console.error('[SkillsBrowserModal.loadInstalled] threw', err);
+      setError(friendlyError(String(err), 'Failed to list installed skills'));
     } finally {
-      setLoading(false);
+      setLoadingInstalled(false);
     }
-  }
+  }, [projects, activeTasks]);
 
-  function filterSkills() {
-    const q = query.toLowerCase().trim();
-    let result = skills;
+  // Re-run the installed scan whenever the user toggles into the Installed view (also
+  // after an install or uninstall while in this view, via the dependency on activeTasks/projects).
+  useEffect(() => {
+    if (view !== 'installed') return;
+    loadInstalled();
+  }, [view, loadInstalled]);
 
-    if (q) {
-      result = result.filter(
-        (s) =>
-          s.name.toLowerCase().includes(q) ||
-          s.description.toLowerCase().includes(q) ||
-          s.tags.some((t) => t.toLowerCase().includes(q)) ||
-          s.repo.toLowerCase().includes(q),
-      );
+  // First-open lifecycle: read meta, refresh if missing/stale, then load categories + run an empty search.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const metaResp = await window.electronAPI.skillsGetMeta();
+        if (cancelled) return;
+        const current = metaResp.success && metaResp.data ? metaResp.data : null;
+        const stale =
+          !current ||
+          current.totalCount === 0 ||
+          current.fetchedAt === null ||
+          Date.now() - current.fetchedAt > STALE_AFTER_MS;
+        const metaToUse = stale ? await refreshRegistry(false) : current;
+        if (cancelled) return;
+        if (metaToUse) setMeta(metaToUse);
+        await loadCategories();
+        if (cancelled) return;
+        await runSearch('', '', 0, false);
+      } catch (err) {
+        // The async helpers (refreshRegistry, runSearch) handle their own errors via
+        // setError; this catch protects against unexpected throws from the bridge itself
+        // (e.g. preload mis-binding) so the modal isn't left wedged in `refreshing` state.
+        if (cancelled) return;
+        console.error('[SkillsBrowserModal] open-lifecycle threw', err);
+        setError(friendlyError(String(err), 'Failed to open Skills Browser'));
+        setRefreshing(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshRegistry, loadCategories, runSearch]);
+
+  // Debounced search on query/category change. The first effect (above) seeds results,
+  // so we skip the very first run here to avoid a duplicate empty search.
+  const initialRenderRef = useRef(true);
+  useEffect(() => {
+    if (initialRenderRef.current) {
+      initialRenderRef.current = false;
+      return;
     }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      runSearch(query, category, 0, false);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, category, runSearch]);
 
-    if (category) {
-      result = result.filter((s) => s.category === category);
+  async function handleManualRefresh() {
+    const next = await refreshRegistry(true);
+    if (next) {
+      await loadCategories();
+      runSearch(query, category, 0, false);
     }
-
-    // Pin official skills at the top
-    result.sort((a, b) => {
-      const aOfficial = a.repo === 'anthropics/skills' ? 1 : 0;
-      const bOfficial = b.repo === 'anthropics/skills' ? 1 : 0;
-      if (aOfficial !== bOfficial) return bOfficial - aOfficial;
-      return 0; // Keep original star-based order otherwise
-    });
-
-    setFilteredSkills(result);
-    setFilteredTotal(result.length);
-    setDisplayLimit(50);
   }
 
   async function loadSkillContent(skill: RegistrySkill) {
+    const token = selectionTokenRef.current;
     setLoadingContent(true);
     setSkillContent(null);
+    setSkillContentError(null);
     try {
-      const result = await window.electronAPI.skillsGetContent({
-        repo: skill.repo,
-        path: skill.path,
-        branch: skill.branch,
-      });
+      // Custom (local-only) skills aren't in the registry and have no repo to fetch from —
+      // read the SKILL.md off the local filesystem instead. localReadLocation is captured
+      // up-front so a switch-back to a registry skill mid-await is still tied to the right token.
+      const localLoc = localReadLocation;
+      const result = localLoc
+        ? await window.electronAPI.skillsReadLocalSkillMd({
+            skillName: deriveInstallSkillName(skill) || skill.name,
+            installLocation: localLoc,
+          })
+        : await window.electronAPI.skillsGetContent({
+            repo: skill.repo,
+            path: skill.path,
+            branch: skill.branch,
+          });
+      if (token !== selectionTokenRef.current) return;
       if (result.success && result.data) {
         setSkillContent(result.data);
       } else {
-        setSkillContent(`Failed to load: ${result.error || 'Unknown error'}`);
+        console.error('[SkillsBrowserModal.loadSkillContent] failed', { error: result.error });
+        setSkillContentError(friendlyError(result.error, 'Failed to load SKILL.md'));
       }
     } catch (err) {
-      setSkillContent(`Failed to load: ${err}`);
+      if (token !== selectionTokenRef.current) return;
+      console.error('[SkillsBrowserModal.loadSkillContent] threw', err);
+      setSkillContentError(friendlyError(String(err), 'Failed to load SKILL.md'));
     } finally {
-      setLoadingContent(false);
+      if (token === selectionTokenRef.current) setLoadingContent(false);
     }
   }
 
+  const checkInstallStatus = useCallback(
+    async (skill: RegistrySkill) => {
+      const token = selectionTokenRef.current;
+      const skillName = deriveInstallSkillName(skill);
+      if (!skillName) {
+        setInstallStatus(null);
+        return;
+      }
+      // Include every active worktree task path so the "Installed in" section can show
+      // task-scoped installs alongside global/project ones. The backend just probes paths;
+      // the renderer figures out which is which when rendering.
+      const probePaths = [
+        ...projects.map((p) => p.path),
+        ...activeTasks.map((t) => t.worktreePath),
+      ];
+      try {
+        const result = await window.electronAPI.skillsCheckInstalled({
+          skillName,
+          probePaths,
+        });
+        if (token !== selectionTokenRef.current) return;
+        if (result.success && result.data) {
+          setInstallStatus(result.data);
+        } else {
+          console.error('[SkillsBrowserModal.checkInstallStatus] failed', {
+            error: result.error,
+          });
+          setInstallStatus(null);
+        }
+      } catch (err) {
+        if (token !== selectionTokenRef.current) return;
+        console.error('[SkillsBrowserModal.checkInstallStatus] threw', err);
+        setInstallStatus(null);
+      }
+    },
+    [projects, activeTasks],
+  );
+
   function handleSelectSkill(skill: RegistrySkill) {
+    // Bump the selection token so any in-flight loadSkillContent / checkInstallStatus
+    // for the previous skill will discard their results when they eventually resolve.
+    selectionTokenRef.current += 1;
     setSelectedSkill(skill);
     setSkillContent(null);
+    setSkillContentError(null);
     setInstallSuccess(null);
     setInstallError(null);
     setInstallStatus(null);
+    setLocalReadLocation(null);
+    setCustomInstalled(null);
     checkInstallStatus(skill);
   }
 
-  async function checkInstallStatus(skill: RegistrySkill) {
-    const skillName = skill.name.replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-');
+  // For installed skills the registry doesn't know about: synthesize a stub RegistrySkill
+  // so the detail pane works, route SKILL.md reads to the local filesystem instead of
+  // GitHub, and skip the registry-driven install flow (the skill is already on disk).
+  function handleSelectCustom(entry: InstalledSkill) {
+    selectionTokenRef.current += 1;
+    // Pick a deterministic location to read from: prefer global, otherwise the first
+    // probe path we know it's installed in. Both reads return the same SKILL.md content
+    // unless the user has divergent copies — acceptable trade-off vs. UI complexity.
+    const installLocation = entry.globalInstalled ? 'global' : entry.installedPaths[0];
+    if (!installLocation) {
+      // Defensive: listInstalled wouldn't surface an entry with neither global nor
+      // probe-path installs, but a stale render could. Skip silently.
+      return;
+    }
+    const stub: RegistrySkill = {
+      name: entry.skillName,
+      description: '',
+      repo: '',
+      path: '',
+      branch: '',
+      category: '',
+      tags: [],
+      stars: 0,
+    };
+    setSelectedSkill(stub);
+    setSkillContent(null);
+    setSkillContentError(null);
+    setInstallSuccess(null);
+    setInstallError(null);
+    // Synthesize the install status from the entry we already have — no IPC needed.
+    setInstallStatus({
+      global: entry.globalInstalled,
+      installedPaths: entry.installedPaths,
+    });
+    setLocalReadLocation(installLocation);
+    setCustomInstalled(entry);
+    // Custom skills have no description/stars/repo — the SKILL.md body is the only useful
+    // surface. Kick off the read immediately so users don't have to click "View SKILL.md".
+    // Note: loadSkillContent reads localReadLocation off state at call time, so we pass the
+    // synthesized location explicitly via a closure-captured variable to avoid the stale-state
+    // race (setState is async; the fetch would otherwise see localReadLocation=null).
+    void loadSkillContentFromLocal(stub, installLocation);
+  }
+
+  // Twin of loadSkillContent that takes the install location as an explicit arg, used by
+  // handleSelectCustom to avoid waiting for setLocalReadLocation to flush before reading.
+  async function loadSkillContentFromLocal(skill: RegistrySkill, installLocation: string) {
+    const token = selectionTokenRef.current;
+    setLoadingContent(true);
+    setSkillContent(null);
+    setSkillContentError(null);
     try {
-      const result = await window.electronAPI.skillsCheckInstalled({
-        skillName,
-        projectPaths: projects.map((p) => p.path),
+      const result = await window.electronAPI.skillsReadLocalSkillMd({
+        skillName: deriveInstallSkillName(skill) || skill.name,
+        installLocation,
       });
+      if (token !== selectionTokenRef.current) return;
       if (result.success && result.data) {
-        setInstallStatus(result.data);
+        setSkillContent(result.data);
+      } else {
+        console.error('[SkillsBrowserModal.loadSkillContentFromLocal] failed', {
+          error: result.error,
+        });
+        setSkillContentError(friendlyError(result.error, 'Failed to read SKILL.md'));
       }
-    } catch {
-      // Non-critical
+    } catch (err) {
+      if (token !== selectionTokenRef.current) return;
+      console.error('[SkillsBrowserModal.loadSkillContentFromLocal] threw', err);
+      setSkillContentError(friendlyError(String(err), 'Failed to read SKILL.md'));
+    } finally {
+      if (token === selectionTokenRef.current) setLoadingContent(false);
     }
   }
 
-  async function handleUninstall(
-    target: 'global' | 'project',
-    projectPath?: string,
-    projectName?: string,
-  ) {
+  // Human-readable destination label for install/uninstall toasts.
+  function targetLabel(target: SkillInstallTarget, skillName: string, label?: string): string {
+    switch (target.kind) {
+      case 'global':
+        return `~/.claude/skills/${skillName}/`;
+      case 'project':
+        return `${label || 'project'}/.claude/skills/${skillName}/`;
+      case 'task':
+        return `task “${label || 'current task'}” (worktree)`;
+    }
+  }
+
+  async function handleUninstall(target: SkillInstallTarget, label?: string) {
     if (!selectedSkill) return;
+    const skillName = deriveInstallSkillName(selectedSkill);
+    if (!skillName) {
+      setInstallError('Cannot derive a valid skill name to remove.');
+      return;
+    }
     setUninstalling(true);
     setInstallSuccess(null);
     setInstallError(null);
 
-    const skillName = selectedSkill.name.replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-');
-
     try {
-      const result = await window.electronAPI.skillsUninstall({
-        skillName,
-        target,
-        projectPath,
-      });
+      const result = await window.electronAPI.skillsUninstall({ skillName, target });
       if (result.success) {
-        setInstallSuccess(
-          target === 'global'
-            ? `Removed from ~/.claude/skills/${skillName}/`
-            : `Removed from ${projectName || 'project'}`,
-        );
+        setInstallSuccess(`Removed from ${targetLabel(target, skillName, label)}`);
         checkInstallStatus(selectedSkill);
+        // Keep the Installed list in sync when the user is viewing it; otherwise the
+        // card they just removed would linger until they switch tabs.
+        if (view === 'installed') loadInstalled();
       } else {
-        setInstallError(result.error || 'Removal failed');
+        setInstallError(friendlyError(result.error, 'Removal failed'));
       }
     } catch (err) {
-      setInstallError(String(err));
+      console.error('[SkillsBrowserModal.handleUninstall] threw', err);
+      setInstallError(friendlyError(String(err), 'Removal failed'));
     } finally {
       setUninstalling(false);
     }
   }
 
-  async function handleInstall(
-    target: 'global' | 'project',
-    projectPath?: string,
-    projectName?: string,
-  ) {
+  async function handleInstall(target: SkillInstallTarget, label?: string) {
     if (!selectedSkill) return;
+    const skillName = deriveInstallSkillName(selectedSkill);
+    if (!skillName) {
+      setInstallError('Cannot derive a valid skill name to install.');
+      return;
+    }
     setInstalling(true);
     setInstallSuccess(null);
     setInstallError(null);
     setShowInstallDropdown(false);
 
-    // Derive a clean skill name from the registry name
-    const skillName = selectedSkill.name.replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-');
-
     try {
       const result = await window.electronAPI.skillsInstall({
-        repo: selectedSkill.repo,
-        path: selectedSkill.path,
-        branch: selectedSkill.branch,
+        ref: {
+          repo: selectedSkill.repo,
+          path: selectedSkill.path,
+          branch: selectedSkill.branch,
+        },
         skillName,
         target,
-        projectPath: target === 'project' ? projectPath : undefined,
       });
       if (result.success) {
-        setInstallSuccess(
-          target === 'global'
-            ? `Installed to ~/.claude/skills/${skillName}/`
-            : `Installed to ${projectName || 'project'}/.claude/skills/${skillName}/`,
-        );
+        setInstallSuccess(`Installed to ${targetLabel(target, skillName, label)}`);
         checkInstallStatus(selectedSkill);
+        // Keep the Installed list in sync when the user is viewing it; otherwise the
+        // card they just removed would linger until they switch tabs.
+        if (view === 'installed') loadInstalled();
       } else {
-        setInstallError(result.error || 'Installation failed');
+        setInstallError(friendlyError(result.error, 'Installation failed'));
       }
     } catch (err) {
-      setInstallError(String(err));
+      console.error('[SkillsBrowserModal.handleInstall] threw', err);
+      setInstallError(friendlyError(String(err), 'Installation failed'));
     } finally {
       setInstalling(false);
     }
@@ -299,7 +720,30 @@ export function SkillsBrowserModal({
     if (e.target === e.currentTarget) handleClose();
   }
 
-  const displayedSkills = filteredSkills.slice(0, displayLimit);
+  const showLoadMore = view === 'all' && pageOffset + results.length < resultTotal;
+  const totalCached = meta?.totalCount ?? 0;
+  const isInitialLoad = refreshing && results.length === 0;
+  const hasActiveFilter = query.trim().length > 0 || category.length > 0;
+
+  // Client-side filter for the Installed view. The list is small (anything a user has
+  // actually installed) so doing this in JS is fine and avoids round-tripping to main
+  // for every keystroke.
+  const filteredInstalled = (() => {
+    if (view !== 'installed') return [];
+    const q = query.trim().toLowerCase();
+    return installedList.filter((entry) => {
+      if (category && entry.catalog?.category !== category) return false;
+      if (!q) return true;
+      const haystacks = [
+        entry.skillName,
+        entry.catalog?.name,
+        entry.catalog?.description,
+        entry.catalog?.repo,
+        ...(entry.catalog?.tags ?? []),
+      ];
+      return haystacks.some((h) => typeof h === 'string' && h.toLowerCase().includes(q));
+    });
+  })();
 
   return (
     <div
@@ -314,42 +758,100 @@ export function SkillsBrowserModal({
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div
-          className="flex items-center justify-between px-5 h-12 border-b border-border/60 flex-shrink-0"
-          style={{ background: 'hsl(var(--surface-2))' }}
-        >
+        <div className="flex items-center justify-between px-5 h-12 border-b border-border/60 flex-shrink-0 bg-[hsl(var(--surface-2))]">
           <div className="flex items-center gap-3 min-w-0">
-            <Blocks size={14} className="text-muted-foreground flex-shrink-0" strokeWidth={1.8} />
+            <Blocks
+              size={ICON_SIZE}
+              strokeWidth={ICON_STROKE}
+              className="text-muted-foreground flex-shrink-0"
+            />
             <span className="text-[13px] font-medium text-foreground">Skills Browser</span>
-            {!loading && (
-              <span className="text-[11px] text-muted-foreground">
-                {filteredTotal} skill{filteredTotal !== 1 ? 's' : ''}
-              </span>
-            )}
+            {view === 'installed'
+              ? !loadingInstalled && (
+                  <span className="text-[11px] text-muted-foreground">
+                    {formatCount(filteredInstalled.length)} installed
+                    {hasActiveFilter && filteredInstalled.length !== installedList.length && (
+                      <span className="ml-1 text-muted-foreground/70">
+                        of {formatCount(installedList.length)}
+                      </span>
+                    )}
+                  </span>
+                )
+              : !isInitialLoad &&
+                (totalCached > 0 ? (
+                  <Tooltip
+                    content={`Searching across the top ${totalCached} skills by GitHub stars. Refresh to update.`}
+                  >
+                    <span className="text-[11px] text-muted-foreground">
+                      {formatCount(resultTotal)} result{resultTotal !== 1 ? 's' : ''}
+                      {/* "of N" is only meaningful when filtering reduces results — otherwise it
+                          just duplicates the same number in two formats. */}
+                      {hasActiveFilter && resultTotal !== totalCached && (
+                        <span className="ml-1 text-muted-foreground/70">
+                          of {formatCount(totalCached)}
+                        </span>
+                      )}
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <span className="text-[11px] text-muted-foreground">
+                    {formatCount(resultTotal)} result{resultTotal !== 1 ? 's' : ''}
+                  </span>
+                ))}
           </div>
 
           <div className="flex items-center gap-1">
-            <button
-              onClick={() => fetchSkills(true)}
-              disabled={loading}
-              className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-all duration-150 disabled:opacity-40"
-              title="Refresh registry"
-            >
-              <RefreshCw size={13} strokeWidth={2} className={loading ? 'animate-spin' : ''} />
-            </button>
-            <button
-              onClick={handleClose}
-              className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-all duration-150"
-            >
-              <X size={14} strokeWidth={2} />
-            </button>
+            <Tooltip content="Refresh registry">
+              <button
+                onClick={handleManualRefresh}
+                disabled={refreshing}
+                className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-all duration-150 disabled:opacity-40"
+              >
+                <RefreshCw
+                  size={ICON_SIZE}
+                  strokeWidth={ICON_STROKE}
+                  className={refreshing ? 'animate-spin' : ''}
+                />
+              </button>
+            </Tooltip>
+            <Tooltip content="Close">
+              <button
+                onClick={handleClose}
+                className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-all duration-150"
+              >
+                <X size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+              </button>
+            </Tooltip>
           </div>
         </div>
+
+        {/* Stale-cache banner */}
+        {meta?.stale && meta.totalCount > 0 && (
+          <div className="flex items-center gap-2 px-4 py-2 border-b border-border/40 bg-destructive/10 text-[11px] text-destructive">
+            <AlertCircle size={ICON_SIZE} strokeWidth={ICON_STROKE} className="flex-shrink-0" />
+            <span className="flex-1">
+              Refresh failed; showing cached results
+              {meta.fetchedAt ? ` from ${new Date(meta.fetchedAt).toLocaleString()}` : ''}.
+              {meta.refreshError ? ` (${friendlyError(meta.refreshError, 'Network error')})` : ''}
+            </span>
+            <button
+              onClick={handleManualRefresh}
+              disabled={refreshing}
+              className="px-2 py-0.5 rounded text-[11px] font-medium bg-destructive/15 hover:bg-destructive/25 transition-colors disabled:opacity-40"
+            >
+              Retry
+            </button>
+          </div>
+        )}
 
         {/* Search bar */}
         <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border/40">
           <div className="flex-1 flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-background border border-border/60 focus-within:border-primary/40 transition-colors">
-            <Search size={13} className="text-muted-foreground flex-shrink-0" strokeWidth={2} />
+            <Search
+              size={ICON_SIZE}
+              strokeWidth={ICON_STROKE}
+              className="text-muted-foreground flex-shrink-0"
+            />
             <input
               ref={searchRef}
               type="text"
@@ -363,9 +865,33 @@ export function SkillsBrowserModal({
                 onClick={() => setQuery('')}
                 className="text-muted-foreground hover:text-foreground"
               >
-                <X size={11} strokeWidth={2} />
+                <X size={ICON_SIZE} strokeWidth={ICON_STROKE} />
               </button>
             )}
+          </div>
+
+          {/* View toggle: All catalog vs only what's installed on disk */}
+          <div className="flex rounded-lg border border-border/60 overflow-hidden text-[12px]">
+            <button
+              onClick={() => setView('all')}
+              className={`px-2.5 py-1.5 transition-colors ${
+                view === 'all'
+                  ? 'bg-accent text-foreground font-medium'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              All
+            </button>
+            <button
+              onClick={() => setView('installed')}
+              className={`px-2.5 py-1.5 transition-colors ${
+                view === 'installed'
+                  ? 'bg-accent text-foreground font-medium'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Installed
+            </button>
           </div>
 
           {/* Category filter */}
@@ -377,7 +903,11 @@ export function SkillsBrowserModal({
               <span className="truncate">
                 {category ? CATEGORY_LABELS[category] || category : 'All categories'}
               </span>
-              <ChevronDown size={11} className="text-muted-foreground flex-shrink-0" />
+              <ChevronDown
+                size={ICON_SIZE}
+                strokeWidth={ICON_STROKE}
+                className="text-muted-foreground flex-shrink-0"
+              />
             </button>
 
             {showCategoryDropdown && (
@@ -418,35 +948,126 @@ export function SkillsBrowserModal({
         <div className="flex-1 flex overflow-hidden">
           {/* Skill list */}
           <div className="w-[55%] border-r border-border/40 overflow-y-auto">
-            {loading ? (
+            {view === 'installed' ? (
+              loadingInstalled ? (
+                <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground">
+                  <Loader2 size={20} className="animate-spin" />
+                  <span className="text-[12px]">Scanning installed skills...</span>
+                </div>
+              ) : error ? (
+                <div className="flex flex-col items-center justify-center h-full gap-3 px-8">
+                  <AlertCircle size={20} strokeWidth={ICON_STROKE} className="text-destructive" />
+                  <span className="text-[12px] text-destructive text-center">{error}</span>
+                  <button
+                    onClick={loadInstalled}
+                    className="px-3 py-1.5 rounded-md text-[12px] bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+                  >
+                    Retry
+                  </button>
+                </div>
+              ) : filteredInstalled.length === 0 ? (
+                <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground px-8 text-center">
+                  <Search size={20} strokeWidth={ICON_STROKE} />
+                  <span className="text-[12px]">
+                    {installedList.length === 0
+                      ? 'No skills installed yet. Switch to All to browse and install one.'
+                      : 'No installed skills match your filters.'}
+                  </span>
+                </div>
+              ) : (
+                <div className="divide-y divide-border/30">
+                  {filteredInstalled.map((entry) => {
+                    const cat = entry.catalog;
+                    const isCustom = !cat;
+                    // Selection match: registry skills compare by skillKey; custom skills
+                    // are tracked separately via customInstalled.skillName so we can highlight
+                    // the right row even though the synthetic stub has no real repo+path.
+                    const isSelected = isCustom
+                      ? customInstalled?.skillName === entry.skillName
+                      : selectedSkill !== null && skillKey(cat) === skillKey(selectedSkill);
+                    return (
+                      <button
+                        key={entry.skillName}
+                        onClick={() => {
+                          if (cat) handleSelectSkill(cat);
+                          else handleSelectCustom(entry);
+                        }}
+                        // Precedence: selection > custom > default. The selection class is
+                        // applied last so it wins over the custom-row tint when both apply.
+                        // Custom rows get full surface-3 (not 40%) so the tint is actually
+                        // visible against the card body.
+                        className={`w-full text-left px-4 py-3 transition-colors hover:bg-accent/40 ${
+                          isCustom ? 'bg-[hsl(var(--surface-3))]' : ''
+                        } ${isSelected ? 'bg-accent/60' : ''}`}
+                      >
+                        <div className="flex flex-col min-w-0">
+                          <div className="flex items-center gap-2 mb-0.5">
+                            <span className="text-[12px] font-medium text-foreground truncate">
+                              {cat ? displaySkillName(cat) : entry.skillName}
+                            </span>
+                            {cat?.repo === 'anthropics/skills' && (
+                              <span className="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-primary/15 text-primary leading-none flex-shrink-0">
+                                Official
+                              </span>
+                            )}
+                            {cat && <RestrictedBadge skill={cat} />}
+                            {cat?.category && <CategoryBadge category={cat.category} />}
+                            {isCustom && (
+                              <Tooltip content="Installed locally but not present in the cached registry. Refresh, or it may live outside the top 10K by stars.">
+                                <span className="px-1.5 py-0.5 rounded text-[9px] font-medium bg-accent/60 text-muted-foreground leading-none flex-shrink-0">
+                                  Custom
+                                </span>
+                              </Tooltip>
+                            )}
+                          </div>
+                          {cat?.description && (
+                            <p className="text-[11px] text-muted-foreground line-clamp-2 leading-relaxed">
+                              {cat.description}
+                            </p>
+                          )}
+                          {/* Location chips replace the old right-side count + the
+                              "Installed in N locations" fallback text — now you can see
+                              where the skill lives at a glance, including for custom ones. */}
+                          <LocationChips
+                            entry={entry}
+                            projects={projects}
+                            activeTasks={activeTasks}
+                          />
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )
+            ) : isInitialLoad ? (
               <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground">
                 <Loader2 size={20} className="animate-spin" />
-                <span className="text-[12px]">Loading skills registry...</span>
+                <span className="text-[12px]">Building skills index...</span>
               </div>
             ) : error ? (
               <div className="flex flex-col items-center justify-center h-full gap-3 px-8">
-                <AlertCircle size={20} className="text-destructive" />
+                <AlertCircle size={20} strokeWidth={ICON_STROKE} className="text-destructive" />
                 <span className="text-[12px] text-destructive text-center">{error}</span>
                 <button
-                  onClick={() => fetchSkills(true)}
+                  onClick={handleManualRefresh}
                   className="px-3 py-1.5 rounded-md text-[12px] bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
                 >
                   Retry
                 </button>
               </div>
-            ) : displayedSkills.length === 0 ? (
+            ) : results.length === 0 ? (
               <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground">
-                <Search size={20} />
+                <Search size={20} strokeWidth={ICON_STROKE} />
                 <span className="text-[12px]">No skills found</span>
               </div>
             ) : (
               <div className="divide-y divide-border/30">
-                {displayedSkills.map((skill) => (
+                {results.map((skill) => (
                   <button
-                    key={`${skill.repo}-${skill.name}`}
+                    key={skillKey(skill)}
                     onClick={() => handleSelectSkill(skill)}
                     className={`w-full text-left px-4 py-3 hover:bg-accent/40 transition-colors ${
-                      selectedSkill?.name === skill.name && selectedSkill?.repo === skill.repo
+                      selectedSkill && skillKey(selectedSkill) === skillKey(skill)
                         ? 'bg-accent/60'
                         : ''
                     }`}
@@ -455,13 +1076,14 @@ export function SkillsBrowserModal({
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 mb-0.5">
                           <span className="text-[12px] font-medium text-foreground truncate">
-                            {skill.name}
+                            {displaySkillName(skill)}
                           </span>
                           {skill.repo === 'anthropics/skills' && (
                             <span className="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-primary/15 text-primary leading-none flex-shrink-0">
                               Official
                             </span>
                           )}
+                          <RestrictedBadge skill={skill} />
                           <CategoryBadge category={skill.category} />
                         </div>
                         <p className="text-[11px] text-muted-foreground line-clamp-2 leading-relaxed">
@@ -469,20 +1091,23 @@ export function SkillsBrowserModal({
                         </p>
                       </div>
                       <div className="flex items-center gap-1 text-[11px] text-muted-foreground flex-shrink-0 pt-0.5">
-                        <Star size={10} strokeWidth={2} />
+                        <Star size={ICON_SIZE} strokeWidth={ICON_STROKE} />
                         <span>{formatStars(skill.stars)}</span>
                       </div>
                     </div>
                   </button>
                 ))}
 
-                {displayLimit < filteredTotal && (
+                {showLoadMore && (
                   <div className="px-4 py-3">
                     <button
-                      onClick={() => setDisplayLimit((l) => l + 50)}
-                      className="w-full py-2 rounded-md text-[12px] text-muted-foreground hover:text-foreground hover:bg-accent/40 transition-colors border border-border/40"
+                      onClick={() => runSearch(query, category, pageOffset + results.length, true)}
+                      disabled={searching}
+                      className="w-full py-2 rounded-md text-[12px] text-muted-foreground hover:text-foreground hover:bg-accent/40 transition-colors border border-border/40 disabled:opacity-50"
                     >
-                      Load more ({filteredTotal - displayLimit} remaining)
+                      {searching
+                        ? 'Loading...'
+                        : `Load more (${resultTotal - (pageOffset + results.length)} remaining)`}
                     </button>
                   </div>
                 )}
@@ -498,52 +1123,87 @@ export function SkillsBrowserModal({
                 <div className="px-5 pt-4 pb-3 border-b border-border/40">
                   <div className="flex items-center gap-2 mb-2">
                     <h3 className="text-[14px] font-semibold text-foreground">
-                      {selectedSkill.name}
+                      {displaySkillName(selectedSkill)}
                     </h3>
                     {selectedSkill.repo === 'anthropics/skills' && (
                       <span className="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-primary/15 text-primary leading-none">
                         Official
                       </span>
                     )}
+                    <RestrictedBadge skill={selectedSkill} />
+                    {customInstalled && (
+                      <Tooltip content="Installed locally. No catalog entry — description and stars come from the SKILL.md file itself.">
+                        <span className="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-accent/60 text-muted-foreground leading-none">
+                          Custom
+                        </span>
+                      </Tooltip>
+                    )}
                   </div>
 
-                  <p className="text-[12px] text-muted-foreground leading-relaxed mb-3">
-                    {selectedSkill.description}
-                  </p>
+                  {selectedSkill.description && (
+                    <p className="text-[12px] text-muted-foreground leading-relaxed mb-3">
+                      {selectedSkill.description}
+                    </p>
+                  )}
 
-                  <div className="flex items-center gap-4 text-[11px] text-muted-foreground">
-                    <span className="flex items-center gap-1">
-                      <Star size={10} strokeWidth={2} />
-                      {formatStars(selectedSkill.stars)} stars
-                    </span>
+                  <div className="flex items-center gap-4 text-[11px] text-muted-foreground flex-wrap">
+                    {/* Stars and GitHub link only make sense for catalog skills — custom
+                        skills have no remote source. */}
+                    {!customInstalled && (
+                      <span className="flex items-center gap-1">
+                        <Star size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+                        {formatStars(selectedSkill.stars)} stars
+                      </span>
+                    )}
                     {selectedSkill.category && <CategoryBadge category={selectedSkill.category} />}
-                    <button
-                      onClick={() =>
-                        window.electronAPI.openExternal(`https://github.com/${selectedSkill.repo}`)
-                      }
-                      className="flex items-center gap-1 hover:text-foreground transition-colors"
-                    >
-                      <ExternalLink size={10} strokeWidth={2} />
-                      {selectedSkill.repo}
-                    </button>
+                    {selectedSkill.repo && (
+                      <Tooltip content={`Open on GitHub: ${skillGithubUrl(selectedSkill)}`}>
+                        <button
+                          onClick={() =>
+                            window.electronAPI.openExternal(skillGithubUrl(selectedSkill))
+                          }
+                          className="flex items-center gap-1 hover:text-foreground transition-colors"
+                        >
+                          <ExternalLink size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+                          {selectedSkill.repo}
+                        </button>
+                      </Tooltip>
+                    )}
                   </div>
                 </div>
 
                 {/* SKILL.md content */}
                 <div className="flex-1 overflow-y-auto px-5 py-3">
-                  {skillContent === null && !loadingContent ? (
+                  {loadingContent ? (
+                    <div className="flex items-center gap-2 text-muted-foreground py-4">
+                      <Loader2 size={ICON_SIZE} className="animate-spin" />
+                      <span className="text-[12px]">Loading...</span>
+                    </div>
+                  ) : skillContentError ? (
+                    <div className="flex flex-col gap-2">
+                      <div className="flex items-start gap-1.5 text-[12px] text-destructive">
+                        <AlertCircle
+                          size={ICON_SIZE}
+                          strokeWidth={ICON_STROKE}
+                          className="flex-shrink-0 mt-px"
+                        />
+                        <span>{skillContentError}</span>
+                      </div>
+                      <button
+                        onClick={() => loadSkillContent(selectedSkill)}
+                        className="self-start px-3 py-1.5 rounded-md text-[12px] text-muted-foreground hover:text-foreground hover:bg-accent/40 transition-colors border border-border/40"
+                      >
+                        Retry
+                      </button>
+                    </div>
+                  ) : skillContent === null ? (
                     <button
                       onClick={() => loadSkillContent(selectedSkill)}
                       className="flex items-center gap-2 px-3 py-2 rounded-md text-[12px] text-muted-foreground hover:text-foreground hover:bg-accent/40 transition-colors border border-border/40"
                     >
-                      <FolderOpen size={12} strokeWidth={2} />
+                      <FolderOpen size={ICON_SIZE} strokeWidth={ICON_STROKE} />
                       View SKILL.md
                     </button>
-                  ) : loadingContent ? (
-                    <div className="flex items-center gap-2 text-muted-foreground py-4">
-                      <Loader2 size={14} className="animate-spin" />
-                      <span className="text-[12px]">Loading...</span>
-                    </div>
                   ) : (
                     <pre className="text-[11px] text-foreground/90 whitespace-pre-wrap break-words font-mono leading-relaxed">
                       {skillContent}
@@ -551,9 +1211,24 @@ export function SkillsBrowserModal({
                   )}
                 </div>
 
+                {/* Probe error: at least one path couldn't be read (e.g. EACCES). The user
+                    should know their "not installed" view may be a false negative. */}
+                {installStatus?.probeError && (
+                  <div className="px-5 py-2 border-t border-border/40 flex-shrink-0">
+                    <div className="flex items-start gap-1.5 text-[11px] text-destructive">
+                      <AlertCircle
+                        size={ICON_SIZE}
+                        strokeWidth={ICON_STROKE}
+                        className="flex-shrink-0 mt-px"
+                      />
+                      <span>{installStatus.probeError}</span>
+                    </div>
+                  </div>
+                )}
+
                 {/* Installed status */}
                 {installStatus &&
-                  (installStatus.global || installStatus.projectPaths.length > 0) && (
+                  (installStatus.global || installStatus.installedPaths.length > 0) && (
                     <div className="px-5 py-2 border-t border-border/40 flex-shrink-0">
                       <div className="text-[11px] font-medium text-muted-foreground mb-1.5">
                         Installed in
@@ -563,45 +1238,80 @@ export function SkillsBrowserModal({
                           <div className="flex items-center justify-between gap-2 py-1 px-2 rounded-md bg-accent/30">
                             <div className="flex items-center gap-1.5 text-[11px] text-foreground min-w-0">
                               <Check
-                                size={11}
-                                strokeWidth={2}
+                                size={ICON_SIZE}
+                                strokeWidth={ICON_STROKE}
                                 className="text-[hsl(var(--git-added))] flex-shrink-0"
                               />
                               <span className="truncate">Global (~/.claude/skills/)</span>
                             </div>
-                            <button
-                              onClick={() => handleUninstall('global')}
-                              disabled={uninstalling}
-                              className="p-1 rounded hover:bg-destructive/15 text-muted-foreground hover:text-destructive transition-colors flex-shrink-0 disabled:opacity-40"
-                              title="Remove"
-                            >
-                              <Trash2 size={11} strokeWidth={2} />
-                            </button>
+                            <Tooltip content="Remove globally installed skill">
+                              <button
+                                onClick={() => handleUninstall({ kind: 'global' })}
+                                disabled={uninstalling}
+                                className="p-1 rounded hover:bg-destructive/15 text-muted-foreground hover:text-destructive transition-colors flex-shrink-0 disabled:opacity-40"
+                              >
+                                <Trash2 size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+                              </button>
+                            </Tooltip>
                           </div>
                         )}
-                        {installStatus.projectPaths.map((pp) => {
-                          const proj = projects.find((p) => p.path === pp);
+                        {installStatus.installedPaths.map((pp) => {
+                          // The probe list mixes project paths and active task worktrees.
+                          // Match the path back to the right scope so we can label it and
+                          // target the right uninstall variant.
+                          const matchedTask = activeTasks.find((t) => t.worktreePath === pp);
+                          const matchedProject = matchedTask
+                            ? null
+                            : projects.find((p) => p.path === pp);
+                          const target: SkillInstallTarget = matchedTask
+                            ? { kind: 'task', worktreePath: pp }
+                            : { kind: 'project', projectPath: pp };
+                          const primaryLabel = matchedTask
+                            ? matchedTask.taskName
+                            : matchedProject?.name || pp;
+                          const secondaryLabel = matchedTask ? matchedTask.projectName : null;
+                          const removeTooltip = matchedTask
+                            ? `Remove from task “${matchedTask.taskName}” (worktree in ${matchedTask.projectName})`
+                            : `Remove from ${matchedProject?.name || pp}`;
+                          const Icon = matchedTask ? GitBranch : Check;
                           return (
                             <div
                               key={pp}
                               className="flex items-center justify-between gap-2 py-1 px-2 rounded-md bg-accent/30"
                             >
                               <div className="flex items-center gap-1.5 text-[11px] text-foreground min-w-0">
-                                <Check
-                                  size={11}
-                                  strokeWidth={2}
-                                  className="text-[hsl(var(--git-added))] flex-shrink-0"
+                                <Icon
+                                  size={ICON_SIZE}
+                                  strokeWidth={ICON_STROKE}
+                                  className={
+                                    matchedTask
+                                      ? 'text-muted-foreground flex-shrink-0'
+                                      : 'text-[hsl(var(--git-added))] flex-shrink-0'
+                                  }
                                 />
-                                <span className="truncate">{proj?.name || pp}</span>
+                                <span className="truncate">
+                                  {primaryLabel}
+                                  {secondaryLabel && (
+                                    <span className="ml-1 text-muted-foreground/70">
+                                      · {secondaryLabel}
+                                    </span>
+                                  )}
+                                </span>
                               </div>
-                              <button
-                                onClick={() => handleUninstall('project', pp, proj?.name)}
-                                disabled={uninstalling}
-                                className="p-1 rounded hover:bg-destructive/15 text-muted-foreground hover:text-destructive transition-colors flex-shrink-0 disabled:opacity-40"
-                                title="Remove"
-                              >
-                                <Trash2 size={11} strokeWidth={2} />
-                              </button>
+                              <Tooltip content={removeTooltip}>
+                                <button
+                                  onClick={() =>
+                                    handleUninstall(
+                                      target,
+                                      matchedTask ? matchedTask.taskName : matchedProject?.name,
+                                    )
+                                  }
+                                  disabled={uninstalling}
+                                  className="p-1 rounded hover:bg-destructive/15 text-muted-foreground hover:text-destructive transition-colors flex-shrink-0 disabled:opacity-40"
+                                >
+                                  <Trash2 size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+                                </button>
+                              </Tooltip>
                             </div>
                           );
                         })}
@@ -609,17 +1319,20 @@ export function SkillsBrowserModal({
                     </div>
                   )}
 
-                {/* Install actions */}
+                {/* Install actions — only meaningful for catalog skills. Custom skills
+                    have no remote source to copy from, so the entire install picker is
+                    hidden; uninstall still works via the per-location trash buttons in
+                    the "Installed in" section above. */}
                 <div className="px-5 py-3 border-t border-border/40 flex-shrink-0">
                   {installSuccess && (
                     <div className="flex items-center gap-2 mb-2 text-[11px] text-[hsl(var(--git-added))]">
-                      <Check size={12} strokeWidth={2} />
+                      <Check size={ICON_SIZE} strokeWidth={ICON_STROKE} />
                       {installSuccess}
                     </div>
                   )}
                   {installError && (
                     <div className="flex items-center gap-2 mb-2 text-[11px] text-destructive">
-                      <AlertCircle size={12} strokeWidth={2} />
+                      <AlertCircle size={ICON_SIZE} strokeWidth={ICON_STROKE} />
                       {installError}
                     </div>
                   )}
@@ -627,18 +1340,22 @@ export function SkillsBrowserModal({
                   <div className="relative flex items-center gap-2">
                     {installing || uninstalling ? (
                       <div className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] text-muted-foreground">
-                        <Loader2 size={12} className="animate-spin" />
+                        <Loader2 size={ICON_SIZE} className="animate-spin" />
                         {uninstalling ? 'Removing...' : 'Installing...'}
                       </div>
+                    ) : customInstalled ? (
+                      <p className="text-[11px] text-muted-foreground italic">
+                        Custom skill — manage files directly on disk to install elsewhere.
+                      </p>
                     ) : (
                       <>
                         <button
                           onClick={() => setShowInstallDropdown(!showInstallDropdown)}
                           className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[12px] font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
                         >
-                          <Download size={12} strokeWidth={2} />
+                          <Download size={ICON_SIZE} strokeWidth={ICON_STROKE} />
                           Install
-                          <ChevronDown size={11} />
+                          <ChevronDown size={ICON_SIZE} strokeWidth={ICON_STROKE} />
                         </button>
 
                         {showInstallDropdown && (
@@ -647,14 +1364,14 @@ export function SkillsBrowserModal({
                               className="fixed inset-0 z-10"
                               onClick={() => setShowInstallDropdown(false)}
                             />
-                            <div className="absolute left-0 bottom-full mb-1 z-20 bg-card border border-border/60 rounded-lg shadow-xl py-1 min-w-[220px]">
+                            <div className="absolute left-0 bottom-full mb-1 z-20 bg-card border border-border/60 rounded-lg shadow-xl py-1 min-w-[260px] max-h-[60vh] overflow-y-auto">
                               <button
-                                onClick={() => handleInstall('global')}
+                                onClick={() => handleInstall({ kind: 'global' })}
                                 className="w-full text-left px-3 py-2 text-[12px] hover:bg-accent/60 transition-colors text-foreground flex items-center gap-2"
                               >
                                 <Download
-                                  size={12}
-                                  strokeWidth={2}
+                                  size={ICON_SIZE}
+                                  strokeWidth={ICON_STROKE}
                                   className="text-muted-foreground flex-shrink-0"
                                 />
                                 <div>
@@ -665,6 +1382,46 @@ export function SkillsBrowserModal({
                                 </div>
                               </button>
 
+                              {activeTasks.length > 0 && (
+                                <div className="border-t border-border/30 mt-1 pt-1">
+                                  <div className="px-3 py-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider flex items-center justify-between">
+                                    <span>Tasks</span>
+                                    <span
+                                      className="font-normal normal-case tracking-normal text-muted-foreground/70"
+                                      title="Files written here are uncommitted changes in the task's worktree."
+                                    >
+                                      uncommitted
+                                    </span>
+                                  </div>
+                                  {activeTasks.map((t) => (
+                                    <button
+                                      key={t.taskId}
+                                      onClick={() =>
+                                        handleInstall(
+                                          { kind: 'task', worktreePath: t.worktreePath },
+                                          t.taskName,
+                                        )
+                                      }
+                                      className={`w-full text-left px-3 py-2 text-[12px] hover:bg-accent/60 transition-colors text-foreground flex items-center gap-2 ${
+                                        t.taskId === currentTaskId ? 'bg-accent/30' : ''
+                                      }`}
+                                    >
+                                      <GitBranch
+                                        size={ICON_SIZE}
+                                        strokeWidth={ICON_STROKE}
+                                        className="text-muted-foreground flex-shrink-0"
+                                      />
+                                      <div className="min-w-0">
+                                        <div className="font-medium truncate">{t.taskName}</div>
+                                        <div className="text-[10px] text-muted-foreground/80 truncate">
+                                          {t.projectName}
+                                        </div>
+                                      </div>
+                                    </button>
+                                  ))}
+                                </div>
+                              )}
+
                               {projects.length > 0 && (
                                 <div className="border-t border-border/30 mt-1 pt-1">
                                   <div className="px-3 py-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
@@ -673,12 +1430,17 @@ export function SkillsBrowserModal({
                                   {projects.map((p) => (
                                     <button
                                       key={p.id}
-                                      onClick={() => handleInstall('project', p.path, p.name)}
+                                      onClick={() =>
+                                        handleInstall(
+                                          { kind: 'project', projectPath: p.path },
+                                          p.name,
+                                        )
+                                      }
                                       className={`w-full text-left px-3 py-2 text-[12px] hover:bg-accent/60 transition-colors text-foreground flex items-center gap-2 ${p.id === activeProjectId ? 'bg-accent/30' : ''}`}
                                     >
                                       <FolderOpen
-                                        size={12}
-                                        strokeWidth={2}
+                                        size={ICON_SIZE}
+                                        strokeWidth={ICON_STROKE}
                                         className="text-muted-foreground flex-shrink-0"
                                       />
                                       <div className="min-w-0">

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -41,6 +41,17 @@
     --git-renamed: 217 91% 60%;
     --git-untracked: 0 0% 50%;
     --git-conflicted: 25 95% 53%;
+
+    /* Category palette — hashed category names map deterministically to a slot 1..8.
+       Hues spread evenly around the wheel so adjacent slots stay distinguishable. */
+    --cat-1: 210 70% 48%; /* blue */
+    --cat-2: 142 55% 40%; /* green */
+    --cat-3: 25 85% 50%; /* orange */
+    --cat-4: 280 55% 55%; /* purple */
+    --cat-5: 340 65% 50%; /* pink */
+    --cat-6: 175 55% 38%; /* teal */
+    --cat-7: 45 80% 45%; /* gold */
+    --cat-8: 245 55% 58%; /* indigo */
   }
 
   .dark {
@@ -77,6 +88,16 @@
     --git-renamed: 217 91% 60%;
     --git-untracked: 0 0% 56%;
     --git-conflicted: 25 95% 53%;
+
+    /* Category palette (dark) — bumped lightness so badges stay legible on dark surfaces. */
+    --cat-1: 210 75% 65%;
+    --cat-2: 142 50% 55%;
+    --cat-3: 25 85% 62%;
+    --cat-4: 280 60% 70%;
+    --cat-5: 340 65% 65%;
+    --cat-6: 175 55% 55%;
+    --cat-7: 45 80% 60%;
+    --cat-8: 245 65% 72%;
   }
 }
 

--- a/src/shared/skills.ts
+++ b/src/shared/skills.ts
@@ -1,0 +1,30 @@
+import type { RegistrySkill } from './types';
+
+// Single source of truth for the folder name a registry skill installs into. Both the
+// renderer (deriving the name before calling install/uninstall) and the main process
+// (matching marker-less folders against catalog entries during backfill) must agree —
+// previously we had two near-identical copies kept in sync by comment.
+export function deriveSkillFolderName(skill: Pick<RegistrySkill, 'name' | 'path'>): string {
+  const candidates = [skill.name, lastPathSegment(skill.path)];
+  for (const c of candidates) {
+    if (!c) continue;
+    const sanitized = sanitizeForFilesystem(c);
+    if (sanitized && sanitized !== 'unknown' && /^[a-z0-9]/.test(sanitized)) return sanitized;
+  }
+  return '';
+}
+
+function lastPathSegment(p: string): string {
+  const segs = p.split('/').filter(Boolean);
+  const last = segs[segs.length - 1] ?? '';
+  if (last.toLowerCase() === 'skill.md') return segs[segs.length - 2] ?? '';
+  return last;
+}
+
+function sanitizeForFilesystem(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -381,16 +381,15 @@ export interface RegistrySkill {
   distribution?: 'compatible' | 'restricted';
 }
 
-export interface SkillsRegistryMeta {
-  /** Epoch ms when the cache was last refreshed from upstream; null if never. */
-  fetchedAt: number | null;
-  /** Number of skills currently held in the local cache. */
-  totalCount: number;
-  /** True iff the most recent refresh attempt failed and we're returning the prior cache. */
-  stale?: boolean;
-  /** Human-readable reason the latest refresh failed; only set when `stale` is true. */
-  refreshError?: string;
-}
+/**
+ * Tagged union so renderers can't confuse "no cache yet" with "stale cache" — the
+ * earlier optional-fields shape made it easy to render an empty browser silently when
+ * a refresh failure replaced a populated cache.
+ */
+export type SkillsRegistryMeta =
+  | { status: 'never-fetched'; totalCount: 0; fetchedAt: null }
+  | { status: 'fresh'; totalCount: number; fetchedAt: number }
+  | { status: 'stale'; totalCount: number; fetchedAt: number; refreshError: string };
 
 export interface SkillsSearchArgs {
   query: string;
@@ -417,19 +416,32 @@ export interface InstalledSkill {
   catalog: RegistrySkill | null;
 }
 
+export interface InstalledSkillsResult {
+  skills: InstalledSkill[];
+  /** Paths that couldn't be enumerated (EACCES, EIO etc.) — those probes silently
+   *  truncated prior to this field, so the UI now warns the user that the list may
+   *  be incomplete instead of misrepresenting "not found" results. */
+  probeFailures: ProbeFailure[];
+}
+
+export interface ProbeFailure {
+  /** 'global' for the home dir probe, otherwise an absolute project/worktree path. */
+  scope: 'global' | string;
+  /** errno code (EACCES, EIO, etc.) or 'unknown'. */
+  code: string;
+}
+
 export interface SkillInstallStatus {
   global: boolean;
   /** Subset of the input probe paths where the skill is currently installed. The caller
    *  passes both project roots and task worktree paths; the renderer maps them back. */
   installedPaths: string[];
-  /** Non-ENOENT errors encountered while probing — e.g. EACCES on a path means we don't
-   *  actually know whether the skill is installed there. UI should warn the user rather
-   *  than treat a probe failure as "not installed". */
-  probeError?: string;
+  /** Non-ENOENT errors per probe path — e.g. EACCES on /Users/foo/proj means we can't tell
+   *  whether the skill is installed there. UI should treat any of these as "unknown"
+   *  rather than "not installed", and ideally list each affected path inline. */
+  probeFailures?: ProbeFailure[];
 }
 
-/** Where a skill should be installed/uninstalled. Discriminated so the relevant path
- *  can never be missing, and so the renderer can label the result correctly. */
 export type SkillInstallTarget =
   | { kind: 'global' }
   | { kind: 'project'; projectPath: string }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -363,6 +363,11 @@ export interface PixelAgentsOffice {
 
 // ── Skills Registry Types ──────────────────────────────────
 
+/**
+ * Slim card-and-search shape persisted in the local SQLite cache. We deliberately drop
+ * registry fields we don't display (license, permissionNote, sourceUrl, author, source)
+ * — users who want license details click through to GitHub.
+ */
 export interface RegistrySkill {
   name: string;
   description: string;
@@ -372,7 +377,26 @@ export interface RegistrySkill {
   category: string;
   tags: string[];
   stars: number;
-  source: string;
+  /** "compatible" → safe to install, "restricted" → license requires verification before reuse. */
+  distribution?: 'compatible' | 'restricted';
+}
+
+export interface SkillsRegistryMeta {
+  /** Epoch ms when the cache was last refreshed from upstream; null if never. */
+  fetchedAt: number | null;
+  /** Number of skills currently held in the local cache. */
+  totalCount: number;
+  /** True iff the most recent refresh attempt failed and we're returning the prior cache. */
+  stale?: boolean;
+  /** Human-readable reason the latest refresh failed; only set when `stale` is true. */
+  refreshError?: string;
+}
+
+export interface SkillsSearchArgs {
+  query: string;
+  category?: string;
+  limit?: number;
+  offset?: number;
 }
 
 export interface SkillsSearchResult {
@@ -380,9 +404,55 @@ export interface SkillsSearchResult {
   total: number;
 }
 
+/** A skill found on disk by `listInstalled`. The catalog field carries the registry
+ *  metadata when the skill is also in our cached top-N — null otherwise (e.g. user
+ *  installed a long-tail skill, or a skill from outside the registry). */
+export interface InstalledSkill {
+  /** Folder name under .claude/skills/. */
+  skillName: string;
+  /** True iff installed at ~/.claude/skills/<skillName>/. */
+  globalInstalled: boolean;
+  /** Subset of probePaths where the skill is installed. */
+  installedPaths: string[];
+  catalog: RegistrySkill | null;
+}
+
 export interface SkillInstallStatus {
   global: boolean;
-  projectPaths: string[];
+  /** Subset of the input probe paths where the skill is currently installed. The caller
+   *  passes both project roots and task worktree paths; the renderer maps them back. */
+  installedPaths: string[];
+  /** Non-ENOENT errors encountered while probing — e.g. EACCES on a path means we don't
+   *  actually know whether the skill is installed there. UI should warn the user rather
+   *  than treat a probe failure as "not installed". */
+  probeError?: string;
+}
+
+/** Where a skill should be installed/uninstalled. Discriminated so the relevant path
+ *  can never be missing, and so the renderer can label the result correctly. */
+export type SkillInstallTarget =
+  | { kind: 'global' }
+  | { kind: 'project'; projectPath: string }
+  /** A task lives in its own worktree directory; installing here writes uncommitted
+   *  files into that worktree only — invisible to other tasks and to the project root. */
+  | { kind: 'task'; worktreePath: string };
+
+/** Identifies a remote skill in the registry. */
+export interface SkillRef {
+  repo: string;
+  path: string;
+  branch: string;
+}
+
+export interface SkillInstallArgs {
+  ref: SkillRef;
+  skillName: string;
+  target: SkillInstallTarget;
+}
+
+export interface SkillUninstallArgs {
+  skillName: string;
+  target: SkillInstallTarget;
 }
 
 export interface PixelAgentsConfig {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -424,12 +424,12 @@ export interface InstalledSkillsResult {
   probeFailures: ProbeFailure[];
 }
 
-export interface ProbeFailure {
-  /** 'global' for the home dir probe, otherwise an absolute project/worktree path. */
-  scope: 'global' | string;
-  /** errno code (EACCES, EIO, etc.) or 'unknown'. */
-  code: string;
-}
+/** Structured probe failure so the renderer can render the right label per scope without
+ *  string-sniffing. `code` is either an errno (EACCES, EIO, …) or a Dash-internal sentinel
+ *  ('marker-corrupt') so the UI can offer the matching recovery action. */
+export type ProbeFailure =
+  | { scope: 'global'; code: string }
+  | { scope: 'path'; path: string; code: string };
 
 export interface SkillInstallStatus {
   global: boolean;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -361,6 +361,30 @@ export interface PixelAgentsOffice {
   enabled: boolean;
 }
 
+// ── Skills Registry Types ──────────────────────────────────
+
+export interface RegistrySkill {
+  name: string;
+  description: string;
+  repo: string;
+  path: string;
+  branch: string;
+  category: string;
+  tags: string[];
+  stars: number;
+  source: string;
+}
+
+export interface SkillsSearchResult {
+  skills: RegistrySkill[];
+  total: number;
+}
+
+export interface SkillInstallStatus {
+  global: boolean;
+  projectPaths: string[];
+}
+
 export interface PixelAgentsConfig {
   name: string;
   palette?: number;

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -290,6 +290,9 @@ export interface ElectronAPI {
   skillsCheckInstalled: (args: {
     skillName: string;
     probePaths: string[];
+    /** Provide for registry skills so the marker file is checked; omit for legacy
+     *  presence-only checks. */
+    ref?: SkillRef | null;
   }) => Promise<IpcResponse<SkillInstallStatus>>;
   skillsListInstalled: (args: {
     probePaths: string[];

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -19,9 +19,14 @@ import type {
   PixelAgentsConfig,
   PixelAgentsStatus,
   ActivityInfo,
-  RegistrySkill,
   SkillsSearchResult,
   SkillInstallStatus,
+  SkillRef,
+  SkillInstallArgs,
+  SkillUninstallArgs,
+  SkillsSearchArgs,
+  SkillsRegistryMeta,
+  InstalledSkill,
 } from '../shared/types';
 
 export interface ElectronAPI {
@@ -271,35 +276,23 @@ export interface ElectronAPI {
   onPixelAgentsStatusChanged: (callback: (status: PixelAgentsStatus) => void) => () => void;
 
   // Skills
-  skillsFetchRegistry: (args?: { forceRefresh?: boolean }) => Promise<IpcResponse<RegistrySkill[]>>;
-  skillsSearch: (args: {
-    query: string;
-    category?: string;
-    limit?: number;
-    offset?: number;
-  }) => Promise<IpcResponse<SkillsSearchResult>>;
-  skillsGetContent: (args: {
-    repo: string;
-    path: string;
-    branch: string;
-  }) => Promise<IpcResponse<string>>;
-  skillsInstall: (args: {
-    repo: string;
-    path: string;
-    branch: string;
+  skillsRefresh: (args?: { force?: boolean }) => Promise<IpcResponse<SkillsRegistryMeta>>;
+  skillsGetMeta: () => Promise<IpcResponse<SkillsRegistryMeta>>;
+  skillsGetCategories: () => Promise<IpcResponse<string[]>>;
+  skillsSearch: (args: SkillsSearchArgs) => Promise<IpcResponse<SkillsSearchResult>>;
+  skillsGetContent: (args: SkillRef) => Promise<IpcResponse<string>>;
+  skillsReadLocalSkillMd: (args: {
     skillName: string;
-    target: 'global' | 'project';
-    projectPath?: string;
-  }) => Promise<IpcResponse<void>>;
+    /** 'global' for ~/.claude/skills, otherwise an absolute project/worktree path. */
+    installLocation: string;
+  }) => Promise<IpcResponse<string>>;
+  skillsInstall: (args: SkillInstallArgs) => Promise<IpcResponse<void>>;
   skillsCheckInstalled: (args: {
     skillName: string;
-    projectPaths: string[];
+    probePaths: string[];
   }) => Promise<IpcResponse<SkillInstallStatus>>;
-  skillsUninstall: (args: {
-    skillName: string;
-    target: 'global' | 'project';
-    projectPath?: string;
-  }) => Promise<IpcResponse<void>>;
+  skillsListInstalled: (args: { probePaths: string[] }) => Promise<IpcResponse<InstalledSkill[]>>;
+  skillsUninstall: (args: SkillUninstallArgs) => Promise<IpcResponse<void>>;
 
   // Telemetry
   telemetryCapture: (event: string, properties?: Record<string, unknown>) => Promise<void>;

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -19,6 +19,9 @@ import type {
   PixelAgentsConfig,
   PixelAgentsStatus,
   ActivityInfo,
+  RegistrySkill,
+  SkillsSearchResult,
+  SkillInstallStatus,
 } from '../shared/types';
 
 export interface ElectronAPI {
@@ -266,6 +269,37 @@ export interface ElectronAPI {
   pixelAgentsStart: () => Promise<IpcResponse<void>>;
   pixelAgentsStop: () => Promise<IpcResponse<void>>;
   onPixelAgentsStatusChanged: (callback: (status: PixelAgentsStatus) => void) => () => void;
+
+  // Skills
+  skillsFetchRegistry: (args?: { forceRefresh?: boolean }) => Promise<IpcResponse<RegistrySkill[]>>;
+  skillsSearch: (args: {
+    query: string;
+    category?: string;
+    limit?: number;
+    offset?: number;
+  }) => Promise<IpcResponse<SkillsSearchResult>>;
+  skillsGetContent: (args: {
+    repo: string;
+    path: string;
+    branch: string;
+  }) => Promise<IpcResponse<string>>;
+  skillsInstall: (args: {
+    repo: string;
+    path: string;
+    branch: string;
+    skillName: string;
+    target: 'global' | 'project';
+    projectPath?: string;
+  }) => Promise<IpcResponse<void>>;
+  skillsCheckInstalled: (args: {
+    skillName: string;
+    projectPaths: string[];
+  }) => Promise<IpcResponse<SkillInstallStatus>>;
+  skillsUninstall: (args: {
+    skillName: string;
+    target: 'global' | 'project';
+    projectPath?: string;
+  }) => Promise<IpcResponse<void>>;
 
   // Telemetry
   telemetryCapture: (event: string, properties?: Record<string, unknown>) => Promise<void>;

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -23,10 +23,11 @@ import type {
   SkillInstallStatus,
   SkillRef,
   SkillInstallArgs,
+  SkillInstallTarget,
   SkillUninstallArgs,
   SkillsSearchArgs,
   SkillsRegistryMeta,
-  InstalledSkill,
+  InstalledSkillsResult,
 } from '../shared/types';
 
 export interface ElectronAPI {
@@ -283,16 +284,18 @@ export interface ElectronAPI {
   skillsGetContent: (args: SkillRef) => Promise<IpcResponse<string>>;
   skillsReadLocalSkillMd: (args: {
     skillName: string;
-    /** 'global' for ~/.claude/skills, otherwise an absolute project/worktree path. */
-    installLocation: string;
+    target: SkillInstallTarget;
   }) => Promise<IpcResponse<string>>;
   skillsInstall: (args: SkillInstallArgs) => Promise<IpcResponse<void>>;
   skillsCheckInstalled: (args: {
     skillName: string;
     probePaths: string[];
   }) => Promise<IpcResponse<SkillInstallStatus>>;
-  skillsListInstalled: (args: { probePaths: string[] }) => Promise<IpcResponse<InstalledSkill[]>>;
+  skillsListInstalled: (args: {
+    probePaths: string[];
+  }) => Promise<IpcResponse<InstalledSkillsResult>>;
   skillsUninstall: (args: SkillUninstallArgs) => Promise<IpcResponse<void>>;
+  skillsResetCache: () => Promise<IpcResponse<SkillsRegistryMeta>>;
 
   // Telemetry
   telemetryCapture: (event: string, properties?: Record<string, unknown>) => Promise<void>;


### PR DESCRIPTION
## Summary
- Adds a Skills Browser modal that pulls from the [claude-skill-registry](https://github.com/majiayu000/claude-skill-registry) (153K+ skills sorted by GitHub stars)
- Users can search, filter by category, preview full SKILL.md content, and install skills globally or to specific projects via a dropdown
- Skills from `anthropics/skills` are marked with an "Official" badge
- Includes install status tracking and uninstall/remove support with per-location trash buttons

## New files
- `src/main/services/SkillsService.ts` — registry fetch, 24h cache (top 500 by stars), search, install/uninstall
- `src/main/ipc/skillsIpc.ts` — 6 IPC handlers (fetchRegistry, search, getContent, install, checkInstalled, uninstall)
- `src/renderer/components/SkillsBrowserModal.tsx` — split-pane UI with search, category filter, detail panel, install dropdown

## Modified files
- `src/shared/types.ts` — RegistrySkill, SkillsSearchResult, SkillInstallStatus types
- `src/main/ipc/index.ts` — register skillsIpc
- `src/main/preload.ts` — expose 6 skills methods
- `src/types/electron-api.d.ts` — skills method type signatures
- `src/renderer/App.tsx` — modal state + rendering
- `src/renderer/components/LeftSidebar.tsx` — Skills button (collapsed + expanded)

## Test plan
- [ ] Open app, verify "Skills" button appears in sidebar (both collapsed and expanded)
- [ ] Click Skills → modal opens, loads registry (first load fetches ~9.7MB, subsequent loads use cache)
- [ ] Search filters skills in real-time
- [ ] Category dropdown filters by category
- [ ] Click a skill → detail panel shows description, stars, repo link
- [ ] Click "View SKILL.md" → full content loads from GitHub
- [ ] Click "Install" dropdown → shows Global + all projects
- [ ] Install globally → skill written to `~/.claude/skills/{name}/`
- [ ] Install to project → skill written to `{projectPath}/.claude/skills/{name}/`
- [ ] Installed skills show "Installed in" section with trash button to remove
- [ ] Refresh button re-fetches registry from GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)