### PR TITLE
Fix Open in IDE: detect via .app bundles, add Custom IDE option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -9,6 +9,113 @@ const execFileAsync = promisify(execFile);
 
 const FIND_CMD = process.platform === 'win32' ? 'where.exe' : 'which';
 
+// ── IDE registry ──────────────────────────────────────────────
+// Ordered by auto-detect preference. Launching via the CLI bundled inside the
+// .app avoids relying on the user having run VS Code's "Install 'code' command
+// in PATH" (or equivalents), which is the #1 reason "Open in IDE" silently fails.
+interface IdeRegistryEntry {
+  id: string;
+  label: string;
+  macAppNames: string[]; // .app bundle basenames to look for
+  macCliInBundle: string; // path to CLI inside the .app bundle
+  linuxCommand: string; // command expected on PATH on Linux/Windows
+  newWindowArgs: string[];
+}
+
+const IDE_REGISTRY: IdeRegistryEntry[] = [
+  {
+    id: 'cursor',
+    label: 'Cursor',
+    macAppNames: ['Cursor.app'],
+    macCliInBundle: 'Contents/Resources/app/bin/cursor',
+    linuxCommand: 'cursor',
+    newWindowArgs: ['--new-window'],
+  },
+  {
+    id: 'vscode',
+    label: 'VS Code',
+    macAppNames: ['Visual Studio Code.app', 'Visual Studio Code - Insiders.app'],
+    macCliInBundle: 'Contents/Resources/app/bin/code',
+    linuxCommand: 'code',
+    newWindowArgs: ['--new-window'],
+  },
+  {
+    id: 'windsurf',
+    label: 'Windsurf',
+    macAppNames: ['Windsurf.app'],
+    macCliInBundle: 'Contents/Resources/app/bin/windsurf',
+    linuxCommand: 'windsurf',
+    newWindowArgs: ['--new-window'],
+  },
+  {
+    id: 'antigravity',
+    label: 'Antigravity',
+    macAppNames: ['Antigravity.app'],
+    macCliInBundle: 'Contents/Resources/app/bin/antigravity',
+    linuxCommand: 'antigravity',
+    newWindowArgs: ['--new-window'],
+  },
+  {
+    id: 'zed',
+    label: 'Zed',
+    macAppNames: ['Zed.app', 'Zed Preview.app'],
+    macCliInBundle: 'Contents/MacOS/cli',
+    linuxCommand: 'zed',
+    newWindowArgs: ['--new'],
+  },
+];
+
+interface DetectedIde {
+  id: string;
+  label: string;
+  launcher: string;
+  newWindowArgs: string[];
+}
+
+async function detectIdes(): Promise<DetectedIde[]> {
+  // No caching: detection is cheap (parallelized existsSync on macOS, parallel
+  // `which`/`where.exe` on Linux/Windows) and skipping the cache means
+  // install/uninstall changes take effect immediately without an app restart.
+  const appSearchRoots =
+    process.platform === 'darwin' ? ['/Applications', join(homedir(), 'Applications')] : [];
+
+  const launchers = await Promise.all(
+    IDE_REGISTRY.map(async (entry): Promise<string | null> => {
+      if (process.platform === 'darwin') {
+        for (const root of appSearchRoots) {
+          for (const appName of entry.macAppNames) {
+            const candidate = join(root, appName, entry.macCliInBundle);
+            if (existsSync(candidate)) return candidate;
+          }
+        }
+        return null;
+      }
+      // Linux and Windows: probe PATH via `which` / `where.exe`
+      try {
+        const { stdout } = await execFileAsync(FIND_CMD, [entry.linuxCommand]);
+        return stdout.trim().split(/\r?\n/)[0] || null;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  const results: DetectedIde[] = [];
+  IDE_REGISTRY.forEach((entry, i) => {
+    const launcher = launchers[i];
+    if (launcher) {
+      results.push({
+        id: entry.id,
+        label: entry.label,
+        launcher,
+        newWindowArgs: entry.newWindowArgs,
+      });
+    }
+  });
+
+  return results;
+}
+
 let cachedEditor: string | null = null;
 
 async function detectEditor(): Promise<string> {
@@ -66,6 +173,27 @@ export function registerAppIpc(): void {
       }
 
       return { success: true, data: result.filePaths };
+    } catch (error) {
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle('app:pickExecutable', async () => {
+    try {
+      const win = BrowserWindow.getFocusedWindow();
+      // On macOS, treat .app bundles as directories so the user can drill into
+      // Contents/MacOS/<binary> if they need the actual executable.
+      const properties: Electron.OpenDialogOptions['properties'] =
+        process.platform === 'darwin' ? ['openFile', 'treatPackageAsDirectory'] : ['openFile'];
+      const options: Electron.OpenDialogOptions = { properties };
+      const result = win
+        ? await dialog.showOpenDialog(win, options)
+        : await dialog.showOpenDialog(options);
+
+      if (result.canceled || result.filePaths.length === 0) {
+        return { success: true, data: null };
+      }
+      return { success: true, data: result.filePaths[0] };
     } catch (error) {
       return { success: false, error: String(error) };
     }
@@ -217,35 +345,66 @@ export function registerAppIpc(): void {
 
   ipcMain.handle(
     'app:openInIDE',
-    async (_event, args: { folderPath: string; ide?: 'cursor' | 'code' }) => {
+    async (
+      _event,
+      args: {
+        folderPath: string;
+        ide?: string;
+        // Only used when ide === 'custom'. Args may contain the literal token
+        // {path}; if absent, folderPath is appended. SECURITY: keep using
+        // execFile (argv-based) — never switch to exec/shell:true, or these
+        // user-supplied args become shell-injectable.
+        customCommand?: { path: string; args: string[] };
+      },
+    ) => {
       try {
         if (!existsSync(args.folderPath)) {
           return { success: false, error: `Path not found: ${args.folderPath}` };
         }
 
-        let ide = args.ide;
-        if (!ide) {
-          // Auto-detect: prefer cursor, then code
-          for (const candidate of ['cursor', 'code'] as const) {
-            try {
-              await execFileAsync(FIND_CMD, [candidate]);
-              ide = candidate;
-              break;
-            } catch {
-              // Not found, try next
-            }
+        if (args.ide === 'custom') {
+          const custom = args.customCommand;
+          if (!custom?.path) {
+            return { success: false, error: 'No custom IDE configured' };
           }
+          if (!existsSync(custom.path)) {
+            return { success: false, error: `Custom IDE not found: ${custom.path}` };
+          }
+          const substituted = custom.args.map((a) => a.replace('{path}', args.folderPath));
+          const finalArgs = custom.args.some((a) => a.includes('{path}'))
+            ? substituted
+            : [...substituted, args.folderPath];
+          await execFileAsync(custom.path, finalArgs);
+          return { success: true, data: null };
         }
 
-        if (!ide) {
-          return { success: false, error: 'No supported IDE found (cursor, code)' };
+        const detected = await detectIdes();
+        if (detected.length === 0) {
+          return { success: false, error: 'No supported IDE found on this machine' };
+        }
+
+        const target =
+          args.ide && args.ide !== 'auto' ? detected.find((d) => d.id === args.ide) : detected[0];
+
+        if (!target) {
+          const entry = IDE_REGISTRY.find((e) => e.id === args.ide);
+          const label = entry?.label ?? args.ide;
+          return {
+            success: false,
+            error: `${label} is not installed or its launcher could not be found`,
+          };
         }
 
         // On Windows, IDE binaries are typically .cmd wrappers that must run via cmd.exe
         if (process.platform === 'win32') {
-          await execFileAsync('cmd.exe', ['/c', ide, args.folderPath]);
+          await execFileAsync('cmd.exe', [
+            '/c',
+            target.launcher,
+            ...target.newWindowArgs,
+            args.folderPath,
+          ]);
         } else {
-          await execFileAsync(ide, [args.folderPath]);
+          await execFileAsync(target.launcher, [...target.newWindowArgs, args.folderPath]);
         }
         return { success: true, data: null };
       } catch (error) {
@@ -256,16 +415,11 @@ export function registerAppIpc(): void {
 
   ipcMain.handle('app:detectAvailableIDEs', async () => {
     try {
-      const available: string[] = [];
-      for (const ide of ['cursor', 'code']) {
-        try {
-          await execFileAsync(FIND_CMD, [ide]);
-          available.push(ide);
-        } catch {
-          // Not found
-        }
-      }
-      return { success: true, data: available };
+      const detected = await detectIdes();
+      return {
+        success: true,
+        data: detected.map(({ id, label }) => ({ id, label })),
+      };
     } catch (error) {
       return { success: false, error: String(error) };
     }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -10,9 +10,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
   openExternal: (url: string) => ipcRenderer.invoke('app:openExternal', url),
   openInEditor: (args: { cwd: string; filePath: string; line?: number; col?: number }) =>
     ipcRenderer.invoke('app:openInEditor', args),
-  openInIDE: (args: { folderPath: string; ide?: 'cursor' | 'code' }) =>
-    ipcRenderer.invoke('app:openInIDE', args),
+  openInIDE: (args: {
+    folderPath: string;
+    ide?: string;
+    customCommand?: { path: string; args: string[] };
+  }) => ipcRenderer.invoke('app:openInIDE', args),
   detectAvailableIDEs: () => ipcRenderer.invoke('app:detectAvailableIDEs'),
+  pickExecutable: () => ipcRenderer.invoke('app:pickExecutable'),
 
   // Database - Projects
   getProjects: () => ipcRenderer.invoke('db:getProjects'),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -103,9 +103,53 @@ export function App() {
   const [terminalTheme, setTerminalTheme] = useState(() => {
     return localStorage.getItem('terminalTheme') || 'default';
   });
-  const [preferredIDE, setPreferredIDE] = useState<'cursor' | 'code' | 'auto'>(() => {
-    return (localStorage.getItem('preferredIDE') as 'cursor' | 'code' | 'auto') || 'auto';
+  const [preferredIDE, setPreferredIDE] = useState<string>(() => {
+    const stored = localStorage.getItem('preferredIDE');
+    if (!stored) return 'auto';
+    // Migrate legacy 'code' → 'vscode'
+    if (stored === 'code') {
+      localStorage.setItem('preferredIDE', 'vscode');
+      return 'vscode';
+    }
+    return stored;
   });
+  const [customIDE, setCustomIDE] = useState<{ path: string; args: string[] }>(() => {
+    const raw = localStorage.getItem('customIDE');
+    if (!raw) return { path: '', args: [] };
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed.path === 'string' && Array.isArray(parsed.args)) {
+        return parsed;
+      }
+      console.warn('[openInIDE] customIDE has unexpected shape, resetting');
+    } catch (err) {
+      console.warn('[openInIDE] Failed to parse customIDE from localStorage:', err);
+    }
+    return { path: '', args: [] };
+  });
+  const [availableIDEs, setAvailableIDEs] = useState<Array<{ id: string; label: string }>>([]);
+  useEffect(() => {
+    let cancelled = false;
+    window.electronAPI.detectAvailableIDEs().then((res) => {
+      if (cancelled) return;
+      if (!res.success || !res.data) {
+        console.warn('[openInIDE] Failed to detect available IDEs:', res.error);
+        return;
+      }
+      setAvailableIDEs(res.data);
+      // Self-heal: if the stored IDE was uninstalled, fall back to auto so
+      // Settings doesn't show a phantom selection and clicks don't 404.
+      setPreferredIDE((current) => {
+        if (current === 'auto' || current === 'custom') return current;
+        if (res.data!.some((d) => d.id === current)) return current;
+        localStorage.removeItem('preferredIDE');
+        return 'auto';
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   const [commitAttribution, setCommitAttribution] = useState<string | undefined>(() => {
     const stored = localStorage.getItem('commitAttribution');
     if (stored === null) return undefined; // "default" — key absent
@@ -1610,6 +1654,16 @@ export function App() {
               localStorage.removeItem('preferredIDE');
             } else {
               localStorage.setItem('preferredIDE', v);
+            }
+          }}
+          availableIDEs={availableIDEs}
+          customIDE={customIDE}
+          onCustomIDEChange={(v) => {
+            setCustomIDE(v);
+            if (!v.path && v.args.length === 0) {
+              localStorage.removeItem('customIDE');
+            } else {
+              localStorage.setItem('customIDE', JSON.stringify(v));
             }
           }}
           commitAttribution={commitAttribution}

--- a/src/renderer/components/MainContent.tsx
+++ b/src/renderer/components/MainContent.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { TerminalPane } from './TerminalPane';
 import { ProjectOverview } from './ProjectOverview';
+import { openInIde } from '../lib/openInIde';
 import {
   FolderOpen,
   GitBranch,
@@ -329,11 +330,7 @@ export function MainContent({
             )}
             <Tooltip content="Open in IDE">
               <button
-                onClick={() => {
-                  const stored = localStorage.getItem('preferredIDE');
-                  const ide = stored === 'cursor' || stored === 'code' ? stored : undefined;
-                  window.electronAPI.openInIDE({ folderPath: activeTask.path, ide });
-                }}
+                onClick={() => openInIde(activeTask.path)}
                 className="p-1 rounded-md transition-colors text-muted-foreground hover:text-foreground hover:bg-accent/60"
               >
                 <Code2 size={14} strokeWidth={1.8} />

--- a/src/renderer/components/ProjectOverview.tsx
+++ b/src/renderer/components/ProjectOverview.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { openInIde } from '../lib/openInIde';
 import {
   GitBranch,
   Plus,
@@ -255,12 +256,7 @@ export function ProjectOverview({
                         tabIndex={-1}
                         onClick={(e) => {
                           e.stopPropagation();
-                          const stored = localStorage.getItem('preferredIDE');
-                          const ide = stored === 'cursor' || stored === 'code' ? stored : undefined;
-                          window.electronAPI.openInIDE({
-                            folderPath: task.path || project.path,
-                            ide,
-                          });
+                          openInIde(task.path || project.path);
                         }}
                         className="absolute top-3 right-3 p-1 rounded-md transition-colors text-muted-foreground hover:text-foreground hover:bg-accent/60 opacity-0 group-hover:opacity-100"
                       >

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { toast } from 'sonner';
 import {
   X,
   Check,
@@ -11,6 +12,8 @@ import {
   Trash2,
   Plus,
   ExternalLink,
+  HelpCircle,
+  FolderOpen,
 } from 'lucide-react';
 import { Tooltip } from './ui/Tooltip';
 import { ToggleSwitch } from './ui/ToggleSwitch';
@@ -67,8 +70,11 @@ interface SettingsModalProps {
   onShellDrawerPositionChange: (value: 'left' | 'main' | 'right') => void;
   terminalTheme: string;
   onTerminalThemeChange: (id: string) => void;
-  preferredIDE: 'cursor' | 'code' | 'auto';
-  onPreferredIDEChange: (value: 'cursor' | 'code' | 'auto') => void;
+  preferredIDE: string;
+  onPreferredIDEChange: (value: string) => void;
+  availableIDEs: Array<{ id: string; label: string }>;
+  customIDE: { path: string; args: string[] };
+  onCustomIDEChange: (value: { path: string; args: string[] }) => void;
   commitAttribution: string | undefined;
   onCommitAttributionChange: (value: string | undefined) => void;
   effortLevel: string;
@@ -970,6 +976,9 @@ export function SettingsModal({
   onTerminalThemeChange,
   preferredIDE,
   onPreferredIDEChange,
+  availableIDEs,
+  customIDE,
+  onCustomIDEChange,
   commitAttribution,
   onCommitAttributionChange,
   effortLevel,
@@ -1292,18 +1301,17 @@ export function SettingsModal({
                   Preferred IDE
                 </label>
                 <div className="grid grid-cols-3 gap-2">
-                  {(
-                    [
-                      { value: 'auto' as const, label: 'Auto-detect' },
-                      { value: 'cursor' as const, label: 'Cursor' },
-                      { value: 'code' as const, label: 'VS Code' },
-                    ] as const
-                  ).map(({ value, label }) => {
-                    const isActive = preferredIDE === value;
+                  {[
+                    ...(availableIDEs.length > 0
+                      ? [{ id: 'auto', label: 'Auto-detect' }, ...availableIDEs]
+                      : []),
+                    { id: 'custom', label: 'Custom' },
+                  ].map(({ id, label }) => {
+                    const isActive = preferredIDE === id;
                     return (
                       <button
-                        key={value}
-                        onClick={() => onPreferredIDEChange(value)}
+                        key={id}
+                        onClick={() => onPreferredIDEChange(id)}
                         className={`px-3 py-2.5 rounded-lg text-[12px] border transition-all duration-150 ${
                           isActive
                             ? 'border-primary/40 bg-primary/8 text-foreground ring-1 ring-primary/20 font-medium'
@@ -1315,9 +1323,84 @@ export function SettingsModal({
                     );
                   })}
                 </div>
+                {availableIDEs.length === 0 && (
+                  <p className="text-[11px] text-foreground/70 mt-2">
+                    No supported IDE auto-detected. Install Cursor, VS Code, Windsurf, Antigravity,
+                    or Zed — or configure a Custom IDE below.
+                  </p>
+                )}
                 <p className="text-[10px] text-foreground/80 mt-2">
-                  IDE used when opening a task from the header
+                  IDE used when opening a task from the header. Only installed IDEs are shown.
                 </p>
+
+                {preferredIDE === 'custom' && (
+                  <div className="mt-4 space-y-3 p-3 rounded-lg border border-border/40 bg-accent/20">
+                    <Tooltip content="Launch any editor Dash doesn't detect natively. Point at an executable and pass flags — use {path} to place the folder anywhere in the command, or it's appended at the end.">
+                      <div className="inline-flex items-center gap-1.5 cursor-help">
+                        <span className="text-[11px] font-medium text-foreground">
+                          Custom IDE command
+                        </span>
+                        <HelpCircle size={12} strokeWidth={1.8} className="text-foreground/60" />
+                      </div>
+                    </Tooltip>
+
+                    <div>
+                      <label className="block text-[10px] text-foreground/70 mb-1">
+                        Executable path
+                      </label>
+                      <div className="flex gap-2">
+                        <input
+                          type="text"
+                          value={customIDE.path}
+                          onChange={(e) =>
+                            onCustomIDEChange({ ...customIDE, path: e.target.value })
+                          }
+                          placeholder="/Applications/MyIDE.app/Contents/MacOS/myide"
+                          className="flex-1 px-2.5 py-1.5 text-[11px] rounded-md border border-border/60 bg-background text-foreground placeholder:text-foreground/40 focus:outline-none focus:ring-1 focus:ring-primary/40"
+                        />
+                        <button
+                          onClick={async () => {
+                            const res = await window.electronAPI.pickExecutable();
+                            if (!res.success) {
+                              toast.error(res.error || 'Failed to open file picker');
+                              return;
+                            }
+                            if (res.data) {
+                              onCustomIDEChange({ ...customIDE, path: res.data });
+                            }
+                          }}
+                          className="px-2.5 py-1.5 text-[11px] rounded-md border border-border/60 text-foreground/80 hover:bg-accent/40 hover:text-foreground flex items-center gap-1"
+                        >
+                          <FolderOpen size={12} strokeWidth={1.8} />
+                          Browse
+                        </button>
+                      </div>
+                    </div>
+
+                    <div>
+                      <label className="block text-[10px] text-foreground/70 mb-1">
+                        Arguments (optional, one per line)
+                      </label>
+                      <textarea
+                        value={customIDE.args.join('\n')}
+                        onChange={(e) =>
+                          onCustomIDEChange({
+                            ...customIDE,
+                            args: e.target.value.split('\n').filter((line) => line.length > 0),
+                          })
+                        }
+                        rows={3}
+                        placeholder={'--new-window\n{path}'}
+                        className="w-full px-2.5 py-1.5 text-[11px] rounded-md border border-border/60 bg-background text-foreground placeholder:text-foreground/40 focus:outline-none focus:ring-1 focus:ring-primary/40 font-mono resize-y"
+                      />
+                      <p className="text-[10px] text-foreground/60 mt-1">
+                        One argument per line — spaces inside a line are preserved. Use{' '}
+                        <code>{'{path}'}</code> to place the folder anywhere; otherwise it's
+                        appended at the end.
+                      </p>
+                    </div>
+                  </div>
+                )}
               </div>
 
               {/* Commit Attribution */}

--- a/src/renderer/lib/openInIde.ts
+++ b/src/renderer/lib/openInIde.ts
@@ -1,0 +1,27 @@
+import { toast } from 'sonner';
+
+export async function openInIde(folderPath: string): Promise<void> {
+  const preferredIDE = localStorage.getItem('preferredIDE') || 'auto';
+
+  let customCommand: { path: string; args: string[] } | undefined;
+  if (preferredIDE === 'custom') {
+    try {
+      const raw = localStorage.getItem('customIDE');
+      if (raw) customCommand = JSON.parse(raw);
+    } catch (err) {
+      // Leave customCommand undefined so the main process surfaces a clear
+      // "No custom IDE configured" toast rather than crashing on exec.
+      console.warn('[openInIDE] Failed to parse customIDE from localStorage:', err);
+    }
+  }
+
+  const res = await window.electronAPI.openInIDE({
+    folderPath,
+    ide: preferredIDE,
+    customCommand,
+  });
+
+  if (!res.success) {
+    toast.error(res.error || 'Failed to open in IDE');
+  }
+}

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -35,8 +35,13 @@ export interface ElectronAPI {
     line?: number;
     col?: number;
   }) => Promise<IpcResponse<null>>;
-  openInIDE: (args: { folderPath: string; ide?: 'cursor' | 'code' }) => Promise<IpcResponse<null>>;
-  detectAvailableIDEs: () => Promise<IpcResponse<string[]>>;
+  openInIDE: (args: {
+    folderPath: string;
+    ide?: string;
+    customCommand?: { path: string; args: string[] };
+  }) => Promise<IpcResponse<null>>;
+  detectAvailableIDEs: () => Promise<IpcResponse<Array<{ id: string; label: string }>>>;
+  pickExecutable: () => Promise<IpcResponse<string | null>>;
 
   // Database - Projects
   getProjects: () => Promise<IpcResponse<Project[]>>;


### PR DESCRIPTION
## Summary

Fixes #118 — "Open in IDE" silently failed when users uninstalled their preferred editor or had VS Code installed without the `code` shell CLI. This PR overhauls detection and launching, adds a Custom IDE escape hatch, and surfaces failures to the user.

- **Detect via `.app` bundles, not shell CLIs.** On macOS, detection now walks `/Applications` and `~/Applications` looking for known bundles (Cursor, VS Code + Insiders, Windsurf, Antigravity, Zed) and launches via the CLI bundled inside each bundle (e.g. `Cursor.app/Contents/Resources/app/bin/cursor`). This removes the dependency on the user having run VS Code's *"Install 'code' command in PATH"* (which was the #1 reason clicks silently did nothing).
- **New-window launching.** All detected IDEs are launched with the appropriate new-window flag (`--new-window` for VS Code-family, `--new` for Zed).
- **Self-healing `preferredIDE`.** If the stored selection points at an IDE that's no longer installed, it resets to `auto` on next launch instead of leaving the picker in a phantom state.
- **Custom IDE option.** New "Custom" tile in Settings reveals an executable-path input (with a Browse button that understands `.app` bundles on macOS) and a one-arg-per-line textarea for flags. `{path}` is substituted with the folder; otherwise the folder is appended at the end.
- **Toast on failure.** Previously silent — now the user gets a sonner toast with the actual error (`ENOENT`, `Path not found`, etc.).
- **Linux fallback** uses parallel `which` probes for the same IDE list.

### Security

`execFile` with argv is preserved throughout — custom user-supplied args never hit a shell. A `SECURITY:` comment in `openInIDE` warns future maintainers not to switch to `exec`/`shell: true`.

## Test plan

- [x] `pnpm type-check` clean
- [x] macOS: click "Open in IDE" on a task with Cursor installed → new window opens
- [x] macOS: click "Open in IDE" with VS Code installed but no `code` CLI in PATH → still opens
- [x] macOS: uninstall Cursor while app is running, click again → detection refreshes (no cache), toast surfaces error if nothing installed
- [x] Settings → Preferred IDE: only installed IDEs appear; selecting one and clicking works
- [x] Settings → Custom → Browse: picks a binary (or drills into an `.app`), launches correctly with custom flags
- [x] Custom IDE with args containing spaces (one arg per line) is preserved as a single argv entry
- [x] Malformed `customIDE` in localStorage → console warning, graceful fallback to empty form
- [x] With previously-selected IDE uninstalled, Settings shows `auto` selected (self-healing)
- [x] Failure path (e.g. custom path points at a non-existent file) surfaces a toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)