### PR TITLE
Show context usage in Active Tasks, add toggle to Usage tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/renderer/components/LeftSidebar.tsx
+++ b/src/renderer/components/LeftSidebar.tsx
@@ -36,6 +36,7 @@ function RotationSection({
   projects,
   onSelectTask,
   onRemoveFromRotation,
+  contextUsage = {},
 }: {
   rotationTasks: Task[];
   activeTaskId: string | null;
@@ -44,6 +45,7 @@ function RotationSection({
   projects: Project[];
   onSelectTask: (projectId: string, taskId: string) => void;
   onRemoveFromRotation?: (taskId: string) => void;
+  contextUsage?: Record<string, ContextUsage>;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
@@ -102,6 +104,7 @@ function RotationSection({
           const activity = taskActivity[task.id]?.state;
           const isActiveTask = task.id === activeTaskId;
           const project = projects.find((p) => p.id === task.projectId);
+          const ctx = contextUsage[task.id];
 
           return (
             <div
@@ -128,6 +131,18 @@ function RotationSection({
               ) : null}
 
               <span className="truncate flex-1">{task.name}</span>
+              {ctx && ctx.percentage > 0 && (
+                <span
+                  className={`text-[9px] tabular-nums flex-shrink-0 ${
+                    ctx.percentage >= 80
+                      ? 'text-red-400 font-medium'
+                      : usageTextColor(ctx.percentage)
+                  }`}
+                  title={`Context: ${ctx.used.toLocaleString()} / ${ctx.total.toLocaleString()} tokens (${Math.round(ctx.percentage)}%)`}
+                >
+                  {Math.round(ctx.percentage)}%
+                </span>
+              )}
               {project && (
                 <span className="text-muted-foreground/40 text-[11px] whitespace-nowrap overflow-hidden flex-shrink min-w-0">
                   {project.name}
@@ -402,6 +417,7 @@ export function LeftSidebar({
           projects={projects}
           onSelectTask={onSelectTask}
           onRemoveFromRotation={onRemoveFromRotation}
+          contextUsage={contextUsage}
         />
       )}
 

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -581,12 +581,16 @@ function UsageSection({
   latestRateLimits,
   thresholds,
   onThresholdsChange,
+  showUsageInline,
+  onShowUsageInlineChange,
 }: {
   statusLineData: Record<string, StatusLineData>;
   taskNames: Record<string, string>;
   latestRateLimits?: RateLimits;
   thresholds: UsageThresholds;
   onThresholdsChange: (t: UsageThresholds) => void;
+  showUsageInline: boolean;
+  onShowUsageInlineChange: (value: boolean) => void;
 }) {
   const entries = Object.entries(statusLineData);
 
@@ -687,6 +691,24 @@ function UsageSection({
             ))}
           </div>
         )}
+      </div>
+
+      {/* Inline Usage Display */}
+      <div>
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-foreground/60">
+            Display
+          </span>
+          <div className="flex-1 h-px bg-border/30" />
+        </div>
+        <ToggleSwitch
+          enabled={showUsageInline}
+          onToggle={onShowUsageInlineChange}
+          label="Show context usage in sidebar and header"
+        />
+        <p className="text-[10px] text-foreground/40 mt-2">
+          Display context window percentage and progress bars next to tasks.
+        </p>
       </div>
 
       {/* Threshold Alerts */}
@@ -1591,6 +1613,8 @@ export function SettingsModal({
               latestRateLimits={latestRateLimits}
               thresholds={usageThresholds}
               onThresholdsChange={onUsageThresholdsChange}
+              showUsageInline={showUsageInline}
+              onShowUsageInlineChange={onShowUsageInlineChange}
             />
           )}
 


### PR DESCRIPTION
## Summary
- Thread `contextUsage` into the Active Tasks (rotation) section so each task shows its context window percentage badge, matching the main task list
- Surface the existing "Show inline usage" toggle in the Usage settings tab for discoverability (shared state with the General tab toggle)
- Bump version to 0.9.4

## Test plan
- [x] Verify percentage badges appear next to tasks in the Active Tasks section
- [x] Toggle "Show context usage in sidebar and header" OFF in either General or Usage tab — confirm badges disappear from both Active Tasks and the main task list
- [x] Toggle back ON from the Usage tab — confirm it re-enables everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)