### PR TITLE
Add RTK (Rust Token Killer) integration

### DIFF
--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -163,8 +163,11 @@ export function registerAppIpc(): void {
 
   // Electron's clipboard module bypasses the web clipboard API, which is
   // unreliable on Linux (Wayland permission prompts, silent failures when
-  // the page loses focus between keydown and the async write).
-  ipcMain.on('app:clipboardWriteText', (_event, text: string) => {
+  // the page loses focus between keydown and the async write). Both write
+  // and read use `handle` so the renderer can `await` and surface failures —
+  // a fire-and-forget write would mean a wedged main process leaves the user
+  // pasting stale content elsewhere with no signal.
+  ipcMain.handle('app:clipboardWriteText', (_event, text: string) => {
     clipboard.writeText(text);
   });
   ipcMain.handle('app:clipboardReadText', () => {

--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, app, shell, BrowserWindow, Notification } from 'electron';
+import { ipcMain, dialog, app, shell, BrowserWindow, Notification, clipboard } from 'electron';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { existsSync, readFileSync } from 'fs';
@@ -159,6 +159,16 @@ export function registerAppIpc(): void {
 
   ipcMain.handle('app:openExternal', async (_event, url: string) => {
     await shell.openExternal(url);
+  });
+
+  // Electron's clipboard module bypasses the web clipboard API, which is
+  // unreliable on Linux (Wayland permission prompts, silent failures when
+  // the page loses focus between keydown and the async write).
+  ipcMain.on('app:clipboardWriteText', (_event, text: string) => {
+    clipboard.writeText(text);
+  });
+  ipcMain.handle('app:clipboardReadText', () => {
+    return clipboard.readText();
   });
 
   ipcMain.handle('app:showOpenDialog', async () => {

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -7,6 +7,7 @@ import { registerGithubIpc } from './githubIpc';
 import { registerAutoUpdateIpc } from './autoUpdateIpc';
 import { registerAzureDevOpsIpc } from './azureDevOpsIpc';
 import { registerPixelAgentsIpc } from './pixelAgentsIpc';
+import { registerRtkIpc } from './rtkIpc';
 import { registerTelemetryIpc } from './telemetryIpc';
 
 export function registerAllIpc(): void {
@@ -19,5 +20,6 @@ export function registerAllIpc(): void {
   registerAutoUpdateIpc();
   registerAzureDevOpsIpc();
   registerPixelAgentsIpc();
+  registerRtkIpc();
   registerTelemetryIpc();
 }

--- a/src/main/ipc/rtkIpc.ts
+++ b/src/main/ipc/rtkIpc.ts
@@ -30,14 +30,10 @@ export function registerRtkIpc(): void {
 
   ipcMain.handle('rtk:setEnabled', async (_event, enabled: boolean) => {
     try {
-      if (enabled) {
-        // Refuse to enable without a resolvable binary; otherwise the toggle
-        // would show "on" while buildPreToolUseHooks silently omits the entry.
-        const status = await RtkService.getStatus();
-        if (!status.installed) {
-          return { success: false, error: 'rtk is not installed' };
-        }
-      }
+      // RtkService.setEnabled throws "rtk is not installed" if no binary is
+      // resolved; we surface it via the IPC error envelope. The wire-type
+      // (RtkStatus) makes "enabled while not installed" unrepresentable, so
+      // a redundant pre-flight check would only widen the race window.
       RtkService.setEnabled(enabled);
       const { failures } = refreshActivePtyHooks();
       // Flag persisted to disk either way. When refresh partially failed,

--- a/src/main/ipc/rtkIpc.ts
+++ b/src/main/ipc/rtkIpc.ts
@@ -1,9 +1,21 @@
+import { basename } from 'node:path';
 import { ipcMain } from 'electron';
 import { RtkService } from '../services/RtkService';
-import { refreshActivePtyHooks } from '../services/ptyManager';
+import { refreshActivePtyHooks, type RefreshFailure } from '../services/ptyManager';
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function summarizeFailures(failures: RefreshFailure[]): string {
+  const n = failures.length;
+  const head = `${n} active task${n === 1 ? '' : 's'} didn't pick up the change`;
+  const detail = failures
+    .slice(0, 3)
+    .map((f) => `${basename(f.settingsPath)}: ${f.error}`)
+    .join('; ');
+  const more = n > 3 ? ` (+${n - 3} more)` : '';
+  return `${head} — ${detail}${more}`;
 }
 
 export function registerRtkIpc(): void {
@@ -27,8 +39,14 @@ export function registerRtkIpc(): void {
         }
       }
       RtkService.setEnabled(enabled);
-      refreshActivePtyHooks();
-      return { success: true };
+      const { failures } = refreshActivePtyHooks();
+      // Flag persisted to disk either way. When refresh partially failed,
+      // return success (don't roll back the toggle — the state IS saved)
+      // with a `warning` so the renderer can surface the partial state.
+      if (failures.length > 0) {
+        return { success: true, data: { warning: `Saved, but ${summarizeFailures(failures)}` } };
+      }
+      return { success: true, data: {} };
     } catch (error) {
       console.error('[rtk:setEnabled]', error);
       return { success: false, error: errorMessage(error) };
@@ -39,8 +57,16 @@ export function registerRtkIpc(): void {
     try {
       await RtkService.download();
       // Refresh hook JSON in active PTYs so a download while the toggle is
-      // already on starts rewriting immediately.
-      refreshActivePtyHooks();
+      // already on starts rewriting immediately. Failures here are informational:
+      // the binary installed fine and next-task-spawn writes settings anew, so
+      // the refresh is best-effort and we don't fail the download IPC.
+      const { failures } = refreshActivePtyHooks();
+      if (failures.length > 0) {
+        console.warn(
+          `[rtk:download] install succeeded but hook refresh failed for ${failures.length} task(s):`,
+          failures,
+        );
+      }
       return { success: true };
     } catch (error) {
       console.error('[rtk:download]', error);

--- a/src/main/ipc/rtkIpc.ts
+++ b/src/main/ipc/rtkIpc.ts
@@ -57,17 +57,20 @@ export function registerRtkIpc(): void {
     try {
       await RtkService.download();
       // Refresh hook JSON in active PTYs so a download while the toggle is
-      // already on starts rewriting immediately. Failures here are informational:
-      // the binary installed fine and next-task-spawn writes settings anew, so
-      // the refresh is best-effort and we don't fail the download IPC.
+      // already on starts rewriting immediately. Failures are surfaced via
+      // a `warning` field (matching rtk:setEnabled): the install itself
+      // succeeded, but the user has running tasks that won't pick up the
+      // new hook until they restart, and they should know.
       const { failures } = refreshActivePtyHooks();
       if (failures.length > 0) {
-        console.warn(
-          `[rtk:download] install succeeded but hook refresh failed for ${failures.length} task(s):`,
-          failures,
-        );
+        return {
+          success: true,
+          data: {
+            warning: `Installed. ${summarizeFailures(failures)} — restart those tasks to start compressing.`,
+          },
+        };
       }
-      return { success: true };
+      return { success: true, data: undefined };
     } catch (error) {
       console.error('[rtk:download]', error);
       return { success: false, error: errorMessage(error) };

--- a/src/main/ipc/rtkIpc.ts
+++ b/src/main/ipc/rtkIpc.ts
@@ -2,33 +2,49 @@ import { ipcMain } from 'electron';
 import { RtkService } from '../services/RtkService';
 import { refreshActivePtyHooks } from '../services/ptyManager';
 
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 export function registerRtkIpc(): void {
   ipcMain.handle('rtk:getStatus', async () => {
     try {
       return { success: true, data: await RtkService.getStatus() };
     } catch (error) {
-      return { success: false, error: String(error) };
+      console.error('[rtk:getStatus]', error);
+      return { success: false, error: errorMessage(error) };
     }
   });
 
-  ipcMain.handle('rtk:setEnabled', (_event, enabled: boolean) => {
+  ipcMain.handle('rtk:setEnabled', async (_event, enabled: boolean) => {
     try {
+      if (enabled) {
+        // Refuse to enable without a resolvable binary; otherwise the toggle
+        // would show "on" while buildPreToolUseHooks silently omits the entry.
+        const status = await RtkService.getStatus();
+        if (!status.installed) {
+          return { success: false, error: 'rtk is not installed' };
+        }
+      }
       RtkService.setEnabled(enabled);
-      // Flip hooks live on every running Claude Code session — no restart needed.
       refreshActivePtyHooks();
       return { success: true };
     } catch (error) {
-      return { success: false, error: String(error) };
+      console.error('[rtk:setEnabled]', error);
+      return { success: false, error: errorMessage(error) };
     }
   });
 
-  // Fire-and-forget: progress is streamed via rtk:downloadProgress events.
   ipcMain.handle('rtk:download', async () => {
     try {
       await RtkService.download();
+      // Refresh hook JSON in active PTYs so a download while the toggle is
+      // already on starts rewriting immediately.
+      refreshActivePtyHooks();
       return { success: true };
     } catch (error) {
-      return { success: false, error: String(error) };
+      console.error('[rtk:download]', error);
+      return { success: false, error: errorMessage(error) };
     }
   });
 
@@ -36,7 +52,8 @@ export function registerRtkIpc(): void {
     try {
       return { success: true, data: await RtkService.runHookTest() };
     } catch (error) {
-      return { success: false, error: String(error) };
+      console.error('[rtk:test]', error);
+      return { success: false, error: errorMessage(error) };
     }
   });
 }

--- a/src/main/ipc/rtkIpc.ts
+++ b/src/main/ipc/rtkIpc.ts
@@ -1,0 +1,42 @@
+import { ipcMain } from 'electron';
+import { RtkService } from '../services/RtkService';
+import { refreshActivePtyHooks } from '../services/ptyManager';
+
+export function registerRtkIpc(): void {
+  ipcMain.handle('rtk:getStatus', async () => {
+    try {
+      return { success: true, data: await RtkService.getStatus() };
+    } catch (error) {
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle('rtk:setEnabled', (_event, enabled: boolean) => {
+    try {
+      RtkService.setEnabled(enabled);
+      // Flip hooks live on every running Claude Code session — no restart needed.
+      refreshActivePtyHooks();
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: String(error) };
+    }
+  });
+
+  // Fire-and-forget: progress is streamed via rtk:downloadProgress events.
+  ipcMain.handle('rtk:download', async () => {
+    try {
+      await RtkService.download();
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle('rtk:test', async () => {
+    try {
+      return { success: true, data: await RtkService.runHookTest() };
+    } catch (error) {
+      return { success: false, error: String(error) };
+    }
+  });
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -144,6 +144,12 @@ app.whenReady().then(async () => {
     PixelAgentsService.start();
   }
 
+  // Warm RTK binary resolution so ptyManager's writeHookSettings can grab
+  // the absolute path synchronously on spawn.
+  const { RtkService } = await import('./services/RtkService');
+  RtkService.setSender(mainWindow.webContents);
+  RtkService.warmUp();
+
   // Cleanup orphaned reserve worktrees (background, non-blocking)
   setTimeout(async () => {
     try {
@@ -210,6 +216,8 @@ app.on('activate', async () => {
     remoteControlService.setSender(mainWindow.webContents);
     const { PixelAgentsService } = await import('./services/PixelAgentsService');
     PixelAgentsService.setSender(mainWindow.webContents);
+    const { RtkService } = await import('./services/RtkService');
+    RtkService.setSender(mainWindow.webContents);
     const { contextUsageService } = await import('./services/ContextUsageService');
     contextUsageService.setSender(mainWindow.webContents);
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -144,11 +144,12 @@ app.whenReady().then(async () => {
     PixelAgentsService.start();
   }
 
-  // Warm RTK binary resolution so ptyManager's writeHookSettings can grab
-  // the absolute path synchronously on spawn.
+  // Resolve rtk synchronously at startup; getHookCommand() is called on PTY spawn.
   const { RtkService } = await import('./services/RtkService');
   RtkService.setSender(mainWindow.webContents);
-  RtkService.warmUp();
+  await RtkService.warmUp().catch((err) => {
+    console.error('[RtkService.warmUp]', err);
+  });
 
   // Cleanup orphaned reserve worktrees (background, non-blocking)
   setTimeout(async () => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -8,6 +8,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Dialogs
   showOpenDialog: () => ipcRenderer.invoke('app:showOpenDialog'),
   openExternal: (url: string) => ipcRenderer.invoke('app:openExternal', url),
+  clipboardWriteText: (text: string) => ipcRenderer.send('app:clipboardWriteText', text),
+  clipboardReadText: () => ipcRenderer.invoke('app:clipboardReadText'),
   openInEditor: (args: { cwd: string; filePath: string; line?: number; col?: number }) =>
     ipcRenderer.invoke('app:openInEditor', args),
   openInIDE: (args: {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -242,6 +242,22 @@ contextBridge.exposeInMainWorld('electronAPI', {
     };
   },
 
+  // RTK (Rust Token Killer)
+  rtkGetStatus: () => ipcRenderer.invoke('rtk:getStatus'),
+  rtkSetEnabled: (enabled: boolean) => ipcRenderer.invoke('rtk:setEnabled', enabled),
+  rtkDownload: () => ipcRenderer.invoke('rtk:download'),
+  rtkTest: () => ipcRenderer.invoke('rtk:test'),
+  onRtkDownloadProgress: (
+    callback: (progress: import('@shared/types').RtkDownloadProgress) => void,
+  ) => {
+    const handler = (_event: unknown, progress: import('@shared/types').RtkDownloadProgress) =>
+      callback(progress);
+    ipcRenderer.on('rtk:downloadProgress', handler);
+    return () => {
+      ipcRenderer.removeListener('rtk:downloadProgress', handler);
+    };
+  },
+
   // Telemetry
   telemetryCapture: (event: string, properties?: Record<string, unknown>) =>
     ipcRenderer.invoke('telemetry:capture', { event, properties }),

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -8,7 +8,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Dialogs
   showOpenDialog: () => ipcRenderer.invoke('app:showOpenDialog'),
   openExternal: (url: string) => ipcRenderer.invoke('app:openExternal', url),
-  clipboardWriteText: (text: string) => ipcRenderer.send('app:clipboardWriteText', text),
+  clipboardWriteText: (text: string) => ipcRenderer.invoke('app:clipboardWriteText', text),
   clipboardReadText: () => ipcRenderer.invoke('app:clipboardReadText'),
   openInEditor: (args: { cwd: string; filePath: string; line?: number; col?: number }) =>
     ipcRenderer.invoke('app:openInEditor', args),

--- a/src/main/services/RtkService.ts
+++ b/src/main/services/RtkService.ts
@@ -6,6 +6,8 @@ import {
   createReadStream,
   createWriteStream,
   chmodSync,
+  lstatSync,
+  renameSync,
   rmSync,
 } from 'node:fs';
 import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
@@ -19,7 +21,7 @@ import { createHash } from 'node:crypto';
 import type { ReadableStream as WebReadableStream } from 'node:stream/web';
 import { app } from 'electron';
 import type { WebContents } from 'electron';
-import type { RtkStatus, RtkDownloadProgress, RtkTestResult } from '@shared/types';
+import type { RtkStatus, RtkSource, RtkDownloadProgress, RtkTestResult } from '@shared/types';
 
 const execFileAsync = promisify(execFile);
 
@@ -34,13 +36,16 @@ export class RtkService {
   private static sender: WebContents | null = null;
   private static cachedResolution: {
     path: string;
-    source: 'path' | 'managed';
+    source: RtkSource;
     version: string;
   } | null = null;
   private static downloadInFlight: Promise<void> | null = null;
   // Mirrors the on-disk rtk-config.json flag; saves a disk read per hook write.
   // null = not yet loaded; hydrated on first isEnabled() call and after setEnabled().
   private static enabledCache: boolean | null = null;
+  // Track whether we've already toasted a corrupt-config warning, so we don't
+  // spam the user once per hook write — they only need to see it once.
+  private static corruptConfigToasted = false;
 
   static setSender(sender: WebContents): void {
     RtkService.sender = sender;
@@ -64,6 +69,9 @@ export class RtkService {
         console.warn(
           '[RtkService.isEnabled] rtk-config.json "enabled" is not a boolean; treating as false.',
         );
+        RtkService.notifyCorruptConfig(
+          'RTK config has an invalid "enabled" value — RTK is off until you re-toggle it in Settings.',
+        );
       }
       RtkService.enabledCache = value;
       return value;
@@ -72,8 +80,24 @@ export class RtkService {
         '[RtkService.isEnabled] rtk-config.json unreadable, treating as disabled:',
         err,
       );
+      // The user toggled RTK on at some point; a corrupt config now silently
+      // means hooks stop firing in every spawn. Surface it instead of letting
+      // the toggle keep showing ON while reality says OFF.
+      RtkService.notifyCorruptConfig(
+        `RTK config is unreadable (${err instanceof Error ? err.message : String(err)}) — RTK is off until you re-toggle it in Settings.`,
+      );
       RtkService.enabledCache = false;
       return false;
+    }
+  }
+
+  /** Toast a corrupt-config warning once per process lifetime. */
+  private static notifyCorruptConfig(message: string): void {
+    if (RtkService.corruptConfigToasted) return;
+    RtkService.corruptConfigToasted = true;
+    const sender = RtkService.sender;
+    if (sender && !sender.isDestroyed()) {
+      sender.send('app:toast', { message });
     }
   }
 
@@ -87,8 +111,16 @@ export class RtkService {
     }
     const p = RtkService.getConfigPath();
     mkdirSync(dirname(p), { recursive: true });
-    writeFileSync(p, JSON.stringify({ enabled }, null, 2));
+    // Atomic write: tmp + rename so a crash here can never leave a half-
+    // flushed JSON file that isEnabled() would treat as corrupt and silently
+    // disable RTK on the next launch.
+    const tmp = `${p}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(tmp, JSON.stringify({ enabled }, null, 2));
+    renameSync(tmp, p);
     RtkService.enabledCache = enabled;
+    // A successful write means the file is good. Clear the "we already toasted"
+    // latch so a later re-corruption (manual edit, disk error) toasts again.
+    RtkService.corruptConfigToasted = false;
   }
 
   private static getManagedBinDir(): string {
@@ -111,7 +143,7 @@ export class RtkService {
 
   private static async resolveBinary(): Promise<{
     path: string;
-    source: 'path' | 'managed';
+    source: RtkSource;
     version: string;
   } | null> {
     const managed = RtkService.getManagedBinPath();
@@ -171,16 +203,23 @@ export class RtkService {
 
   static async getStatus(): Promise<RtkStatus> {
     const resolved = await RtkService.resolveBinary();
-    RtkService.cachedResolution = resolved;
+    // Only update the cache on a positive resolution. A transient failure
+    // (probe timeout, `which` flake) used to clobber a previously-good entry,
+    // which made getHookCommand() silently return null while isEnabled() on
+    // disk still said the toggle was ON — the UI would lie about RTK firing.
+    if (resolved) {
+      RtkService.cachedResolution = resolved;
+    }
 
     const enabled = RtkService.isEnabled();
     const downloadable = RtkService.isPlatformDownloadable();
-    if (resolved) {
+    const effective = resolved ?? RtkService.cachedResolution;
+    if (effective) {
       return {
         installed: true,
-        version: resolved.version,
-        path: resolved.path,
-        source: resolved.source,
+        version: effective.version,
+        path: effective.path,
+        source: effective.source,
         enabled,
         downloadable,
       };
@@ -190,7 +229,18 @@ export class RtkService {
 
   /** Populates cachedResolution so getHookCommand() is synchronous later. */
   static async warmUp(): Promise<void> {
-    RtkService.cachedResolution = await RtkService.resolveBinary();
+    const resolved = await RtkService.resolveBinary();
+    if (resolved) RtkService.cachedResolution = resolved;
+  }
+
+  /**
+   * Force-clear the cached resolution. Call when the binary has been removed
+   * from disk (uninstall flow) — there is no read-only path to "the binary is
+   * gone" elsewhere, so without this, stale cache could keep getHookCommand()
+   * returning a path that no longer exists.
+   */
+  static invalidateCache(): void {
+    RtkService.cachedResolution = null;
   }
 
   // No Windows native release exists upstream — manual-install guidance only there.
@@ -315,6 +365,14 @@ export class RtkService {
       if (!existsSync(binPath)) {
         throw new Error(`Archive did not contain expected binary at ${binPath}`);
       }
+      // Defense-in-depth: even though verifyArchive rejected symlinks/hardlinks
+      // at preflight, lstat the extracted binary before chmod. chmodSync on a
+      // symlink would follow the link and modify the target instead of binPath.
+      const stat = lstatSync(binPath);
+      if (!stat.isFile()) {
+        rmSync(binPath, { force: true });
+        throw new Error(`Extracted binary is not a regular file at ${binPath}`);
+      }
       // Must chmod before the probeVersion spawn below; tar on some systems drops +x.
       chmodSync(binPath, 0o755);
 
@@ -346,15 +404,8 @@ export class RtkService {
     throw new Error(`checksums.txt does not list ${assetName}`);
   }
 
-  private static async verifyChecksum(filePath: string, expectedSha: string): Promise<void> {
-    const hash = createHash('sha256');
-    await pipeline(createReadStream(filePath), hash);
-    const actual = hash.digest('hex');
-    if (actual !== expectedSha) {
-      throw new Error(
-        `Checksum mismatch: expected ${expectedSha}, got ${actual}. Refusing to install.`,
-      );
-    }
+  private static verifyChecksum(filePath: string, expectedSha: string): Promise<void> {
+    return verifyChecksum(filePath, expectedSha);
   }
 
   private static async fetchToFile(url: string, dest: string): Promise<void> {
@@ -390,8 +441,10 @@ export class RtkService {
 
   private static async verifyArchive(archivePath: string): Promise<void> {
     try {
-      // Also validates every member is relative and stays inside dest (prevents
-      // path-traversal via crafted archives).
+      // Validates every member is relative, stays inside dest, AND is a
+      // regular file or directory — symlinks/hardlinks are refused outright
+      // because tar honors their targets at extract time, which would let a
+      // crafted archive write outside dest even though the entry name is safe.
       const entries = await RtkService.listTarball(archivePath);
       const dest = RtkService.getManagedBinDir();
       for (const entry of entries) {
@@ -420,9 +473,13 @@ export class RtkService {
     ]);
   }
 
-  private static listTarball(archivePath: string): Promise<string[]> {
+  private static listTarball(archivePath: string): Promise<TarEntry[]> {
     return new Promise((resolveP, rejectP) => {
-      const proc = spawn('tar', ['-tzf', archivePath], {
+      // -tvf prints "<mode> <owner> <size> <mtime> <name>[ -> target]" per entry.
+      // The first char of the mode column is the file type ('-' regular, 'd'
+      // directory, 'l' symlink, 'h' hardlink); we use it to reject link types
+      // before extraction. Both BSD (macOS) and GNU tar use this format.
+      const proc = spawn('tar', ['-tvzf', archivePath], {
         stdio: ['ignore', 'pipe', 'pipe'],
         timeout: TAR_TIMEOUT_MS,
       });
@@ -442,9 +499,9 @@ export class RtkService {
         }
       });
       proc.on('exit', (code, signal) => {
-        if (signal) rejectP(new Error(`tar -tzf killed by signal ${signal} (timed out?)`));
-        else if (code === 0) resolveP(stdout.split(/\r?\n/).filter(Boolean));
-        else rejectP(new Error(`tar -tzf exited ${code}: ${stderr.trim()}`));
+        if (signal) rejectP(new Error(`tar -tvzf killed by signal ${signal} (timed out?)`));
+        else if (code === 0) resolveP(parseTarVerbose(stdout));
+        else rejectP(new Error(`tar -tvzf exited ${code}: ${stderr.trim()}`));
       });
     });
   }
@@ -545,6 +602,9 @@ export class RtkService {
         rawOutput: stdout.slice(0, 2000),
         ...(code === 2 ? { blocked: { stderr: stderr.trim().slice(0, 400) } } : {}),
         ...(execDiff ? { execDiff } : {}),
+        // execDiff `kind: 'failed'` is forwarded as-is; the renderer renders
+        // it as a "couldn't capture diff" warning rather than the green
+        // pass-through banner that null used to produce.
       };
     } catch (err) {
       return { ok: false, testedCommand, error: err instanceof Error ? err.message : String(err) };
@@ -554,15 +614,25 @@ export class RtkService {
   /**
    * Execute both the raw and rtk-rewritten commands inside a throwaway git
    * repo populated with enough untracked files to make `git status` verbose.
-   * Returns null on any failure — this is a best-effort visualization, not a
-   * correctness check. The rewrite-directive check above already proved rtk
-   * is working; this just makes the compression visible to the user.
+   * Returns a `failed` variant on any error rather than null — the previous
+   * null-on-error meant the UI rendered the green "rtk chose pass-through"
+   * card for genuine failures (missing git, EACCES on tmpdir, rtk panic).
    */
   private static async captureExecDiff(
     rawCommand: string,
     rewrittenCommand: string,
-  ): Promise<import('@shared/types').RtkExecDiff | null> {
-    const dir = await mkdtemp(join(tmpdir(), 'dash-rtk-verify-'));
+  ): Promise<import('@shared/types').RtkExecDiff> {
+    let dir: string;
+    try {
+      dir = await mkdtemp(join(tmpdir(), 'dash-rtk-verify-'));
+    } catch (err) {
+      return {
+        kind: 'failed',
+        stage: 'setup',
+        reason: `Couldn't create temp dir: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
     try {
       // Give `git status` something non-trivial to emit — multiple files
       // across a few directories so rtk's grouping/dedup filters have work.
@@ -585,7 +655,16 @@ export class RtkService {
         ),
       ]);
 
-      await runShell('git init -q', dir);
+      const initRes = await runShell('git init -q', dir);
+      if (initRes.code !== 0) {
+        return {
+          kind: 'failed',
+          stage: 'setup',
+          exitCode: initRes.code ?? undefined,
+          stderr: initRes.stderr.slice(0, 400),
+          reason: `git init failed (exit ${initRes.code ?? 'null'}). Is git installed?`,
+        };
+      }
 
       // Make sure rtk resolves from the rewritten command even when the user
       // never installed it on the system PATH — prepend our managed bin dir.
@@ -598,19 +677,48 @@ export class RtkService {
         runShell(rewrittenCommand, dir, env),
       ]);
 
-      // Trim IPC payload but report the TRUE byte counts so savings math stays honest.
+      if (rawRes.code !== 0) {
+        return {
+          kind: 'failed',
+          stage: 'raw',
+          exitCode: rawRes.code ?? undefined,
+          stderr: rawRes.stderr.slice(0, 400),
+          reason: `Raw command exited ${rawRes.code ?? 'null'}: ${rawCommand}`,
+        };
+      }
+      if (rewrittenRes.code !== 0) {
+        return {
+          kind: 'failed',
+          stage: 'rewritten',
+          exitCode: rewrittenRes.code ?? undefined,
+          stderr: rewrittenRes.stderr.slice(0, 400),
+          reason: `Rewritten command exited ${rewrittenRes.code ?? 'null'}: ${rewrittenCommand}`,
+        };
+      }
+
+      // Trim IPC payload. When stdout hit the cap, byte counts reflect the
+      // truncated buffer (we stopped reading) — surface that via `truncated`
+      // so the UI can warn instead of advertising a misleading savings %.
       const DISPLAY_CAP = 8 * 1024;
       return {
+        kind: 'ok',
         rawStdout: rawRes.stdout.slice(0, DISPLAY_CAP),
         compressedStdout: rewrittenRes.stdout.slice(0, DISPLAY_CAP),
         rawBytes: Buffer.byteLength(rawRes.stdout),
         compressedBytes: Buffer.byteLength(rewrittenRes.stdout),
+        truncated: rawRes.truncated || rewrittenRes.truncated,
       };
     } catch (err) {
-      console.warn('[RtkService.captureExecDiff] non-fatal:', err);
-      return null;
+      console.warn('[RtkService.captureExecDiff] unexpected:', err);
+      return {
+        kind: 'failed',
+        stage: 'unknown',
+        reason: err instanceof Error ? err.message : String(err),
+      };
     } finally {
-      await rm(dir, { recursive: true, force: true }).catch(() => {});
+      await rm(dir, { recursive: true, force: true }).catch((err) => {
+        console.warn('[RtkService.captureExecDiff] tmpdir cleanup failed:', err);
+      });
     }
   }
 }
@@ -629,21 +737,24 @@ function runShell(
   cwd: string,
   env: NodeJS.ProcessEnv = process.env,
   timeoutMs = 15_000,
-): Promise<{ stdout: string; stderr: string; code: number | null }> {
+): Promise<{ stdout: string; stderr: string; code: number | null; truncated: boolean }> {
   return new Promise((resolveP, rejectP) => {
     const shell = process.platform === 'win32' ? 'cmd.exe' : 'sh';
     const args = process.platform === 'win32' ? ['/c', cmd] : ['-c', cmd];
     const proc = spawn(shell, args, { cwd, env, timeout: timeoutMs });
     let stdout = '';
     let stderr = '';
+    let truncated = false;
     proc.stdout.on('data', (c: Buffer) => {
       if (stdout.length < RUN_SHELL_OUTPUT_CAP) stdout += c.toString();
+      else truncated = true;
     });
     proc.stderr.on('data', (c: Buffer) => {
       if (stderr.length < RUN_SHELL_OUTPUT_CAP) stderr += c.toString();
+      else truncated = true;
     });
     proc.on('error', rejectP);
-    proc.on('close', (code) => resolveP({ stdout, stderr, code }));
+    proc.on('close', (code) => resolveP({ stdout, stderr, code, truncated }));
   });
 }
 
@@ -752,21 +863,94 @@ function assertTrustedDownloadUrl(raw: string): void {
   }
 }
 
-function assertSafeArchiveMember(entry: string, destDir: string): void {
+type TarMemberType = 'file' | 'dir' | 'symlink' | 'hardlink' | 'other';
+
+interface TarEntry {
+  /** First char of the mode column from `tar -tvf` (`-`, `d`, `l`, `h`, ...). */
+  type: TarMemberType;
+  name: string;
+}
+
+function parseTarVerbose(stdout: string): TarEntry[] {
+  const out: TarEntry[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line) continue;
+    // Lines start with the mode string; first char encodes the file type.
+    const typeChar = line[0];
+    let type: TarMemberType;
+    switch (typeChar) {
+      case '-':
+        type = 'file';
+        break;
+      case 'd':
+        type = 'dir';
+        break;
+      case 'l':
+        type = 'symlink';
+        break;
+      case 'h':
+        type = 'hardlink';
+        break;
+      default:
+        type = 'other';
+    }
+    // Strip "<name> -> <target>" tail so name validation only sees the entry path.
+    // The target itself doesn't need validation: we reject symlinks/hardlinks outright.
+    const arrow = line.indexOf(' -> ');
+    const trail = arrow >= 0 ? line.slice(0, arrow) : line;
+    // Name is the last whitespace-delimited token (mode/owner/size/date have
+    // varying field counts between BSD and GNU tar; the name is always last).
+    const tokens = trail.split(/\s+/);
+    const name = tokens[tokens.length - 1];
+    if (name) out.push({ type, name });
+  }
+  return out;
+}
+
+function assertSafeArchiveMember(entry: TarEntry, destDir: string): void {
+  // Refuse symlinks/hardlinks outright. `tar -xzf` honors their targets at
+  // extract time, so a crafted archive with `rtk -> /etc/passwd` would let
+  // chmod/exec follow the link out of dest even though the entry name is
+  // benign. Defense-in-depth: SHA-256 + URL allowlist already make this hard
+  // to reach, but the link types themselves are never legitimate in an rtk
+  // release tarball.
+  if (entry.type === 'symlink' || entry.type === 'hardlink') {
+    throw new Error(`Archive contains ${entry.type}, which is not allowed: ${entry.name}`);
+  }
+  if (entry.type === 'other') {
+    throw new Error(`Archive contains unsupported member type: ${entry.name}`);
+  }
+  // Reject embedded null bytes — tar entries should never contain them, and
+  // some libcs truncate at \0 which could let a malicious entry name slip
+  // past a downstream check.
+  if (entry.name.includes('\0')) {
+    throw new Error(`Archive member contains null byte: ${JSON.stringify(entry.name)}`);
+  }
   // Reject absolute paths. The Windows-drive regex runs on every platform by
   // design: a tarball authored on Windows can reach any OS, so we refuse
   // `C:\...` entries regardless of where extraction happens.
-  if (entry.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(entry)) {
-    throw new Error(`Archive contains absolute path: ${entry}`);
+  if (entry.name.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(entry.name)) {
+    throw new Error(`Archive contains absolute path: ${entry.name}`);
   }
   // Normalize backslashes to forward slashes before resolve(). On POSIX,
   // path.resolve treats `\` as a literal filename character, so `..\\evil`
   // would not be recognised as a parent-traversal attempt without this step.
-  const normalized = normalize(entry.replace(/\\/g, '/'));
+  const normalized = normalize(entry.name.replace(/\\/g, '/'));
   const resolved = resolve(destDir, normalized);
   const base = resolve(destDir) + sep;
   if (resolved !== resolve(destDir) && !resolved.startsWith(base)) {
-    throw new Error(`Archive member escapes destDir: ${entry}`);
+    throw new Error(`Archive member escapes destDir: ${entry.name}`);
+  }
+}
+
+async function verifyChecksum(filePath: string, expectedSha: string): Promise<void> {
+  const hash = createHash('sha256');
+  await pipeline(createReadStream(filePath), hash);
+  const actual = hash.digest('hex');
+  if (actual !== expectedSha) {
+    throw new Error(
+      `Checksum mismatch: expected ${expectedSha}, got ${actual}. Refusing to install.`,
+    );
   }
 }
 
@@ -791,6 +975,8 @@ async function fetchWithTimeout(
 export const __test__ = {
   assertTrustedDownloadUrl,
   assertSafeArchiveMember,
+  parseTarVerbose,
   shellQuoteUnix,
   extractRewrittenCommand,
+  verifyChecksum,
 };

--- a/src/main/services/RtkService.ts
+++ b/src/main/services/RtkService.ts
@@ -123,26 +123,13 @@ export class RtkService {
     const resolved = await RtkService.resolveBinary();
     RtkService.cachedResolution = resolved;
 
-    const downloadable = RtkService.isPlatformDownloadable();
-
-    if (!resolved) {
-      return {
-        installed: false,
-        version: null,
-        path: null,
-        source: 'none',
-        enabled: RtkService.isEnabled(),
-        downloadable,
-      };
-    }
-
     return {
-      installed: true,
-      version: resolved.version,
-      path: resolved.path,
-      source: resolved.source,
+      installed: !!resolved,
+      version: resolved?.version ?? null,
+      path: resolved?.path ?? null,
+      source: resolved?.source ?? 'none',
       enabled: RtkService.isEnabled(),
-      downloadable,
+      downloadable: RtkService.isPlatformDownloadable(),
     };
   }
 
@@ -282,21 +269,12 @@ export class RtkService {
 
   /** Throws if the archive isn't a valid gzip-ed tar — cheap enough to do before extraction. */
   private static async verifyArchive(archivePath: string): Promise<void> {
-    await new Promise<void>((resolve, reject) => {
-      const proc = spawn('tar', ['-tzf', archivePath], { stdio: ['ignore', 'ignore', 'pipe'] });
-      let stderr = '';
-      proc.stderr?.on('data', (d: Buffer) => {
-        stderr += d.toString();
-      });
-      proc.on('error', reject);
-      proc.on('exit', (code) => {
-        if (code === 0) resolve();
-        else
-          reject(
-            new Error(`Archive integrity check failed: ${stderr.trim() || `tar exited ${code}`}`),
-          );
-      });
-    });
+    try {
+      await RtkService.runTar(['-tzf', archivePath]);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`Archive integrity check failed: ${detail}`);
+    }
   }
 
   private static async extractTarball(archivePath: string, destDir: string): Promise<void> {

--- a/src/main/services/RtkService.ts
+++ b/src/main/services/RtkService.ts
@@ -17,19 +17,28 @@ import { createHash } from 'node:crypto';
 import type { ReadableStream as WebReadableStream } from 'node:stream/web';
 import { app } from 'electron';
 import type { WebContents } from 'electron';
-import type { RtkStatus, RtkDownloadProgress, RtkSource, RtkTestResult } from '@shared/types';
+import type { RtkStatus, RtkDownloadProgress, RtkTestResult } from '@shared/types';
 
 const execFileAsync = promisify(execFile);
+
+// Cap download phases so a hung CDN cannot leave the single-flight promise
+// pending forever — subsequent download() calls would await the dead promise.
+const FETCH_API_TIMEOUT_MS = 60_000;
+const FETCH_BODY_TIMEOUT_MS = 300_000;
+const TAR_TIMEOUT_MS = 120_000;
 
 /** Managed-bin resolution wins over $PATH so uninstalling Dash leaves no orphan binary. */
 export class RtkService {
   private static sender: WebContents | null = null;
   private static cachedResolution: {
     path: string;
-    source: RtkSource;
-    version: string | null;
+    source: 'path' | 'managed';
+    version: string;
   } | null = null;
   private static downloadInFlight: Promise<void> | null = null;
+  // Mirrors the on-disk rtk-config.json flag; saves a disk read per hook write.
+  // null = not yet loaded; hydrated on first isEnabled() call and after setEnabled().
+  private static enabledCache: boolean | null = null;
 
   static setSender(sender: WebContents): void {
     RtkService.sender = sender;
@@ -40,24 +49,44 @@ export class RtkService {
   }
 
   static isEnabled(): boolean {
+    if (RtkService.enabledCache !== null) return RtkService.enabledCache;
     const p = RtkService.getConfigPath();
-    if (!existsSync(p)) return false;
+    if (!existsSync(p)) {
+      RtkService.enabledCache = false;
+      return false;
+    }
     try {
       const raw = JSON.parse(readFileSync(p, 'utf-8')) as { enabled?: unknown };
-      return raw.enabled === true;
+      const value = raw.enabled === true;
+      if (raw.enabled !== undefined && typeof raw.enabled !== 'boolean') {
+        console.warn(
+          '[RtkService.isEnabled] rtk-config.json "enabled" is not a boolean; treating as false.',
+        );
+      }
+      RtkService.enabledCache = value;
+      return value;
     } catch (err) {
       console.error(
         '[RtkService.isEnabled] rtk-config.json unreadable, treating as disabled:',
         err,
       );
+      RtkService.enabledCache = false;
       return false;
     }
   }
 
+  /**
+   * Enforces the "installed before enabled" invariant at the data layer so
+   * callers outside the IPC handler can't write a config that lies about state.
+   */
   static setEnabled(enabled: boolean): void {
+    if (enabled && !RtkService.cachedResolution) {
+      throw new Error('rtk is not installed');
+    }
     const p = RtkService.getConfigPath();
     mkdirSync(dirname(p), { recursive: true });
     writeFileSync(p, JSON.stringify({ enabled }, null, 2));
+    RtkService.enabledCache = enabled;
   }
 
   private static getManagedBinDir(): string {
@@ -69,14 +98,19 @@ export class RtkService {
     return join(RtkService.getManagedBinDir(), exe);
   }
 
+  /**
+   * Returns the managed bin dir ONLY when a probed-good binary is there.
+   * Gating on cachedResolution (not just existsSync) prevents poisoning the
+   * PTY PATH with a dir whose binary failed --version.
+   */
   static getManagedBinDirForPath(): string | null {
-    return existsSync(RtkService.getManagedBinPath()) ? RtkService.getManagedBinDir() : null;
+    return RtkService.cachedResolution?.source === 'managed' ? RtkService.getManagedBinDir() : null;
   }
 
   private static async resolveBinary(): Promise<{
     path: string;
-    source: RtkSource;
-    version: string | null;
+    source: 'path' | 'managed';
+    version: string;
   } | null> {
     const managed = RtkService.getManagedBinPath();
     if (existsSync(managed)) {
@@ -101,10 +135,12 @@ export class RtkService {
         return { path: resolved, source: 'path', version };
       }
     } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      // `which` exits 1 when not found; `where.exe` also signals "not found" via non-zero.
-      // Everything else (EACCES, EMFILE, `which` binary missing) is worth surfacing.
-      if (code !== 'ENOENT' && !/exited.*1/i.test(String((err as Error).message ?? ''))) {
+      // Node's execFile rejects with an Error decorated with `code`: the
+      // string 'ENOENT' for a missing `which` binary, or the numeric exit
+      // code for a non-zero exit. Exit 1 from `which`/`where.exe` is the
+      // "not found" signal — not noise.
+      const code = (err as { code?: unknown }).code;
+      if (code !== 'ENOENT' && code !== 1) {
         console.warn('[RtkService] which/where.exe lookup failed unexpectedly:', err);
       }
     }
@@ -135,14 +171,19 @@ export class RtkService {
     const resolved = await RtkService.resolveBinary();
     RtkService.cachedResolution = resolved;
 
-    return {
-      installed: !!resolved,
-      version: resolved?.version ?? null,
-      path: resolved?.path ?? null,
-      source: resolved?.source ?? 'none',
-      enabled: RtkService.isEnabled(),
-      downloadable: RtkService.isPlatformDownloadable(),
-    };
+    const enabled = RtkService.isEnabled();
+    const downloadable = RtkService.isPlatformDownloadable();
+    if (resolved) {
+      return {
+        installed: true,
+        version: resolved.version,
+        path: resolved.path,
+        source: resolved.source,
+        enabled,
+        downloadable,
+      };
+    }
+    return { installed: false, enabled, downloadable };
   }
 
   /** Populates cachedResolution so getHookCommand() is synchronous later. */
@@ -199,9 +240,13 @@ export class RtkService {
     try {
       RtkService.emitProgress({ phase: 'downloading', percent: 0 });
 
-      const apiRes = await fetch('https://api.github.com/repos/rtk-ai/rtk/releases/latest', {
-        headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'dash-rtk-installer' },
-      });
+      const apiRes = await fetchWithTimeout(
+        'https://api.github.com/repos/rtk-ai/rtk/releases/latest',
+        {
+          headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'dash-rtk-installer' },
+        },
+        FETCH_API_TIMEOUT_MS,
+      );
       if (!apiRes.ok) {
         throw new Error(`GitHub API ${apiRes.status}: ${apiRes.statusText}`);
       }
@@ -288,7 +333,7 @@ export class RtkService {
   }
 
   private static async fetchExpectedSha256(url: string, assetName: string): Promise<string> {
-    const res = await fetch(url);
+    const res = await fetchWithTimeout(url, {}, FETCH_API_TIMEOUT_MS);
     if (!res.ok) throw new Error(`Failed to fetch checksums.txt: ${res.status} ${res.statusText}`);
     const body = await res.text();
     // checksums.txt format: "<hex-sha256>  <filename>" per line.
@@ -311,28 +356,34 @@ export class RtkService {
   }
 
   private static async fetchToFile(url: string, dest: string): Promise<void> {
-    const dlRes = await fetch(url);
-    if (!dlRes.ok || !dlRes.body) {
-      throw new Error(`Download failed: ${dlRes.status} ${dlRes.statusText}`);
-    }
-    const total = Number(dlRes.headers.get('content-length') || '0');
-    let transferred = 0;
-
-    const source = Readable.fromWeb(dlRes.body as unknown as WebReadableStream<Uint8Array>);
-    source.on('data', (chunk: Buffer) => {
-      transferred += chunk.length;
-      if (total > 0) {
-        RtkService.emitProgress({
-          phase: 'downloading',
-          percent: Math.min(99, Math.round((transferred / total) * 100)),
-        });
+    const controller = new AbortController();
+    const wallTimer = setTimeout(() => controller.abort(), FETCH_BODY_TIMEOUT_MS);
+    try {
+      const dlRes = await fetch(url, { signal: controller.signal });
+      if (!dlRes.ok || !dlRes.body) {
+        throw new Error(`Download failed: ${dlRes.status} ${dlRes.statusText}`);
       }
-    });
-    await pipeline(source, createWriteStream(dest));
-    if (total > 0 && transferred !== total) {
-      throw new Error(`Truncated download: expected ${total} bytes, got ${transferred}.`);
+      const total = Number(dlRes.headers.get('content-length') || '0');
+      let transferred = 0;
+
+      const source = Readable.fromWeb(dlRes.body as unknown as WebReadableStream<Uint8Array>);
+      source.on('data', (chunk: Buffer) => {
+        transferred += chunk.length;
+        if (total > 0) {
+          RtkService.emitProgress({
+            phase: 'downloading',
+            percent: Math.min(99, Math.round((transferred / total) * 100)),
+          });
+        }
+      });
+      await pipeline(source, createWriteStream(dest));
+      if (total > 0 && transferred !== total) {
+        throw new Error(`Truncated download: expected ${total} bytes, got ${transferred}.`);
+      }
+      RtkService.emitProgress({ phase: 'downloading', percent: 100 });
+    } finally {
+      clearTimeout(wallTimer);
     }
-    RtkService.emitProgress({ phase: 'downloading', percent: 100 });
   }
 
   private static async verifyArchive(archivePath: string): Promise<void> {
@@ -369,7 +420,10 @@ export class RtkService {
 
   private static listTarball(archivePath: string): Promise<string[]> {
     return new Promise((resolveP, rejectP) => {
-      const proc = spawn('tar', ['-tzf', archivePath], { stdio: ['ignore', 'pipe', 'pipe'] });
+      const proc = spawn('tar', ['-tzf', archivePath], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: TAR_TIMEOUT_MS,
+      });
       let stdout = '';
       let stderr = '';
       proc.stdout.on('data', (d: Buffer) => {
@@ -385,8 +439,9 @@ export class RtkService {
           rejectP(err);
         }
       });
-      proc.on('exit', (code) => {
-        if (code === 0) resolveP(stdout.split(/\r?\n/).filter(Boolean));
+      proc.on('exit', (code, signal) => {
+        if (signal) rejectP(new Error(`tar -tzf killed by signal ${signal} (timed out?)`));
+        else if (code === 0) resolveP(stdout.split(/\r?\n/).filter(Boolean));
         else rejectP(new Error(`tar -tzf exited ${code}: ${stderr.trim()}`));
       });
     });
@@ -394,7 +449,10 @@ export class RtkService {
 
   private static runTar(args: string[]): Promise<void> {
     return new Promise((resolveP, rejectP) => {
-      const proc = spawn('tar', args, { stdio: ['ignore', 'ignore', 'pipe'] });
+      const proc = spawn('tar', args, {
+        stdio: ['ignore', 'ignore', 'pipe'],
+        timeout: TAR_TIMEOUT_MS,
+      });
       let stderr = '';
       proc.stderr?.on('data', (d: Buffer) => {
         stderr += d.toString();
@@ -406,8 +464,9 @@ export class RtkService {
           rejectP(err);
         }
       });
-      proc.on('exit', (code) => {
-        if (code === 0) resolveP();
+      proc.on('exit', (code, signal) => {
+        if (signal) rejectP(new Error(`tar killed by signal ${signal} (timed out?)`));
+        else if (code === 0) resolveP();
         else rejectP(new Error(`tar exited ${code}: ${stderr.trim()}`));
       });
     });
@@ -452,6 +511,7 @@ export class RtkService {
           error: `rtk killed by signal ${signal ?? 'unknown'} (likely timeout)`,
         };
       }
+      // rtk exits 2 to signal "block this tool call" — a valid hook result, not an error.
       if (code !== 0 && code !== 2) {
         return {
           ok: false,
@@ -460,19 +520,19 @@ export class RtkService {
         };
       }
 
-      const rewritten = extractRewrittenCommand(stdout);
-      if (rewritten instanceof Error) {
+      const extracted = extractRewrittenCommand(stdout);
+      if (!extracted.ok) {
         return {
           ok: false,
           testedCommand,
-          error: `rtk produced unparsable output: ${rewritten.message}`,
+          error: `rtk produced unparsable output: ${extracted.reason}`,
         };
       }
 
       return {
         ok: true,
         testedCommand,
-        rewrittenCommand: rewritten,
+        rewrittenCommand: extracted.command,
         rawOutput: stdout.slice(0, 2000),
         ...(code === 2 ? { blocked: { stderr: stderr.trim().slice(0, 400) } } : {}),
       };
@@ -501,7 +561,11 @@ function pipeStdin(
       stderr += c.toString();
     });
     // rtk may exit before reading stdin; EPIPE must not become unhandled.
-    proc.stdin.on('error', () => {});
+    proc.stdin.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code !== 'EPIPE') {
+        console.warn('[RtkService.pipeStdin] unexpected stdin error:', err);
+      }
+    });
     proc.on('error', rejectP);
     proc.on('close', (code, signal) => resolveP({ code, signal, stdout, stderr }));
     proc.stdin.write(stdin);
@@ -509,15 +573,20 @@ function pipeStdin(
   });
 }
 
-function extractRewrittenCommand(stdout: string): string | null | Error {
+type ExtractResult = { ok: true; command: string | null } | { ok: false; reason: string };
+
+function extractRewrittenCommand(stdout: string): ExtractResult {
   const trimmed = stdout.trim();
-  if (!trimmed) return null;
+  if (!trimmed) return { ok: true, command: null };
   let parsed: Record<string, unknown>;
   try {
     parsed = JSON.parse(trimmed) as Record<string, unknown>;
   } catch (err) {
-    return err instanceof Error ? err : new Error(String(err));
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
   }
+  // Claude Code's hook JSON schema has evolved; accept both historical and
+  // current field names so version skew between rtk releases and Dash's
+  // expectations doesn't silently render as "pass-through".
   const paths: Array<(v: Record<string, unknown>) => unknown> = [
     (v) => (isObject(v.hookSpecificOutput) ? v.hookSpecificOutput.updatedInput : undefined),
     (v) => (isObject(v.hookSpecificOutput) ? v.hookSpecificOutput.modifiedToolInput : undefined),
@@ -530,10 +599,10 @@ function extractRewrittenCommand(stdout: string): string | null | Error {
   for (const get of paths) {
     const node = get(parsed);
     if (isObject(node) && typeof node.command === 'string') {
-      return node.command;
+      return { ok: true, command: node.command };
     }
   }
-  return null;
+  return { ok: true, command: null };
 }
 
 function isObject(v: unknown): v is Record<string, unknown> {
@@ -581,13 +650,44 @@ function assertTrustedDownloadUrl(raw: string): void {
 }
 
 function assertSafeArchiveMember(entry: string, destDir: string): void {
-  // Reject absolute paths and any entry whose resolved location escapes destDir.
+  // Reject absolute paths. The Windows-drive regex runs on every platform by
+  // design: a tarball authored on Windows can reach any OS, so we refuse
+  // `C:\...` entries regardless of where extraction happens.
   if (entry.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(entry)) {
     throw new Error(`Archive contains absolute path: ${entry}`);
   }
-  const resolved = resolve(destDir, normalize(entry));
+  // Normalize backslashes to forward slashes before resolve(). On POSIX,
+  // path.resolve treats `\` as a literal filename character, so `..\\evil`
+  // would not be recognised as a parent-traversal attempt without this step.
+  const normalized = normalize(entry.replace(/\\/g, '/'));
+  const resolved = resolve(destDir, normalized);
   const base = resolve(destDir) + sep;
   if (resolved !== resolve(destDir) && !resolved.startsWith(base)) {
     throw new Error(`Archive member escapes destDir: ${entry}`);
   }
 }
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Test-only exports of module-private helpers. Importing from here keeps the
+ * unit tests exercising the real code instead of a drifting re-implementation.
+ */
+export const __test__ = {
+  assertTrustedDownloadUrl,
+  assertSafeArchiveMember,
+  shellQuoteUnix,
+  extractRewrittenCommand,
+};

--- a/src/main/services/RtkService.ts
+++ b/src/main/services/RtkService.ts
@@ -65,6 +65,16 @@ export class RtkService {
     return join(RtkService.getManagedBinDir(), exe);
   }
 
+  /**
+   * When rtk is Dash-managed, its rewrite output references the bare name
+   * `rtk` — so the PTY needs our managed bin dir on PATH for the rewritten
+   * command to resolve. Returns null when no managed binary is present, in
+   * which case the user's own $PATH is expected to carry it.
+   */
+  static getManagedBinDirForPath(): string | null {
+    return existsSync(RtkService.getManagedBinPath()) ? RtkService.getManagedBinDir() : null;
+  }
+
   private static async resolveBinary(): Promise<{
     path: string;
     source: RtkSource;

--- a/src/main/services/RtkService.ts
+++ b/src/main/services/RtkService.ts
@@ -3,15 +3,17 @@ import {
   readFileSync,
   writeFileSync,
   mkdirSync,
+  createReadStream,
   createWriteStream,
   chmodSync,
   rmSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join, normalize, resolve, sep } from 'node:path';
 import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { pipeline } from 'node:stream/promises';
 import { Readable } from 'node:stream';
+import { createHash } from 'node:crypto';
 import type { ReadableStream as WebReadableStream } from 'node:stream/web';
 import { app } from 'electron';
 import type { WebContents } from 'electron';
@@ -19,12 +21,7 @@ import type { RtkStatus, RtkDownloadProgress, RtkSource, RtkTestResult } from '@
 
 const execFileAsync = promisify(execFile);
 
-/**
- * RTK (Rust Token Killer) integration. Dash manages rtk's lifecycle so users get
- * ~60–90% token savings on common shell commands without touching their global
- * ~/.claude/settings.json. Binary resolution prefers a Dash-managed copy under
- * userData/bin over whatever is on $PATH, so uninstalling Dash is clean.
- */
+/** Managed-bin resolution wins over $PATH so uninstalling Dash leaves no orphan binary. */
 export class RtkService {
   private static sender: WebContents | null = null;
   private static cachedResolution: {
@@ -32,6 +29,7 @@ export class RtkService {
     source: RtkSource;
     version: string | null;
   } | null = null;
+  private static downloadInFlight: Promise<void> | null = null;
 
   static setSender(sender: WebContents): void {
     RtkService.sender = sender;
@@ -42,18 +40,24 @@ export class RtkService {
   }
 
   static isEnabled(): boolean {
+    const p = RtkService.getConfigPath();
+    if (!existsSync(p)) return false;
     try {
-      const p = RtkService.getConfigPath();
-      if (!existsSync(p)) return false;
-      const raw = JSON.parse(readFileSync(p, 'utf-8'));
+      const raw = JSON.parse(readFileSync(p, 'utf-8')) as { enabled?: unknown };
       return raw.enabled === true;
-    } catch {
+    } catch (err) {
+      console.error(
+        '[RtkService.isEnabled] rtk-config.json unreadable, treating as disabled:',
+        err,
+      );
       return false;
     }
   }
 
   static setEnabled(enabled: boolean): void {
-    writeFileSync(RtkService.getConfigPath(), JSON.stringify({ enabled }, null, 2));
+    const p = RtkService.getConfigPath();
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, JSON.stringify({ enabled }, null, 2));
   }
 
   private static getManagedBinDir(): string {
@@ -65,12 +69,6 @@ export class RtkService {
     return join(RtkService.getManagedBinDir(), exe);
   }
 
-  /**
-   * When rtk is Dash-managed, its rewrite output references the bare name
-   * `rtk` — so the PTY needs our managed bin dir on PATH for the rewritten
-   * command to resolve. Returns null when no managed binary is present, in
-   * which case the user's own $PATH is expected to carry it.
-   */
   static getManagedBinDirForPath(): string | null {
     return existsSync(RtkService.getManagedBinPath()) ? RtkService.getManagedBinDir() : null;
   }
@@ -83,6 +81,10 @@ export class RtkService {
     const managed = RtkService.getManagedBinPath();
     if (existsSync(managed)) {
       const version = await RtkService.probeVersion(managed);
+      if (version === null) {
+        console.warn('[RtkService] managed binary exists but --version failed:', managed);
+        return null;
+      }
       return { path: managed, source: 'managed', version };
     }
 
@@ -92,10 +94,19 @@ export class RtkService {
       const resolved = stdout.trim().split(/\r?\n/)[0]?.trim();
       if (resolved) {
         const version = await RtkService.probeVersion(resolved);
+        if (version === null) {
+          console.warn('[RtkService] PATH binary found but --version failed:', resolved);
+          return null;
+        }
         return { path: resolved, source: 'path', version };
       }
-    } catch {
-      // Not on PATH
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      // `which` exits 1 when not found; `where.exe` also signals "not found" via non-zero.
+      // Everything else (EACCES, EMFILE, `which` binary missing) is worth surfacing.
+      if (code !== 'ENOENT' && !/exited.*1/i.test(String((err as Error).message ?? ''))) {
+        console.warn('[RtkService] which/where.exe lookup failed unexpectedly:', err);
+      }
     }
 
     return null;
@@ -103,20 +114,21 @@ export class RtkService {
 
   private static async probeVersion(binPath: string): Promise<string | null> {
     try {
-      const { stdout } = await execFileAsync(binPath, ['--version']);
+      const { stdout } = await execFileAsync(binPath, ['--version'], { timeout: 3000 });
       return stdout.trim();
-    } catch {
+    } catch (err) {
+      console.warn(`[RtkService] ${binPath} --version failed:`, err);
       return null;
     }
   }
 
-  /** Absolute path + subcommand emitted into the PreToolUse hook. */
   static getHookCommand(): string | null {
     const resolved = RtkService.cachedResolution;
     if (!resolved) return null;
-    // Quote for paths containing spaces (userData on macOS: "Application Support").
-    const quoted = resolved.path.includes(' ') ? `"${resolved.path}"` : resolved.path;
-    return `${quoted} hook claude`;
+    // Claude Code runs the hook via sh -c on Unix. Single-quote-escape the
+    // path so spaces and any shell metachars ($, `, ", \) in the userData
+    // directory never break or inject into the command.
+    return `${shellQuoteUnix(resolved.path)} hook claude`;
   }
 
   static async getStatus(): Promise<RtkStatus> {
@@ -133,12 +145,12 @@ export class RtkService {
     };
   }
 
-  /** Called once at startup so getHookCommand() works synchronously later. */
+  /** Populates cachedResolution so getHookCommand() is synchronous later. */
   static async warmUp(): Promise<void> {
     RtkService.cachedResolution = await RtkService.resolveBinary();
   }
 
-  /** No Windows native release exists upstream — fall back to manual-install guidance there. */
+  // No Windows native release exists upstream — manual-install guidance only there.
   private static isPlatformDownloadable(): boolean {
     if (process.platform === 'darwin') return true;
     if (process.platform === 'linux') return process.arch === 'x64' || process.arch === 'arm64';
@@ -158,15 +170,26 @@ export class RtkService {
     return null;
   }
 
-  /** Streams RtkDownloadProgress to the renderer via rtk:downloadProgress. */
-  static async download(): Promise<void> {
+  /** Single-flight wrapper so double-clicks don't race on the tmp archive. */
+  static download(): Promise<void> {
+    if (RtkService.downloadInFlight) return RtkService.downloadInFlight;
+    RtkService.downloadInFlight = RtkService.doDownload().finally(() => {
+      RtkService.downloadInFlight = null;
+    });
+    return RtkService.downloadInFlight;
+  }
+
+  /**
+   * Streams RtkDownloadProgress via rtk:downloadProgress AND rejects on failure
+   * so the IPC caller sees the same error. Progress events are for UI; the
+   * promise is authoritative.
+   */
+  private static async doDownload(): Promise<void> {
     const assetName = RtkService.getReleaseAssetName();
     if (!assetName) {
-      RtkService.emitProgress({
-        phase: 'error',
-        error: `No rtk release for ${process.platform}/${process.arch}. Install manually from rtk-ai.app.`,
-      });
-      return;
+      const msg = `No rtk release for ${process.platform}/${process.arch}. Install manually from rtk-ai.app.`;
+      RtkService.emitProgress({ phase: 'error', error: msg });
+      throw new Error(msg);
     }
 
     const binDir = RtkService.getManagedBinDir();
@@ -182,31 +205,45 @@ export class RtkService {
       if (!apiRes.ok) {
         throw new Error(`GitHub API ${apiRes.status}: ${apiRes.statusText}`);
       }
-      const release = (await apiRes.json()) as {
-        tag_name: string;
-        assets: Array<{ name: string; browser_download_url: string }>;
-      };
+      const release = (await apiRes.json()) as unknown;
+      if (!isReleasePayload(release)) {
+        throw new Error(`Unexpected GitHub API response: ${JSON.stringify(release).slice(0, 200)}`);
+      }
 
       const asset = release.assets.find((a) => a.name === assetName);
       if (!asset) {
         throw new Error(`Release ${release.tag_name} has no asset "${assetName}"`);
       }
+      assertTrustedDownloadUrl(asset.browser_download_url);
+
+      const checksumAsset = release.assets.find((a) => a.name === 'checksums.txt');
+      if (!checksumAsset) {
+        throw new Error(`Release ${release.tag_name} has no checksums.txt — refusing to install.`);
+      }
+      assertTrustedDownloadUrl(checksumAsset.browser_download_url);
 
       if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true });
 
-      // GitHub's release CDN occasionally serves truncated/corrupt bytes. Download,
-      // verify the gzip is intact via `tar -tzf`, and retry a few times before
-      // surfacing an error to the user.
+      const expectedSha = await RtkService.fetchExpectedSha256(
+        checksumAsset.browser_download_url,
+        assetName,
+      );
+
+      // GitHub's release CDN occasionally serves truncated/corrupt bytes;
+      // retry a few times before surfacing an error to the user.
       const MAX_ATTEMPTS = 3;
       let lastError: Error | null = null;
       for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
         try {
           await RtkService.fetchToFile(asset.browser_download_url, tmpArchive);
+          RtkService.emitProgress({ phase: 'verifying' });
+          await RtkService.verifyChecksum(tmpArchive, expectedSha);
           await RtkService.verifyArchive(tmpArchive);
           lastError = null;
           break;
         } catch (err) {
           lastError = err instanceof Error ? err : new Error(String(err));
+          console.warn(`[RtkService.download] attempt ${attempt} failed:`, lastError.message);
           rmSync(tmpArchive, { force: true });
           if (attempt < MAX_ATTEMPTS) {
             RtkService.emitProgress({ phase: 'downloading', percent: 0 });
@@ -215,8 +252,7 @@ export class RtkService {
       }
       if (lastError) {
         throw new Error(
-          `Download repeatedly corrupted (${MAX_ATTEMPTS} attempts): ${lastError.message}. ` +
-            `This is usually a transient CDN issue — try again in a minute.`,
+          `Download repeatedly failed (${MAX_ATTEMPTS} attempts): ${lastError.message}`,
         );
       }
 
@@ -224,7 +260,7 @@ export class RtkService {
       try {
         await RtkService.extractTarball(tmpArchive, binDir);
       } catch (err) {
-        // Partial extraction may have dropped a half-written binary at binPath.
+        // Partial extraction may have dropped a half-written binary.
         rmSync(binPath, { force: true });
         throw err;
       }
@@ -232,17 +268,45 @@ export class RtkService {
       if (!existsSync(binPath)) {
         throw new Error(`Archive did not contain expected binary at ${binPath}`);
       }
+      // Must chmod before the probeVersion spawn below; tar on some systems drops +x.
       chmodSync(binPath, 0o755);
 
       RtkService.cachedResolution = await RtkService.resolveBinary();
+      if (!RtkService.cachedResolution) {
+        rmSync(binPath, { force: true });
+        throw new Error('Installed binary failed to report --version; removed.');
+      }
+
       RtkService.emitProgress({ phase: 'done', version: release.tag_name });
     } catch (err) {
-      RtkService.emitProgress({
-        phase: 'error',
-        error: err instanceof Error ? err.message : String(err),
-      });
+      const message = err instanceof Error ? err.message : String(err);
+      RtkService.emitProgress({ phase: 'error', error: message });
+      throw err instanceof Error ? err : new Error(message);
     } finally {
       rmSync(tmpArchive, { force: true });
+    }
+  }
+
+  private static async fetchExpectedSha256(url: string, assetName: string): Promise<string> {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Failed to fetch checksums.txt: ${res.status} ${res.statusText}`);
+    const body = await res.text();
+    // checksums.txt format: "<hex-sha256>  <filename>" per line.
+    for (const line of body.split(/\r?\n/)) {
+      const match = line.match(/^([a-f0-9]{64})\s+\*?(.+?)\s*$/i);
+      if (match && match[2] === assetName) return match[1]!.toLowerCase();
+    }
+    throw new Error(`checksums.txt does not list ${assetName}`);
+  }
+
+  private static async verifyChecksum(filePath: string, expectedSha: string): Promise<void> {
+    const hash = createHash('sha256');
+    await pipeline(createReadStream(filePath), hash);
+    const actual = hash.digest('hex');
+    if (actual !== expectedSha) {
+      throw new Error(
+        `Checksum mismatch: expected ${expectedSha}, got ${actual}. Refusing to install.`,
+      );
     }
   }
 
@@ -265,12 +329,21 @@ export class RtkService {
       }
     });
     await pipeline(source, createWriteStream(dest));
+    if (total > 0 && transferred !== total) {
+      throw new Error(`Truncated download: expected ${total} bytes, got ${transferred}.`);
+    }
+    RtkService.emitProgress({ phase: 'downloading', percent: 100 });
   }
 
-  /** Throws if the archive isn't a valid gzip-ed tar — cheap enough to do before extraction. */
   private static async verifyArchive(archivePath: string): Promise<void> {
     try {
-      await RtkService.runTar(['-tzf', archivePath]);
+      // Also validates every member is relative and stays inside dest (prevents
+      // path-traversal via crafted archives).
+      const entries = await RtkService.listTarball(archivePath);
+      const dest = RtkService.getManagedBinDir();
+      for (const entry of entries) {
+        assertSafeArchiveMember(entry, dest);
+      }
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       throw new Error(`Archive integrity check failed: ${detail}`);
@@ -278,25 +351,64 @@ export class RtkService {
   }
 
   private static async extractTarball(archivePath: string, destDir: string): Promise<void> {
-    // Try plain extract first (rtk's releases put the binary at the archive root).
+    // Plain extract first (rtk's releases put the binary at the archive root).
     // If the binary still isn't where we expect, retry with --strip-components=1
-    // to handle archives that nest the binary under a top-level directory.
-    await RtkService.runTar(['-xzf', archivePath, '-C', destDir]);
+    // for archives that nest the binary under a top-level directory.
+    await RtkService.runTar(['-xzf', archivePath, '-C', destDir, '--no-same-owner']);
     if (existsSync(RtkService.getManagedBinPath())) return;
-    await RtkService.runTar(['-xzf', archivePath, '-C', destDir, '--strip-components=1']);
+    console.warn('[RtkService] binary not at archive root, retrying with --strip-components=1');
+    await RtkService.runTar([
+      '-xzf',
+      archivePath,
+      '-C',
+      destDir,
+      '--strip-components=1',
+      '--no-same-owner',
+    ]);
+  }
+
+  private static listTarball(archivePath: string): Promise<string[]> {
+    return new Promise((resolveP, rejectP) => {
+      const proc = spawn('tar', ['-tzf', archivePath], { stdio: ['ignore', 'pipe', 'pipe'] });
+      let stdout = '';
+      let stderr = '';
+      proc.stdout.on('data', (d: Buffer) => {
+        stdout += d.toString();
+      });
+      proc.stderr.on('data', (d: Buffer) => {
+        stderr += d.toString();
+      });
+      proc.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'ENOENT') {
+          rejectP(new Error('`tar` is not available on PATH. Install it and retry.'));
+        } else {
+          rejectP(err);
+        }
+      });
+      proc.on('exit', (code) => {
+        if (code === 0) resolveP(stdout.split(/\r?\n/).filter(Boolean));
+        else rejectP(new Error(`tar -tzf exited ${code}: ${stderr.trim()}`));
+      });
+    });
   }
 
   private static runTar(args: string[]): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolveP, rejectP) => {
       const proc = spawn('tar', args, { stdio: ['ignore', 'ignore', 'pipe'] });
       let stderr = '';
       proc.stderr?.on('data', (d: Buffer) => {
         stderr += d.toString();
       });
-      proc.on('error', reject);
+      proc.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'ENOENT') {
+          rejectP(new Error('`tar` is not available on PATH. Install it and retry.'));
+        } else {
+          rejectP(err);
+        }
+      });
       proc.on('exit', (code) => {
-        if (code === 0) resolve();
-        else reject(new Error(`tar exited ${code}: ${stderr.trim()}`));
+        if (code === 0) resolveP();
+        else rejectP(new Error(`tar exited ${code}: ${stderr.trim()}`));
       });
     });
   }
@@ -308,12 +420,7 @@ export class RtkService {
     }
   }
 
-  /**
-   * Pipe a synthetic Claude Code PreToolUse payload through `rtk hook claude`
-   * so the UI can prove, in-process, that the same binary Dash hands to Claude
-   * actually emits a rewrite directive. `git status` is the headline example
-   * in rtk's README (~75% token reduction) so it's a reliable positive case.
-   */
+  /** Exercises `rtk hook claude` end-to-end so Settings can prove the binary rewrites. */
   static async runHookTest(): Promise<RtkTestResult> {
     const resolved = RtkService.cachedResolution ?? (await RtkService.resolveBinary());
     if (!resolved) {
@@ -328,7 +435,7 @@ export class RtkService {
     });
 
     try {
-      const { stdout, stderr, code } = await pipeStdin(
+      const { stdout, stderr, code, signal } = await pipeStdin(
         resolved.path,
         ['hook', 'claude'],
         input,
@@ -337,6 +444,13 @@ export class RtkService {
 
       if (/panic|unwrap|segfault/i.test(stderr)) {
         return { ok: false, testedCommand, error: `rtk crashed: ${stderr.trim().slice(0, 400)}` };
+      }
+      if (code === null) {
+        return {
+          ok: false,
+          testedCommand,
+          error: `rtk killed by signal ${signal ?? 'unknown'} (likely timeout)`,
+        };
       }
       if (code !== 0 && code !== 2) {
         return {
@@ -347,12 +461,20 @@ export class RtkService {
       }
 
       const rewritten = extractRewrittenCommand(stdout);
+      if (rewritten instanceof Error) {
+        return {
+          ok: false,
+          testedCommand,
+          error: `rtk produced unparsable output: ${rewritten.message}`,
+        };
+      }
+
       return {
         ok: true,
         testedCommand,
         rewrittenCommand: rewritten,
-        wouldCompress: rewritten != null && rewritten !== testedCommand,
         rawOutput: stdout.slice(0, 2000),
+        ...(code === 2 ? { blocked: { stderr: stderr.trim().slice(0, 400) } } : {}),
       };
     } catch (err) {
       return { ok: false, testedCommand, error: err instanceof Error ? err.message : String(err) };
@@ -367,8 +489,8 @@ function pipeStdin(
   args: string[],
   stdin: string,
   timeoutMs: number,
-): Promise<{ code: number | null; stdout: string; stderr: string }> {
-  return new Promise((resolve, reject) => {
+): Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string }> {
+  return new Promise((resolveP, rejectP) => {
     const proc = spawn(cmd, args, { timeout: timeoutMs });
     let stdout = '';
     let stderr = '';
@@ -378,42 +500,94 @@ function pipeStdin(
     proc.stderr.on('data', (c: Buffer) => {
       stderr += c.toString();
     });
-    proc.on('error', reject);
-    proc.on('close', (code) => resolve({ code, stdout, stderr }));
+    // rtk may exit before reading stdin; EPIPE must not become unhandled.
+    proc.stdin.on('error', () => {});
+    proc.on('error', rejectP);
+    proc.on('close', (code, signal) => resolveP({ code, signal, stdout, stderr }));
     proc.stdin.write(stdin);
     proc.stdin.end();
   });
 }
 
-/**
- * Claude Code's hook schema accepts a few equivalent shapes for rewriting a
- * tool call. Walk the likely paths rather than pinning to one — keeps the
- * test resilient if rtk's output format shifts between releases.
- */
-function extractRewrittenCommand(stdout: string): string | null {
+function extractRewrittenCommand(stdout: string): string | null | Error {
   const trimmed = stdout.trim();
   if (!trimmed) return null;
+  let parsed: Record<string, unknown>;
   try {
-    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
-    const paths: Array<(v: Record<string, unknown>) => unknown> = [
-      // rtk's actual shape as of writing: hookSpecificOutput.updatedInput.command
-      (v) => (v.hookSpecificOutput as Record<string, unknown>)?.updatedInput,
-      (v) => (v.hookSpecificOutput as Record<string, unknown>)?.modifiedToolInput,
-      (v) => (v.hookSpecificOutput as Record<string, unknown>)?.updatedToolInput,
-      (v) => v.updatedInput,
-      (v) => v.modifiedToolInput,
-      (v) => v.updatedToolInput,
-      (v) => v.tool_input,
-    ];
-    for (const get of paths) {
-      const node = get(parsed);
-      if (node && typeof node === 'object' && 'command' in node) {
-        const cmd = (node as Record<string, unknown>).command;
-        if (typeof cmd === 'string') return cmd;
-      }
+    parsed = JSON.parse(trimmed) as Record<string, unknown>;
+  } catch (err) {
+    return err instanceof Error ? err : new Error(String(err));
+  }
+  const paths: Array<(v: Record<string, unknown>) => unknown> = [
+    (v) => (isObject(v.hookSpecificOutput) ? v.hookSpecificOutput.updatedInput : undefined),
+    (v) => (isObject(v.hookSpecificOutput) ? v.hookSpecificOutput.modifiedToolInput : undefined),
+    (v) => (isObject(v.hookSpecificOutput) ? v.hookSpecificOutput.updatedToolInput : undefined),
+    (v) => v.updatedInput,
+    (v) => v.modifiedToolInput,
+    (v) => v.updatedToolInput,
+    (v) => v.tool_input,
+  ];
+  for (const get of paths) {
+    const node = get(parsed);
+    if (isObject(node) && typeof node.command === 'string') {
+      return node.command;
     }
-    return null;
+  }
+  return null;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object';
+}
+
+function shellQuoteUnix(s: string): string {
+  // POSIX sh single-quote escape: close quote, inject escaped ', reopen.
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+interface ReleasePayload {
+  tag_name: string;
+  assets: Array<{ name: string; browser_download_url: string }>;
+}
+
+function isReleasePayload(v: unknown): v is ReleasePayload {
+  if (!isObject(v)) return false;
+  if (typeof v.tag_name !== 'string') return false;
+  if (!Array.isArray(v.assets)) return false;
+  return v.assets.every(
+    (a) => isObject(a) && typeof a.name === 'string' && typeof a.browser_download_url === 'string',
+  );
+}
+
+function assertTrustedDownloadUrl(raw: string): void {
+  let url: URL;
+  try {
+    url = new URL(raw);
   } catch {
-    return null;
+    throw new Error(`Refusing malformed asset URL: ${raw}`);
+  }
+  if (url.protocol !== 'https:') {
+    throw new Error(`Refusing non-HTTPS asset URL: ${raw}`);
+  }
+  const host = url.hostname.toLowerCase();
+  const allowed =
+    host === 'github.com' ||
+    host === 'api.github.com' ||
+    host === 'objects.githubusercontent.com' ||
+    host.endsWith('.githubusercontent.com');
+  if (!allowed) {
+    throw new Error(`Refusing asset URL outside GitHub: ${raw}`);
+  }
+}
+
+function assertSafeArchiveMember(entry: string, destDir: string): void {
+  // Reject absolute paths and any entry whose resolved location escapes destDir.
+  if (entry.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(entry)) {
+    throw new Error(`Archive contains absolute path: ${entry}`);
+  }
+  const resolved = resolve(destDir, normalize(entry));
+  const base = resolve(destDir) + sep;
+  if (resolved !== resolve(destDir) && !resolved.startsWith(base)) {
+    throw new Error(`Archive member escapes destDir: ${entry}`);
   }
 }

--- a/src/main/services/RtkService.ts
+++ b/src/main/services/RtkService.ts
@@ -8,7 +8,9 @@ import {
   chmodSync,
   rmSync,
 } from 'node:fs';
-import { dirname, join, normalize, resolve, sep } from 'node:path';
+import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { delimiter, dirname, join, normalize, resolve, sep } from 'node:path';
+import { tmpdir } from 'node:os';
 import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { pipeline } from 'node:stream/promises';
@@ -529,20 +531,121 @@ export class RtkService {
         };
       }
 
+      // Only attempt real execution when rtk actually rewrote the command AND
+      // didn't block it — otherwise the diff would be empty or meaningless.
+      const execDiff =
+        extracted.command && extracted.command !== testedCommand && code !== 2
+          ? await RtkService.captureExecDiff(testedCommand, extracted.command)
+          : null;
+
       return {
         ok: true,
         testedCommand,
         rewrittenCommand: extracted.command,
         rawOutput: stdout.slice(0, 2000),
         ...(code === 2 ? { blocked: { stderr: stderr.trim().slice(0, 400) } } : {}),
+        ...(execDiff ? { execDiff } : {}),
       };
     } catch (err) {
       return { ok: false, testedCommand, error: err instanceof Error ? err.message : String(err) };
     }
   }
+
+  /**
+   * Execute both the raw and rtk-rewritten commands inside a throwaway git
+   * repo populated with enough untracked files to make `git status` verbose.
+   * Returns null on any failure — this is a best-effort visualization, not a
+   * correctness check. The rewrite-directive check above already proved rtk
+   * is working; this just makes the compression visible to the user.
+   */
+  private static async captureExecDiff(
+    rawCommand: string,
+    rewrittenCommand: string,
+  ): Promise<import('@shared/types').RtkExecDiff | null> {
+    const dir = await mkdtemp(join(tmpdir(), 'dash-rtk-verify-'));
+    try {
+      // Give `git status` something non-trivial to emit — multiple files
+      // across a few directories so rtk's grouping/dedup filters have work.
+      await Promise.all([
+        writeFile(join(dir, 'package.json'), '{}\n'),
+        writeFile(join(dir, 'README.md'), '# test\n'),
+        writeFile(join(dir, 'config.toml'), '[section]\nvalue = 1\n'),
+        mkdir(join(dir, 'src')).then(() =>
+          Promise.all([
+            writeFile(join(dir, 'src', 'index.ts'), 'export {};\n'),
+            writeFile(join(dir, 'src', 'lib.ts'), 'export {};\n'),
+            writeFile(join(dir, 'src', 'types.ts'), 'export {};\n'),
+          ]),
+        ),
+        mkdir(join(dir, 'tests')).then(() =>
+          Promise.all([
+            writeFile(join(dir, 'tests', 'a.test.ts'), 'test\n'),
+            writeFile(join(dir, 'tests', 'b.test.ts'), 'test\n'),
+          ]),
+        ),
+      ]);
+
+      await runShell('git init -q', dir);
+
+      // Make sure rtk resolves from the rewritten command even when the user
+      // never installed it on the system PATH — prepend our managed bin dir.
+      const managedDir = RtkService.getManagedBinDirForPath();
+      const pathWithRtk = [managedDir, process.env.PATH].filter(Boolean).join(delimiter);
+      const env = { ...process.env, PATH: pathWithRtk };
+
+      const [rawRes, rewrittenRes] = await Promise.all([
+        runShell(rawCommand, dir, env),
+        runShell(rewrittenCommand, dir, env),
+      ]);
+
+      // Trim IPC payload but report the TRUE byte counts so savings math stays honest.
+      const DISPLAY_CAP = 8 * 1024;
+      return {
+        rawStdout: rawRes.stdout.slice(0, DISPLAY_CAP),
+        compressedStdout: rewrittenRes.stdout.slice(0, DISPLAY_CAP),
+        rawBytes: Buffer.byteLength(rawRes.stdout),
+        compressedBytes: Buffer.byteLength(rewrittenRes.stdout),
+      };
+    } catch (err) {
+      console.warn('[RtkService.captureExecDiff] non-fatal:', err);
+      return null;
+    } finally {
+      await rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
 }
 
 // ── Helpers (module-private) ───────────────────────────────────────────────
+
+/**
+ * Run a shell string and capture its stdout/stderr up to a hard cap. Used by
+ * the Test RTK flow to exec both the raw command (e.g. `git status`) and the
+ * rtk-rewritten version (e.g. `rtk git status`) in a controlled environment.
+ */
+const RUN_SHELL_OUTPUT_CAP = 64 * 1024;
+
+function runShell(
+  cmd: string,
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+  timeoutMs = 15_000,
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  return new Promise((resolveP, rejectP) => {
+    const shell = process.platform === 'win32' ? 'cmd.exe' : 'sh';
+    const args = process.platform === 'win32' ? ['/c', cmd] : ['-c', cmd];
+    const proc = spawn(shell, args, { cwd, env, timeout: timeoutMs });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (c: Buffer) => {
+      if (stdout.length < RUN_SHELL_OUTPUT_CAP) stdout += c.toString();
+    });
+    proc.stderr.on('data', (c: Buffer) => {
+      if (stderr.length < RUN_SHELL_OUTPUT_CAP) stderr += c.toString();
+    });
+    proc.on('error', rejectP);
+    proc.on('close', (code) => resolveP({ stdout, stderr, code }));
+  });
+}
 
 function pipeStdin(
   cmd: string,

--- a/src/main/services/RtkService.ts
+++ b/src/main/services/RtkService.ts
@@ -1,0 +1,431 @@
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  createWriteStream,
+  chmodSync,
+  rmSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { execFile, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
+import type { ReadableStream as WebReadableStream } from 'node:stream/web';
+import { app } from 'electron';
+import type { WebContents } from 'electron';
+import type { RtkStatus, RtkDownloadProgress, RtkSource, RtkTestResult } from '@shared/types';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * RTK (Rust Token Killer) integration. Dash manages rtk's lifecycle so users get
+ * ~60–90% token savings on common shell commands without touching their global
+ * ~/.claude/settings.json. Binary resolution prefers a Dash-managed copy under
+ * userData/bin over whatever is on $PATH, so uninstalling Dash is clean.
+ */
+export class RtkService {
+  private static sender: WebContents | null = null;
+  private static cachedResolution: {
+    path: string;
+    source: RtkSource;
+    version: string | null;
+  } | null = null;
+
+  static setSender(sender: WebContents): void {
+    RtkService.sender = sender;
+  }
+
+  private static getConfigPath(): string {
+    return join(app.getPath('userData'), 'rtk-config.json');
+  }
+
+  static isEnabled(): boolean {
+    try {
+      const p = RtkService.getConfigPath();
+      if (!existsSync(p)) return false;
+      const raw = JSON.parse(readFileSync(p, 'utf-8'));
+      return raw.enabled === true;
+    } catch {
+      return false;
+    }
+  }
+
+  static setEnabled(enabled: boolean): void {
+    writeFileSync(RtkService.getConfigPath(), JSON.stringify({ enabled }, null, 2));
+  }
+
+  private static getManagedBinDir(): string {
+    return join(app.getPath('userData'), 'bin');
+  }
+
+  private static getManagedBinPath(): string {
+    const exe = process.platform === 'win32' ? 'rtk.exe' : 'rtk';
+    return join(RtkService.getManagedBinDir(), exe);
+  }
+
+  private static async resolveBinary(): Promise<{
+    path: string;
+    source: RtkSource;
+    version: string | null;
+  } | null> {
+    const managed = RtkService.getManagedBinPath();
+    if (existsSync(managed)) {
+      const version = await RtkService.probeVersion(managed);
+      return { path: managed, source: 'managed', version };
+    }
+
+    try {
+      const findCmd = process.platform === 'win32' ? 'where.exe' : 'which';
+      const { stdout } = await execFileAsync(findCmd, ['rtk']);
+      const resolved = stdout.trim().split(/\r?\n/)[0]?.trim();
+      if (resolved) {
+        const version = await RtkService.probeVersion(resolved);
+        return { path: resolved, source: 'path', version };
+      }
+    } catch {
+      // Not on PATH
+    }
+
+    return null;
+  }
+
+  private static async probeVersion(binPath: string): Promise<string | null> {
+    try {
+      const { stdout } = await execFileAsync(binPath, ['--version']);
+      return stdout.trim();
+    } catch {
+      return null;
+    }
+  }
+
+  /** Absolute path + subcommand emitted into the PreToolUse hook. */
+  static getHookCommand(): string | null {
+    const resolved = RtkService.cachedResolution;
+    if (!resolved) return null;
+    // Quote for paths containing spaces (userData on macOS: "Application Support").
+    const quoted = resolved.path.includes(' ') ? `"${resolved.path}"` : resolved.path;
+    return `${quoted} hook claude`;
+  }
+
+  static async getStatus(): Promise<RtkStatus> {
+    const resolved = await RtkService.resolveBinary();
+    RtkService.cachedResolution = resolved;
+
+    const downloadable = RtkService.isPlatformDownloadable();
+
+    if (!resolved) {
+      return {
+        installed: false,
+        version: null,
+        path: null,
+        source: 'none',
+        enabled: RtkService.isEnabled(),
+        downloadable,
+      };
+    }
+
+    return {
+      installed: true,
+      version: resolved.version,
+      path: resolved.path,
+      source: resolved.source,
+      enabled: RtkService.isEnabled(),
+      downloadable,
+    };
+  }
+
+  /** Called once at startup so getHookCommand() works synchronously later. */
+  static async warmUp(): Promise<void> {
+    RtkService.cachedResolution = await RtkService.resolveBinary();
+  }
+
+  /** No Windows native release exists upstream — fall back to manual-install guidance there. */
+  private static isPlatformDownloadable(): boolean {
+    if (process.platform === 'darwin') return true;
+    if (process.platform === 'linux') return process.arch === 'x64' || process.arch === 'arm64';
+    return false;
+  }
+
+  private static getReleaseAssetName(): string | null {
+    if (process.platform === 'darwin') {
+      return process.arch === 'arm64'
+        ? 'rtk-aarch64-apple-darwin.tar.gz'
+        : 'rtk-x86_64-apple-darwin.tar.gz';
+    }
+    if (process.platform === 'linux') {
+      if (process.arch === 'x64') return 'rtk-x86_64-unknown-linux-musl.tar.gz';
+      if (process.arch === 'arm64') return 'rtk-aarch64-unknown-linux-gnu.tar.gz';
+    }
+    return null;
+  }
+
+  /** Streams RtkDownloadProgress to the renderer via rtk:downloadProgress. */
+  static async download(): Promise<void> {
+    const assetName = RtkService.getReleaseAssetName();
+    if (!assetName) {
+      RtkService.emitProgress({
+        phase: 'error',
+        error: `No rtk release for ${process.platform}/${process.arch}. Install manually from rtk-ai.app.`,
+      });
+      return;
+    }
+
+    const binDir = RtkService.getManagedBinDir();
+    const tmpArchive = join(binDir, `${assetName}.tmp`);
+    const binPath = RtkService.getManagedBinPath();
+
+    try {
+      RtkService.emitProgress({ phase: 'downloading', percent: 0 });
+
+      const apiRes = await fetch('https://api.github.com/repos/rtk-ai/rtk/releases/latest', {
+        headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'dash-rtk-installer' },
+      });
+      if (!apiRes.ok) {
+        throw new Error(`GitHub API ${apiRes.status}: ${apiRes.statusText}`);
+      }
+      const release = (await apiRes.json()) as {
+        tag_name: string;
+        assets: Array<{ name: string; browser_download_url: string }>;
+      };
+
+      const asset = release.assets.find((a) => a.name === assetName);
+      if (!asset) {
+        throw new Error(`Release ${release.tag_name} has no asset "${assetName}"`);
+      }
+
+      if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true });
+
+      // GitHub's release CDN occasionally serves truncated/corrupt bytes. Download,
+      // verify the gzip is intact via `tar -tzf`, and retry a few times before
+      // surfacing an error to the user.
+      const MAX_ATTEMPTS = 3;
+      let lastError: Error | null = null;
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+          await RtkService.fetchToFile(asset.browser_download_url, tmpArchive);
+          await RtkService.verifyArchive(tmpArchive);
+          lastError = null;
+          break;
+        } catch (err) {
+          lastError = err instanceof Error ? err : new Error(String(err));
+          rmSync(tmpArchive, { force: true });
+          if (attempt < MAX_ATTEMPTS) {
+            RtkService.emitProgress({ phase: 'downloading', percent: 0 });
+          }
+        }
+      }
+      if (lastError) {
+        throw new Error(
+          `Download repeatedly corrupted (${MAX_ATTEMPTS} attempts): ${lastError.message}. ` +
+            `This is usually a transient CDN issue — try again in a minute.`,
+        );
+      }
+
+      RtkService.emitProgress({ phase: 'extracting' });
+      try {
+        await RtkService.extractTarball(tmpArchive, binDir);
+      } catch (err) {
+        // Partial extraction may have dropped a half-written binary at binPath.
+        rmSync(binPath, { force: true });
+        throw err;
+      }
+
+      if (!existsSync(binPath)) {
+        throw new Error(`Archive did not contain expected binary at ${binPath}`);
+      }
+      chmodSync(binPath, 0o755);
+
+      RtkService.cachedResolution = await RtkService.resolveBinary();
+      RtkService.emitProgress({ phase: 'done', version: release.tag_name });
+    } catch (err) {
+      RtkService.emitProgress({
+        phase: 'error',
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      rmSync(tmpArchive, { force: true });
+    }
+  }
+
+  private static async fetchToFile(url: string, dest: string): Promise<void> {
+    const dlRes = await fetch(url);
+    if (!dlRes.ok || !dlRes.body) {
+      throw new Error(`Download failed: ${dlRes.status} ${dlRes.statusText}`);
+    }
+    const total = Number(dlRes.headers.get('content-length') || '0');
+    let transferred = 0;
+
+    const source = Readable.fromWeb(dlRes.body as unknown as WebReadableStream<Uint8Array>);
+    source.on('data', (chunk: Buffer) => {
+      transferred += chunk.length;
+      if (total > 0) {
+        RtkService.emitProgress({
+          phase: 'downloading',
+          percent: Math.min(99, Math.round((transferred / total) * 100)),
+        });
+      }
+    });
+    await pipeline(source, createWriteStream(dest));
+  }
+
+  /** Throws if the archive isn't a valid gzip-ed tar — cheap enough to do before extraction. */
+  private static async verifyArchive(archivePath: string): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      const proc = spawn('tar', ['-tzf', archivePath], { stdio: ['ignore', 'ignore', 'pipe'] });
+      let stderr = '';
+      proc.stderr?.on('data', (d: Buffer) => {
+        stderr += d.toString();
+      });
+      proc.on('error', reject);
+      proc.on('exit', (code) => {
+        if (code === 0) resolve();
+        else
+          reject(
+            new Error(`Archive integrity check failed: ${stderr.trim() || `tar exited ${code}`}`),
+          );
+      });
+    });
+  }
+
+  private static async extractTarball(archivePath: string, destDir: string): Promise<void> {
+    // Try plain extract first (rtk's releases put the binary at the archive root).
+    // If the binary still isn't where we expect, retry with --strip-components=1
+    // to handle archives that nest the binary under a top-level directory.
+    await RtkService.runTar(['-xzf', archivePath, '-C', destDir]);
+    if (existsSync(RtkService.getManagedBinPath())) return;
+    await RtkService.runTar(['-xzf', archivePath, '-C', destDir, '--strip-components=1']);
+  }
+
+  private static runTar(args: string[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn('tar', args, { stdio: ['ignore', 'ignore', 'pipe'] });
+      let stderr = '';
+      proc.stderr?.on('data', (d: Buffer) => {
+        stderr += d.toString();
+      });
+      proc.on('error', reject);
+      proc.on('exit', (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`tar exited ${code}: ${stderr.trim()}`));
+      });
+    });
+  }
+
+  private static emitProgress(progress: RtkDownloadProgress): void {
+    const sender = RtkService.sender;
+    if (sender && !sender.isDestroyed()) {
+      sender.send('rtk:downloadProgress', progress);
+    }
+  }
+
+  /**
+   * Pipe a synthetic Claude Code PreToolUse payload through `rtk hook claude`
+   * so the UI can prove, in-process, that the same binary Dash hands to Claude
+   * actually emits a rewrite directive. `git status` is the headline example
+   * in rtk's README (~75% token reduction) so it's a reliable positive case.
+   */
+  static async runHookTest(): Promise<RtkTestResult> {
+    const resolved = RtkService.cachedResolution ?? (await RtkService.resolveBinary());
+    if (!resolved) {
+      return { ok: false, error: 'rtk is not installed' };
+    }
+
+    const testedCommand = 'git status';
+    const input = JSON.stringify({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: testedCommand, description: 'RTK self-test' },
+    });
+
+    try {
+      const { stdout, stderr, code } = await pipeStdin(
+        resolved.path,
+        ['hook', 'claude'],
+        input,
+        10_000,
+      );
+
+      if (/panic|unwrap|segfault/i.test(stderr)) {
+        return { ok: false, testedCommand, error: `rtk crashed: ${stderr.trim().slice(0, 400)}` };
+      }
+      if (code !== 0 && code !== 2) {
+        return {
+          ok: false,
+          testedCommand,
+          error: `rtk exited ${code}${stderr ? ': ' + stderr.trim().slice(0, 400) : ''}`,
+        };
+      }
+
+      const rewritten = extractRewrittenCommand(stdout);
+      return {
+        ok: true,
+        testedCommand,
+        rewrittenCommand: rewritten,
+        wouldCompress: rewritten != null && rewritten !== testedCommand,
+        rawOutput: stdout.slice(0, 2000),
+      };
+    } catch (err) {
+      return { ok: false, testedCommand, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}
+
+// ── Helpers (module-private) ───────────────────────────────────────────────
+
+function pipeStdin(
+  cmd: string,
+  args: string[],
+  stdin: string,
+  timeoutMs: number,
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(cmd, args, { timeout: timeoutMs });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (c: Buffer) => {
+      stdout += c.toString();
+    });
+    proc.stderr.on('data', (c: Buffer) => {
+      stderr += c.toString();
+    });
+    proc.on('error', reject);
+    proc.on('close', (code) => resolve({ code, stdout, stderr }));
+    proc.stdin.write(stdin);
+    proc.stdin.end();
+  });
+}
+
+/**
+ * Claude Code's hook schema accepts a few equivalent shapes for rewriting a
+ * tool call. Walk the likely paths rather than pinning to one — keeps the
+ * test resilient if rtk's output format shifts between releases.
+ */
+function extractRewrittenCommand(stdout: string): string | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    const paths: Array<(v: Record<string, unknown>) => unknown> = [
+      // rtk's actual shape as of writing: hookSpecificOutput.updatedInput.command
+      (v) => (v.hookSpecificOutput as Record<string, unknown>)?.updatedInput,
+      (v) => (v.hookSpecificOutput as Record<string, unknown>)?.modifiedToolInput,
+      (v) => (v.hookSpecificOutput as Record<string, unknown>)?.updatedToolInput,
+      (v) => v.updatedInput,
+      (v) => v.modifiedToolInput,
+      (v) => v.updatedToolInput,
+      (v) => v.tool_input,
+    ];
+    for (const get of paths) {
+      const node = get(parsed);
+      if (node && typeof node === 'object' && 'command' in node) {
+        const cmd = (node as Record<string, unknown>).command;
+        if (typeof cmd === 'string') return cmd;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/main/services/RtkService.ts
+++ b/src/main/services/RtkService.ts
@@ -211,7 +211,6 @@ export class RtkService {
       RtkService.cachedResolution = resolved;
     }
 
-    const enabled = RtkService.isEnabled();
     const downloadable = RtkService.isPlatformDownloadable();
     const effective = resolved ?? RtkService.cachedResolution;
     if (effective) {
@@ -220,11 +219,14 @@ export class RtkService {
         version: effective.version,
         path: effective.path,
         source: effective.source,
-        enabled,
+        enabled: RtkService.isEnabled(),
         downloadable,
       };
     }
-    return { installed: false, enabled, downloadable };
+    // No binary resolved → enabled is omitted by construction; isEnabled()'s
+    // disk flag stays put so the toggle restores correctly once a binary
+    // becomes available again.
+    return { installed: false, downloadable };
   }
 
   /** Populates cachedResolution so getHookCommand() is synchronous later. */
@@ -396,8 +398,9 @@ export class RtkService {
     const res = await fetchWithTimeout(url, {}, FETCH_API_TIMEOUT_MS);
     if (!res.ok) throw new Error(`Failed to fetch checksums.txt: ${res.status} ${res.statusText}`);
     const body = await res.text();
-    // checksums.txt format: "<hex-sha256>  <filename>" per line.
     for (const line of body.split(/\r?\n/)) {
+      // The `\*?` accepts the BSD "binary mode" marker some sha256sum
+      // implementations emit; without it those releases would fail to match.
       const match = line.match(/^([a-f0-9]{64})\s+\*?(.+?)\s*$/i);
       if (match && match[2] === assetName) return match[1]!.toLowerCase();
     }
@@ -588,24 +591,34 @@ export class RtkService {
         };
       }
 
-      // Only attempt real execution when rtk actually rewrote the command AND
-      // didn't block it — otherwise the diff would be empty or meaningless.
-      const execDiff =
-        extracted.command && extracted.command !== testedCommand && code !== 2
-          ? await RtkService.captureExecDiff(testedCommand, extracted.command)
-          : null;
+      const rawOutput = stdout.slice(0, 2000);
 
-      return {
-        ok: true,
-        testedCommand,
-        rewrittenCommand: extracted.command,
-        rawOutput: stdout.slice(0, 2000),
-        ...(code === 2 ? { blocked: { stderr: stderr.trim().slice(0, 400) } } : {}),
-        ...(execDiff ? { execDiff } : {}),
-        // execDiff `kind: 'failed'` is forwarded as-is; the renderer renders
-        // it as a "couldn't capture diff" warning rather than the green
-        // pass-through banner that null used to produce.
-      };
+      // exit 2 → blocked, regardless of any rewrite payload.
+      if (code === 2) {
+        return {
+          ok: true,
+          testedCommand,
+          rawOutput,
+          outcome: { kind: 'blocked', stderr: stderr.trim().slice(0, 400) },
+        };
+      }
+
+      const rewriteCmd = extracted.command;
+      const isRewrite = rewriteCmd !== null && rewriteCmd !== testedCommand;
+      if (isRewrite) {
+        // execDiff is best-effort visualization; capture failures are
+        // forwarded as `kind: 'failed'` so the UI can warn instead of
+        // collapsing to "rtk chose pass-through".
+        const execDiff = await RtkService.captureExecDiff(testedCommand, rewriteCmd);
+        return {
+          ok: true,
+          testedCommand,
+          rawOutput,
+          outcome: { kind: 'rewritten', rewrittenCommand: rewriteCmd, execDiff },
+        };
+      }
+
+      return { ok: true, testedCommand, rawOutput, outcome: { kind: 'pass-through' } };
     } catch (err) {
       return { ok: false, testedCommand, error: err instanceof Error ? err.message : String(err) };
     }
@@ -824,7 +837,6 @@ function isObject(v: unknown): v is Record<string, unknown> {
 }
 
 function shellQuoteUnix(s: string): string {
-  // POSIX sh single-quote escape: close quote, inject escaped ', reopen.
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
 

--- a/src/main/services/RtkService.ts
+++ b/src/main/services/RtkService.ts
@@ -587,17 +587,17 @@ function extractRewrittenCommand(stdout: string): ExtractResult {
   // Claude Code's hook JSON schema has evolved; accept both historical and
   // current field names so version skew between rtk releases and Dash's
   // expectations doesn't silently render as "pass-through".
-  const paths: Array<(v: Record<string, unknown>) => unknown> = [
-    (v) => (isObject(v.hookSpecificOutput) ? v.hookSpecificOutput.updatedInput : undefined),
-    (v) => (isObject(v.hookSpecificOutput) ? v.hookSpecificOutput.modifiedToolInput : undefined),
-    (v) => (isObject(v.hookSpecificOutput) ? v.hookSpecificOutput.updatedToolInput : undefined),
-    (v) => v.updatedInput,
-    (v) => v.modifiedToolInput,
-    (v) => v.updatedToolInput,
-    (v) => v.tool_input,
+  const hso = isObject(parsed.hookSpecificOutput) ? parsed.hookSpecificOutput : null;
+  const candidates: unknown[] = [
+    hso?.updatedInput,
+    hso?.modifiedToolInput,
+    hso?.updatedToolInput,
+    parsed.updatedInput,
+    parsed.modifiedToolInput,
+    parsed.updatedToolInput,
+    parsed.tool_input,
   ];
-  for (const get of paths) {
-    const node = get(parsed);
+  for (const node of candidates) {
     if (isObject(node) && typeof node.command === 'string') {
       return { ok: true, command: node.command };
     }

--- a/src/main/services/__tests__/hookSettingsMerge.test.ts
+++ b/src/main/services/__tests__/hookSettingsMerge.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type HookEntry,
+  entryIsDashOwned,
+  isDashOwnedHook,
+  mergeHookEntries,
+} from '../hookSettingsMerge';
+
+// ---------------------------------------------------------------------------
+// Settings-merge safety. The load-bearing promise of writeHookSettings is
+// "merge with existing settings to preserve user content" — these tests
+// guard the user-authored-hook-survival invariant. A regression here is a
+// silent data-loss bug (user's own hooks vanish without warning), so this
+// is one of the highest-value test surfaces in the project.
+//
+// The merge module is pure (no DB, no electron, no native deps), so we can
+// exercise it directly against the real exported function — no mocking, no
+// re-implementation drift.
+// ---------------------------------------------------------------------------
+
+const DASH_PORT_PREFIX = 'http://127.0.0.1:55123/hook/';
+
+const dashHttp = (endpoint: string): HookEntry => ({
+  matcher: '*',
+  hooks: [{ type: 'http', url: `${DASH_PORT_PREFIX}${endpoint}`, __dash: true }],
+});
+
+describe('isDashOwnedHook', () => {
+  it('recognises an explicitly tagged hook', () => {
+    expect(isDashOwnedHook({ type: 'http', url: 'x', __dash: true }, DASH_PORT_PREFIX)).toBe(true);
+  });
+
+  it('recognises an untagged hook by the Dash hookServer URL prefix (brand-loss fallback)', () => {
+    // Round-tripping through another tool can strip unknown fields. Without
+    // this fallback, every refresh would append a fresh tagged entry while
+    // the prior entry stayed unmatched — the file would accumulate duplicates.
+    expect(
+      isDashOwnedHook({ type: 'http', url: `${DASH_PORT_PREFIX}tool-start` }, DASH_PORT_PREFIX),
+    ).toBe(true);
+  });
+
+  it('does not match a user hook even if it points at localhost (different port)', () => {
+    expect(
+      isDashOwnedHook({ type: 'http', url: 'http://127.0.0.1:9999/something' }, DASH_PORT_PREFIX),
+    ).toBe(false);
+  });
+
+  it('treats command hooks without the tag as user-owned', () => {
+    expect(isDashOwnedHook({ type: 'command', command: 'echo hi' }, DASH_PORT_PREFIX)).toBe(false);
+  });
+
+  it('returns false for null/non-object values', () => {
+    expect(isDashOwnedHook(null, DASH_PORT_PREFIX)).toBe(false);
+    expect(isDashOwnedHook(undefined, DASH_PORT_PREFIX)).toBe(false);
+    expect(isDashOwnedHook('string', DASH_PORT_PREFIX)).toBe(false);
+  });
+
+  it('falls back to brand-only matching when the hookServer port is unbound (null prefix)', () => {
+    // At startup the hookServer hasn't bound yet, so the prefix is null.
+    // Brand match must still work; URL-fallback is silently disabled.
+    expect(isDashOwnedHook({ type: 'http', url: 'x', __dash: true }, null)).toBe(true);
+    expect(isDashOwnedHook({ type: 'http', url: `${DASH_PORT_PREFIX}foo` }, null)).toBe(false);
+  });
+});
+
+describe('entryIsDashOwned', () => {
+  it('returns true if any hook in the entry is Dash-owned', () => {
+    const mixed: HookEntry = {
+      matcher: '*',
+      hooks: [
+        { type: 'command', command: 'user-thing' },
+        { type: 'http', url: 'x', __dash: true },
+      ],
+    };
+    // Conservative: entries with a mix get treated as ours. Users shouldn't
+    // splice their hooks into a Dash-owned entry; if they do, we'd rather
+    // remove the whole entry on cleanup than leave a mystery tagged hook.
+    expect(entryIsDashOwned(mixed, DASH_PORT_PREFIX)).toBe(true);
+  });
+
+  it('returns false for an entry containing only user hooks', () => {
+    const userOnly: HookEntry = {
+      matcher: '*',
+      hooks: [{ type: 'command', command: 'echo hi' }],
+    };
+    expect(entryIsDashOwned(userOnly, DASH_PORT_PREFIX)).toBe(false);
+  });
+
+  it('returns false for malformed entries (no hooks array)', () => {
+    expect(entryIsDashOwned({ matcher: '*' }, DASH_PORT_PREFIX)).toBe(false);
+    expect(entryIsDashOwned(null, DASH_PORT_PREFIX)).toBe(false);
+  });
+});
+
+describe('mergeHookEntries — user content preservation', () => {
+  it('preserves a user-authored hook on a Dash-managed event (PreToolUse)', () => {
+    const userHook: HookEntry = {
+      matcher: 'Bash',
+      hooks: [{ type: 'command', command: 'echo from-user' }],
+    };
+    const existing = { PreToolUse: [userHook] };
+    const dash = { PreToolUse: [dashHttp('tool-start')] };
+
+    const merged = mergeHookEntries(existing, dash, DASH_PORT_PREFIX);
+
+    expect(merged.PreToolUse).toHaveLength(2);
+    // User entry must survive verbatim (deep equality).
+    expect(merged.PreToolUse[0]).toEqual(userHook);
+    // Dash entry appended after.
+    expect(merged.PreToolUse[1].hooks[0]).toMatchObject({ __dash: true });
+  });
+
+  it('drops Dash-owned entries from existing so refreshes don’t accumulate duplicates', () => {
+    // Simulate a refresh: prior write left a tagged Dash entry; the next
+    // write must replace it, not add a sibling.
+    const stale: HookEntry = {
+      matcher: '*',
+      hooks: [{ type: 'http', url: `${DASH_PORT_PREFIX}tool-start`, __dash: true }],
+    };
+    const existing = { PreToolUse: [stale] };
+    const dash = { PreToolUse: [dashHttp('tool-start')] };
+
+    const merged = mergeHookEntries(existing, dash, DASH_PORT_PREFIX);
+
+    expect(merged.PreToolUse).toHaveLength(1);
+  });
+
+  it('drops Dash-owned entries even when the brand was lost in round-trip (URL fallback)', () => {
+    // Same as above but `__dash` was stripped — the URL fallback in
+    // isDashOwnedHook is what stops duplicate accumulation here.
+    const orphan: HookEntry = {
+      matcher: '*',
+      hooks: [{ type: 'http', url: `${DASH_PORT_PREFIX}tool-start` }],
+    };
+    const existing = { PreToolUse: [orphan] };
+    const dash = { PreToolUse: [dashHttp('tool-start')] };
+
+    const merged = mergeHookEntries(existing, dash, DASH_PORT_PREFIX);
+
+    expect(merged.PreToolUse).toHaveLength(1);
+  });
+
+  it('passes user hooks on non-Dash events through unchanged', () => {
+    // PreCompact is a Dash-managed event; CustomEvent is not.
+    const customEvent: HookEntry = {
+      matcher: '*',
+      hooks: [{ type: 'command', command: 'user-script' }],
+    };
+    const existing = { CustomEvent: [customEvent] };
+    const dash = { PreCompact: [dashHttp('compact-start')] };
+
+    const merged = mergeHookEntries(existing, dash, DASH_PORT_PREFIX);
+
+    // Non-Dash event must NOT be filtered (Dash doesn't claim ownership of
+    // events it doesn't write to).
+    expect(merged.CustomEvent).toEqual([customEvent]);
+    expect(merged.PreCompact).toHaveLength(1);
+  });
+
+  it('preserves a user hook on a Dash-managed event when no Dash entry replaces it', () => {
+    // A user might author a Notification hook even though Dash also manages
+    // Notification. The merge produces the user's entry kept, plus whatever
+    // Dash adds — never an empty array that loses the user's hook.
+    const userHook: HookEntry = {
+      matcher: 'idle_prompt',
+      hooks: [{ type: 'command', command: 'osascript -e display dialog "hi"' }],
+    };
+    const existing = { Notification: [userHook] };
+    const dash = {}; // pretend we didn't write Notification this round
+
+    const merged = mergeHookEntries(existing, dash, DASH_PORT_PREFIX);
+
+    expect(merged.Notification).toEqual([userHook]);
+  });
+
+  it('skips entries whose value is not an array (defensive against hand-edited json)', () => {
+    // The raw json read can be `"hooks": { "PreToolUse": "garbage" }`. The
+    // merge must not throw or coerce — it should just skip and continue.
+    const existing = { PreToolUse: 'not-an-array' as unknown as HookEntry[] };
+    const dash = { PreToolUse: [dashHttp('tool-start')] };
+
+    const merged = mergeHookEntries(existing, dash, DASH_PORT_PREFIX);
+
+    expect(merged.PreToolUse).toHaveLength(1);
+    expect(merged.PreToolUse[0].hooks[0]).toMatchObject({ __dash: true });
+  });
+
+  it('handles a fully empty existing object', () => {
+    const merged = mergeHookEntries({}, { PreToolUse: [dashHttp('tool-start')] }, DASH_PORT_PREFIX);
+    expect(Object.keys(merged)).toEqual(['PreToolUse']);
+  });
+
+  it('preserves multiple sibling user hooks across managed events', () => {
+    const userBash: HookEntry = {
+      matcher: 'Bash',
+      hooks: [{ type: 'command', command: 'log-bash' }],
+    };
+    const userPost: HookEntry = {
+      matcher: 'Read',
+      hooks: [{ type: 'command', command: 'log-read' }],
+    };
+    const existing = {
+      PreToolUse: [userBash],
+      PostToolUse: [userPost],
+    };
+    const dash = {
+      PreToolUse: [dashHttp('tool-start')],
+      PostToolUse: [dashHttp('tool-end')],
+    };
+
+    const merged = mergeHookEntries(existing, dash, DASH_PORT_PREFIX);
+
+    expect(merged.PreToolUse).toContainEqual(userBash);
+    expect(merged.PostToolUse).toContainEqual(userPost);
+    expect(merged.PreToolUse).toHaveLength(2);
+    expect(merged.PostToolUse).toHaveLength(2);
+  });
+});

--- a/src/main/services/__tests__/rtk-integration.test.ts
+++ b/src/main/services/__tests__/rtk-integration.test.ts
@@ -1,15 +1,6 @@
-/**
- * End-to-end integration tests for the RTK PreToolUse hook.
- *
- * These tests confirm two separate things:
- *   A) rtk itself compresses commands (hook-only test, no API key).
- *   B) Dash's full integration works end-to-end — the injected hook fires
- *      during a real `claude -p` session and rtk emits its rewrite directive
- *      (e2e test, costs API tokens, gated on ANTHROPIC_API_KEY).
- *
- * Each describe block auto-skips if its prerequisites are missing, so
- * `pnpm test` is safe to run anywhere.
- */
+// Two suites: (A) rtk's hook output alone (no API); (B) full Dash+Claude e2e
+// (gated on ANTHROPIC_API_KEY). Auto-skips when prerequisites are missing so
+// `pnpm test` is safe to run anywhere.
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { execFile, execSync, spawn } from 'node:child_process';
@@ -21,12 +12,7 @@ import { join } from 'node:path';
 
 const execFileAsync = promisify(execFile);
 
-/**
- * Mirror Dash's runtime resolution: prefer the managed binary inside
- * Electron's userData dir (same path RtkService uses), fall back to $PATH.
- * Without this the test skips on machines where rtk was installed via
- * Dash's UI (which never touches $PATH).
- */
+/** Prefer Dash's managed binary (where the UI installs it) over $PATH. */
 function dashManagedRtkPath(): string | null {
   const exe = process.platform === 'win32' ? 'rtk.exe' : 'rtk';
   const candidates =
@@ -76,6 +62,18 @@ async function fileExists(p: string): Promise<boolean> {
   }
 }
 
+/** Pull the rewritten Bash command out of rtk's JSON advice. */
+function extractCommand(rtkStdout: string): string {
+  const parsed = JSON.parse(rtkStdout) as {
+    hookSpecificOutput?: { updatedInput?: { command?: string } };
+  };
+  const cmd = parsed.hookSpecificOutput?.updatedInput?.command;
+  if (typeof cmd !== 'string') {
+    throw new Error(`rtk output missing hookSpecificOutput.updatedInput.command: ${rtkStdout}`);
+  }
+  return cmd;
+}
+
 /** Run a binary with stdin piped in; resolve with exit code, stdout, stderr. */
 function runWithStdin(
   cmd: string,
@@ -123,13 +121,17 @@ describe.runIf(!!resolvedRtkPath)('rtk hook output (no API)', () => {
     const { code, stdout, stderr } = await runWithStdin(rtkPath, ['hook', 'claude'], input);
 
     expect(stderr).not.toMatch(/panic|unwrap|segfault/i);
-    expect(code === 0 || code === 2).toBe(true); // 0=allow(+modify), 2=block; never a crash
+    expect(code).toBe(0); // 0 = allow (with modification); a rewrite must not block.
     expect(stdout.trim().length).toBeGreaterThan(0);
 
-    // The rewrite directive must reference rtk so the follow-up Bash tool call
-    // actually invokes the compression pipeline instead of raw ls.
-    const parsed = JSON.parse(stdout) as unknown;
-    expect(JSON.stringify(parsed)).toMatch(/\brtk\b/);
+    // Assert on the exact field carrying the rewritten command — a broad
+    // /rtk/ match would also hit field names and thus pass under schema drift.
+    const parsed = JSON.parse(stdout) as {
+      hookSpecificOutput?: { updatedInput?: { command?: string } };
+    };
+    const rewritten = parsed.hookSpecificOutput?.updatedInput?.command;
+    expect(typeof rewritten).toBe('string');
+    expect(rewritten).toMatch(/\brtk\b/);
   });
 
   it('returns cleanly on a command rtk does not rewrite (echo)', async () => {
@@ -173,10 +175,9 @@ describe.runIf(canRunE2E)('RTK end-to-end with Claude Code', () => {
     const claudeDir = join(cwd, '.claude');
     await mkdir(claudeDir, { recursive: true });
 
-    // Wrap the hook with tee on both sides so we can verify rtk actually
-    // processed Claude's tool-use payload. The shape of `hooks[0].hooks[0]`
-    // still matches buildPreToolUseHooks() in ptyManager — only the
-    // `command` string differs (adding the tee wrappers).
+    // Wrap the hook with tee so we can capture stdin/stdout. The JSON shape
+    // matches what Dash writes at runtime — drift here means this test no
+    // longer represents production.
     const q = (s: string): string => (s.includes(' ') ? `"${s}"` : s);
     const hookCommand = `sh -c 'tee -a ${q(hookInLog)} | ${q(rtkPath)} hook claude | tee -a ${q(hookOutLog)}'`;
 
@@ -196,10 +197,17 @@ describe.runIf(canRunE2E)('RTK end-to-end with Claude Code', () => {
       `Then use the Bash tool again to run: echo done > "${marker}". ` +
       `Finally reply with the single word: done`;
 
+    // Pass only the env vars claude actually needs; don't leak the developer's
+    // full shell env (local RTK_* overrides, test-affecting vars, etc.) in.
+    const hermeticEnv: NodeJS.ProcessEnv = {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    };
     const { stdout } = await execFileAsync(
       claudePath,
       ['-p', prompt, '--dangerously-skip-permissions'],
-      { cwd, timeout: 180_000, env: process.env, maxBuffer: 4 * 1024 * 1024 },
+      { cwd, timeout: 180_000, env: hermeticEnv, maxBuffer: 4 * 1024 * 1024 },
     );
 
     // 1. The hook was invoked at least once — input log has content.
@@ -208,12 +216,13 @@ describe.runIf(canRunE2E)('RTK end-to-end with Claude Code', () => {
     expect(inLog).toMatch(/PreToolUse/);
     expect(inLog).toMatch(/"tool_name":\s*"Bash"/);
 
-    // 2. rtk wrote back a rewrite directive — output log references rtk,
-    //    proving it intended to compress the command.
+    // 2. rtk wrote back a rewrite directive — assert on the exact command
+    //    field, not a broad /rtk/ match that would also hit field names.
     expect(await fileExists(hookOutLog)).toBe(true);
     const outLog = await readFile(hookOutLog, 'utf-8');
     expect(outLog.trim().length).toBeGreaterThan(0);
-    expect(outLog).toMatch(/\brtk\b/);
+    const rewritten = extractCommand(outLog);
+    expect(rewritten).toMatch(/\brtk\b/);
 
     // 3. The second Bash tool call ran to completion after the hook.
     expect(await fileExists(marker)).toBe(true);

--- a/src/main/services/__tests__/rtk-integration.test.ts
+++ b/src/main/services/__tests__/rtk-integration.test.ts
@@ -1,0 +1,224 @@
+/**
+ * End-to-end integration tests for the RTK PreToolUse hook.
+ *
+ * These tests confirm two separate things:
+ *   A) rtk itself compresses commands (hook-only test, no API key).
+ *   B) Dash's full integration works end-to-end — the injected hook fires
+ *      during a real `claude -p` session and rtk emits its rewrite directive
+ *      (e2e test, costs API tokens, gated on ANTHROPIC_API_KEY).
+ *
+ * Each describe block auto-skips if its prerequisites are missing, so
+ * `pnpm test` is safe to run anywhere.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile, execSync, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, writeFile, mkdir, access, rm, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Mirror Dash's runtime resolution: prefer the managed binary inside
+ * Electron's userData dir (same path RtkService uses), fall back to $PATH.
+ * Without this the test skips on machines where rtk was installed via
+ * Dash's UI (which never touches $PATH).
+ */
+function dashManagedRtkPath(): string | null {
+  const exe = process.platform === 'win32' ? 'rtk.exe' : 'rtk';
+  const candidates =
+    process.platform === 'darwin'
+      ? [join(homedir(), 'Library', 'Application Support', 'Dash', 'bin', exe)]
+      : process.platform === 'linux'
+        ? [join(homedir(), '.config', 'Dash', 'bin', exe)]
+        : [join(homedir(), 'AppData', 'Roaming', 'Dash', 'bin', exe)];
+  return candidates.find(existsSync) ?? null;
+}
+
+function findRtk(): string | null {
+  const managed = dashManagedRtkPath();
+  if (managed) return managed;
+  try {
+    const finder = process.platform === 'win32' ? 'where' : 'which';
+    const out = execSync(`${finder} rtk`, { stdio: ['ignore', 'pipe', 'ignore'] }).toString();
+    return out.trim().split(/\r?\n/)[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+function onPath(bin: string): boolean {
+  try {
+    execSync(`${process.platform === 'win32' ? 'where' : 'which'} ${bin}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveOnPath(bin: string): Promise<string> {
+  const finder = process.platform === 'win32' ? 'where.exe' : 'which';
+  const { stdout } = await execFileAsync(finder, [bin]);
+  const first = stdout.trim().split(/\r?\n/)[0];
+  if (!first) throw new Error(`${bin} not found`);
+  return first;
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Run a binary with stdin piped in; resolve with exit code, stdout, stderr. */
+function runWithStdin(
+  cmd: string,
+  args: string[],
+  stdin: string,
+  timeoutMs = 10_000,
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(cmd, args, { timeout: timeoutMs });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (c: Buffer) => {
+      stdout += c.toString();
+    });
+    proc.stderr.on('data', (c: Buffer) => {
+      stderr += c.toString();
+    });
+    proc.on('error', reject);
+    proc.on('close', (code) => resolve({ code, stdout, stderr }));
+    proc.stdin.write(stdin);
+    proc.stdin.end();
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Suite A: rtk compression behaviour (no Claude API required)
+// ═══════════════════════════════════════════════════════════════════════
+
+const resolvedRtkPath = findRtk();
+
+describe.runIf(!!resolvedRtkPath)('rtk hook output (no API)', () => {
+  const rtkPath = resolvedRtkPath!;
+
+  it('rewrites a known-compressible command (git status) via `rtk hook claude`', async () => {
+    // rtk's PreToolUse hook reads Claude Code's tool-use JSON on stdin and
+    // writes an advice JSON on stdout. `git status` is rtk's headline example
+    // (~75% token reduction), so the advice must include a modified command
+    // that invokes rtk itself — that's how downstream compression is triggered.
+    const input = JSON.stringify({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'git status', description: 'status' },
+    });
+
+    const { code, stdout, stderr } = await runWithStdin(rtkPath, ['hook', 'claude'], input);
+
+    expect(stderr).not.toMatch(/panic|unwrap|segfault/i);
+    expect(code === 0 || code === 2).toBe(true); // 0=allow(+modify), 2=block; never a crash
+    expect(stdout.trim().length).toBeGreaterThan(0);
+
+    // The rewrite directive must reference rtk so the follow-up Bash tool call
+    // actually invokes the compression pipeline instead of raw ls.
+    const parsed = JSON.parse(stdout) as unknown;
+    expect(JSON.stringify(parsed)).toMatch(/\brtk\b/);
+  });
+
+  it('returns cleanly on a command rtk does not rewrite (echo)', async () => {
+    const input = JSON.stringify({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hi', description: 'echo' },
+    });
+    const { code, stderr } = await runWithStdin(rtkPath, ['hook', 'claude'], input);
+    expect(stderr).not.toMatch(/panic|unwrap|segfault/i);
+    // 0 = pass-through, 2 = block; anything else would indicate a crash.
+    expect([0, 2]).toContain(code);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Suite B: end-to-end with a real `claude -p` session
+// ═══════════════════════════════════════════════════════════════════════
+
+const canRunE2E = !!process.env.ANTHROPIC_API_KEY && !!resolvedRtkPath && onPath('claude');
+
+describe.runIf(canRunE2E)('RTK end-to-end with Claude Code', () => {
+  const rtkPath = resolvedRtkPath!;
+  let claudePath = '';
+  let cwd = '';
+  let hookOutLog = '';
+  let hookInLog = '';
+
+  beforeAll(async () => {
+    claudePath = await resolveOnPath('claude');
+    cwd = await mkdtemp(join(tmpdir(), 'dash-rtk-e2e-'));
+    hookInLog = join(cwd, 'hook-in.log');
+    hookOutLog = join(cwd, 'hook-out.log');
+  });
+
+  afterAll(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('hook fires, rtk emits a rewrite directive, and the Bash tool completes', async () => {
+    const claudeDir = join(cwd, '.claude');
+    await mkdir(claudeDir, { recursive: true });
+
+    // Wrap the hook with tee on both sides so we can verify rtk actually
+    // processed Claude's tool-use payload. The shape of `hooks[0].hooks[0]`
+    // still matches buildPreToolUseHooks() in ptyManager — only the
+    // `command` string differs (adding the tee wrappers).
+    const q = (s: string): string => (s.includes(' ') ? `"${s}"` : s);
+    const hookCommand = `sh -c 'tee -a ${q(hookInLog)} | ${q(rtkPath)} hook claude | tee -a ${q(hookOutLog)}'`;
+
+    const settings = {
+      hooks: {
+        PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: hookCommand }] }],
+      },
+    };
+    await writeFile(join(claudeDir, 'settings.local.json'), JSON.stringify(settings, null, 2));
+
+    // `ls -la` is on rtk's rewrite list per its README, so this forces
+    // compression rather than pass-through. The echo-to-marker confirms
+    // the Bash tool call actually completed after the hook ran.
+    const marker = join(cwd, 'marker.txt');
+    const prompt =
+      `Use the Bash tool to run: ls -la /tmp. ` +
+      `Then use the Bash tool again to run: echo done > "${marker}". ` +
+      `Finally reply with the single word: done`;
+
+    const { stdout } = await execFileAsync(
+      claudePath,
+      ['-p', prompt, '--dangerously-skip-permissions'],
+      { cwd, timeout: 180_000, env: process.env, maxBuffer: 4 * 1024 * 1024 },
+    );
+
+    // 1. The hook was invoked at least once — input log has content.
+    expect(await fileExists(hookInLog)).toBe(true);
+    const inLog = await readFile(hookInLog, 'utf-8');
+    expect(inLog).toMatch(/PreToolUse/);
+    expect(inLog).toMatch(/"tool_name":\s*"Bash"/);
+
+    // 2. rtk wrote back a rewrite directive — output log references rtk,
+    //    proving it intended to compress the command.
+    expect(await fileExists(hookOutLog)).toBe(true);
+    const outLog = await readFile(hookOutLog, 'utf-8');
+    expect(outLog.trim().length).toBeGreaterThan(0);
+    expect(outLog).toMatch(/\brtk\b/);
+
+    // 3. The second Bash tool call ran to completion after the hook.
+    expect(await fileExists(marker)).toBe(true);
+
+    // 4. The model finished its turn.
+    expect(stdout.toLowerCase()).toContain('done');
+  }, 240_000);
+});

--- a/src/main/services/__tests__/rtk-unit.test.ts
+++ b/src/main/services/__tests__/rtk-unit.test.ts
@@ -173,24 +173,6 @@ describe('shellQuoteUnix', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Settings-merge safety: user-authored hook entries must survive
-// write → cleanup round-trips. We build the same dash-tagged shapes the
-// ptyManager emits and exercise the filter logic directly.
-// ---------------------------------------------------------------------------
-
-type Hook = { type: string; __dash?: true } & Record<string, unknown>;
-type HookEntry = { matcher: string; hooks: Hook[] };
-
-function entryIsDashOwned(entry: unknown): boolean {
-  if (!entry || typeof entry !== 'object') return false;
-  const hooks = (entry as { hooks?: unknown }).hooks;
-  if (!Array.isArray(hooks)) return false;
-  return hooks.some(
-    (h) => !!h && typeof h === 'object' && (h as { __dash?: unknown }).__dash === true,
-  );
-}
-
 describe('extractRewrittenCommand', () => {
   it('returns a null command for empty stdout (rtk pass-through)', () => {
     const r = extractRewrittenCommand('');
@@ -220,38 +202,6 @@ describe('extractRewrittenCommand', () => {
   it('returns command:null when the JSON is valid but matches no known path', () => {
     const payload = JSON.stringify({ unknownField: { command: 'ignored' } });
     expect(extractRewrittenCommand(payload)).toEqual({ ok: true, command: null });
-  });
-});
-
-describe('settings.local.json merge safety (entryIsDashOwned)', () => {
-  it('recognises a tagged Dash entry', () => {
-    const entry: HookEntry = {
-      matcher: '*',
-      hooks: [{ type: 'http', url: 'x', __dash: true }],
-    };
-    expect(entryIsDashOwned(entry)).toBe(true);
-  });
-
-  it('ignores a user-authored entry without the tag', () => {
-    const entry: HookEntry = {
-      matcher: '*',
-      hooks: [{ type: 'command', command: 'echo hi' }],
-    };
-    expect(entryIsDashOwned(entry)).toBe(false);
-  });
-
-  it('considers entries with a mixed bag as Dash-owned (leaves conservative trail)', () => {
-    // If any hook is tagged, we treat the entry as ours; users shouldn't
-    // mix their hooks into a Dash entry, but if they do, cleanup erring on
-    // "remove" is safer than leaving a mystery tagged hook behind.
-    const entry: HookEntry = {
-      matcher: '*',
-      hooks: [
-        { type: 'command', command: 'user-thing' },
-        { type: 'http', url: 'x', __dash: true },
-      ],
-    };
-    expect(entryIsDashOwned(entry)).toBe(true);
   });
 });
 

--- a/src/main/services/__tests__/rtk-unit.test.ts
+++ b/src/main/services/__tests__/rtk-unit.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
 
 // RtkService imports `app` from electron for userData paths, which isn't
 // available in the vitest Node env. The helpers we test don't touch it.
@@ -13,8 +17,10 @@ import { __test__ } from '../RtkService';
 const {
   assertTrustedDownloadUrl,
   assertSafeArchiveMember,
+  parseTarVerbose,
   shellQuoteUnix,
   extractRewrittenCommand,
+  verifyChecksum,
 } = __test__;
 
 describe('assertTrustedDownloadUrl', () => {
@@ -63,31 +69,65 @@ describe('assertTrustedDownloadUrl', () => {
 
 describe('assertSafeArchiveMember', () => {
   const dest = process.platform === 'win32' ? 'C:\\tmp\\rtk-bin' : '/tmp/rtk-bin';
+  const file = (name: string) => ({ type: 'file' as const, name });
 
   it('accepts a plain file at archive root', () => {
-    expect(() => assertSafeArchiveMember('rtk', dest)).not.toThrow();
+    expect(() => assertSafeArchiveMember(file('rtk'), dest)).not.toThrow();
   });
 
   it('accepts nested-under-directory entries that stay inside dest', () => {
-    expect(() => assertSafeArchiveMember('nested/rtk', dest)).not.toThrow();
+    expect(() => assertSafeArchiveMember(file('nested/rtk'), dest)).not.toThrow();
+  });
+
+  it('accepts directories', () => {
+    expect(() => assertSafeArchiveMember({ type: 'dir', name: 'subdir/' }, dest)).not.toThrow();
+  });
+
+  it('rejects symlinks regardless of target — tar would honor the link at extract time', () => {
+    // A symlink whose name is benign (`./rtk`) but whose target points outside
+    // dest is the canonical defense-in-depth bypass: the entry-name validator
+    // sees nothing wrong, but `tar -xzf` writes through the link.
+    expect(() => assertSafeArchiveMember({ type: 'symlink', name: 'rtk' }, dest)).toThrow(
+      /symlink/,
+    );
+  });
+
+  it('rejects hardlinks for the same reason', () => {
+    expect(() => assertSafeArchiveMember({ type: 'hardlink', name: 'rtk' }, dest)).toThrow(
+      /hardlink/,
+    );
+  });
+
+  it('rejects unsupported member types (sockets, fifos, devices)', () => {
+    expect(() => assertSafeArchiveMember({ type: 'other', name: 'weird' }, dest)).toThrow(
+      /unsupported/,
+    );
+  });
+
+  it('rejects entries with embedded null bytes', () => {
+    // Some libcs truncate at \0; without this check a name like "rtk\0/etc/passwd"
+    // could pass the dest-prefix test then resolve elsewhere downstream.
+    expect(() => assertSafeArchiveMember(file('rtk\0../etc/passwd'), dest)).toThrow(/null byte/);
   });
 
   it('rejects absolute Unix paths', () => {
-    expect(() => assertSafeArchiveMember('/etc/passwd', dest)).toThrow(/absolute/);
+    expect(() => assertSafeArchiveMember(file('/etc/passwd'), dest)).toThrow(/absolute/);
   });
 
   it('rejects absolute Windows paths', () => {
-    expect(() => assertSafeArchiveMember('C:\\Windows\\System32\\evil.exe', dest)).toThrow(
+    expect(() => assertSafeArchiveMember(file('C:\\Windows\\System32\\evil.exe'), dest)).toThrow(
       /absolute/,
     );
   });
 
   it('rejects parent-traversal (..) that escapes dest', () => {
-    expect(() => assertSafeArchiveMember('../../etc/passwd', dest)).toThrow(/escapes/);
+    expect(() => assertSafeArchiveMember(file('../../etc/passwd'), dest)).toThrow(/escapes/);
   });
 
   it('rejects mixed traversal paths', () => {
-    expect(() => assertSafeArchiveMember('subdir/../../../etc/evil', dest)).toThrow(/escapes/);
+    expect(() => assertSafeArchiveMember(file('subdir/../../../etc/evil'), dest)).toThrow(
+      /escapes/,
+    );
   });
 
   it('rejects backslash-traversal (Windows-style) on any OS', () => {
@@ -95,7 +135,9 @@ describe('assertSafeArchiveMember', () => {
     // helper, POSIX pathResolve would treat the backslashes as literal
     // filename chars and this entry would land inside destDir as a file
     // literally named "..\\..\\etc\\passwd" — a security-sensitive false pass.
-    expect(() => assertSafeArchiveMember('..\\..\\etc\\passwd', dest)).toThrow(/escapes|absolute/);
+    expect(() => assertSafeArchiveMember(file('..\\..\\etc\\passwd'), dest)).toThrow(
+      /escapes|absolute/,
+    );
   });
 });
 
@@ -210,5 +252,105 @@ describe('settings.local.json merge safety (entryIsDashOwned)', () => {
       ],
     };
     expect(entryIsDashOwned(entry)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Archive integrity: SHA-256 verification is one of the load-bearing security
+// claims of the install flow ("Refusing to install" on mismatch). A regression
+// (e.g. truncated comparison, swapped operator) needs to fail this test, not
+// silently let a corrupt/swapped binary onto disk.
+// ---------------------------------------------------------------------------
+
+describe('verifyChecksum', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'rtk-unit-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeFixture(name: string, body: string): { path: string; sha: string } {
+    const p = join(dir, name);
+    writeFileSync(p, body);
+    const sha = createHash('sha256').update(body).digest('hex');
+    return { path: p, sha };
+  }
+
+  it('accepts a matching checksum', async () => {
+    const { path, sha } = writeFixture('ok.bin', 'rtk binary contents');
+    await expect(verifyChecksum(path, sha)).resolves.toBeUndefined();
+  });
+
+  it('rejects a one-character-off checksum (the canonical regression)', async () => {
+    // A truncated comparison (`actual.startsWith(expected.slice(0, 8))`) or a
+    // swapped operator (`===` → `!==`) would let this through. Mutating one
+    // hex char makes the assertion pinpoint the equality check itself.
+    const { path, sha } = writeFixture('mismatch.bin', 'rtk binary contents');
+    const tampered = sha.slice(0, -1) + (sha.endsWith('a') ? 'b' : 'a');
+    await expect(verifyChecksum(path, tampered)).rejects.toThrow(
+      /Checksum mismatch.*Refusing to install/,
+    );
+  });
+
+  it('rejects when the file content is mutated post-write', async () => {
+    // Computes sha against original bytes, then writes different bytes — the
+    // streaming hash should pick up the change.
+    const { path, sha } = writeFixture('orig.bin', 'original content');
+    writeFileSync(path, 'tampered content');
+    await expect(verifyChecksum(path, sha)).rejects.toThrow(/Checksum mismatch/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tar verbose-output parsing: type-char detection is the only thing standing
+// between a malicious symlink-bearing tarball and chmod-following the link
+// out of dest. Both BSD (macOS) and GNU tar prefix entries with the mode
+// string, so the first column is the file type ('-', 'd', 'l', 'h', ...).
+// ---------------------------------------------------------------------------
+
+describe('parseTarVerbose', () => {
+  it('parses BSD-style (macOS) verbose lines', () => {
+    const out = parseTarVerbose(
+      [
+        '-rwxr-xr-x  0 root  wheel  1234567 Jan  1 00:00 rtk',
+        'drwxr-xr-x  0 root  wheel        0 Jan  1 00:00 doc/',
+      ].join('\n'),
+    );
+    expect(out).toEqual([
+      { type: 'file', name: 'rtk' },
+      { type: 'dir', name: 'doc/' },
+    ]);
+  });
+
+  it('parses GNU-style verbose lines', () => {
+    const out = parseTarVerbose(
+      [
+        '-rwxr-xr-x user/group  1234567 2024-01-01 00:00 rtk',
+        'lrwxrwxrwx user/group        0 2024-01-01 00:00 evil -> /etc/passwd',
+      ].join('\n'),
+    );
+    expect(out).toEqual([
+      { type: 'file', name: 'rtk' },
+      { type: 'symlink', name: 'evil' },
+    ]);
+  });
+
+  it('strips " -> target" from symlink lines so name validation only sees the entry path', () => {
+    const out = parseTarVerbose('lrwxrwxrwx user 0 date evil -> /etc/passwd');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({ type: 'symlink', name: 'evil' });
+  });
+
+  it('classifies hardlinks as hardlink', () => {
+    const out = parseTarVerbose('hrw-r--r-- user 1234 date hardlink');
+    expect(out[0].type).toBe('hardlink');
+  });
+
+  it('falls back to "other" for unknown type chars', () => {
+    const out = parseTarVerbose('crw-r--r-- user 0 date weird-device');
+    expect(out[0].type).toBe('other');
   });
 });

--- a/src/main/services/__tests__/rtk-unit.test.ts
+++ b/src/main/services/__tests__/rtk-unit.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest';
+
+// These unit tests exercise the URL allowlist, archive-member safety checks,
+// and JSON-extraction helpers in RtkService. The helpers are module-private;
+// we re-implement them here by re-exporting them from the service when needed.
+// The goal is invariants — not integration — so no binary is required.
+
+import { resolve as pathResolve, sep } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Re-implementations that must stay in sync with RtkService's private helpers.
+// If either changes, these tests should fail loudly.
+// ---------------------------------------------------------------------------
+
+function assertTrustedDownloadUrl(raw: string): void {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`Refusing malformed asset URL: ${raw}`);
+  }
+  if (url.protocol !== 'https:') {
+    throw new Error(`Refusing non-HTTPS asset URL: ${raw}`);
+  }
+  const host = url.hostname.toLowerCase();
+  const allowed =
+    host === 'github.com' ||
+    host === 'api.github.com' ||
+    host === 'objects.githubusercontent.com' ||
+    host.endsWith('.githubusercontent.com');
+  if (!allowed) {
+    throw new Error(`Refusing asset URL outside GitHub: ${raw}`);
+  }
+}
+
+function assertSafeArchiveMember(entry: string, destDir: string): void {
+  if (entry.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(entry)) {
+    throw new Error(`Archive contains absolute path: ${entry}`);
+  }
+  const normalized = entry.replace(/\\/g, '/');
+  const resolved = pathResolve(destDir, normalized);
+  const base = pathResolve(destDir) + sep;
+  if (resolved !== pathResolve(destDir) && !resolved.startsWith(base)) {
+    throw new Error(`Archive member escapes destDir: ${entry}`);
+  }
+}
+
+function shellQuoteUnix(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+// ---------------------------------------------------------------------------
+
+describe('assertTrustedDownloadUrl', () => {
+  it('accepts canonical github.com release URLs', () => {
+    expect(() =>
+      assertTrustedDownloadUrl('https://github.com/rtk-ai/rtk/releases/download/v0.1.0/rtk.tar.gz'),
+    ).not.toThrow();
+  });
+
+  it('accepts objects.githubusercontent.com CDN redirects', () => {
+    expect(() =>
+      assertTrustedDownloadUrl(
+        'https://objects.githubusercontent.com/github-production-release-asset-2e65be/...',
+      ),
+    ).not.toThrow();
+  });
+
+  it('accepts any *.githubusercontent.com subdomain', () => {
+    expect(() =>
+      assertTrustedDownloadUrl('https://release-assets.githubusercontent.com/foo'),
+    ).not.toThrow();
+  });
+
+  it('rejects http:// downloads', () => {
+    expect(() =>
+      assertTrustedDownloadUrl('http://github.com/rtk-ai/rtk/releases/download/v0.1.0/rtk.tar.gz'),
+    ).toThrow(/non-HTTPS/);
+  });
+
+  it('rejects foreign hostnames', () => {
+    expect(() => assertTrustedDownloadUrl('https://evil.example.com/rtk.tar.gz')).toThrow(
+      /outside GitHub/,
+    );
+  });
+
+  it('rejects similar-looking hostnames that are not github', () => {
+    expect(() => assertTrustedDownloadUrl('https://github.com.evil.example/rtk.tar.gz')).toThrow(
+      /outside GitHub/,
+    );
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(() => assertTrustedDownloadUrl('not a url')).toThrow(/malformed/);
+  });
+});
+
+describe('assertSafeArchiveMember', () => {
+  const dest = process.platform === 'win32' ? 'C:\\tmp\\rtk-bin' : '/tmp/rtk-bin';
+
+  it('accepts a plain file at archive root', () => {
+    expect(() => assertSafeArchiveMember('rtk', dest)).not.toThrow();
+  });
+
+  it('accepts nested-under-directory entries that stay inside dest', () => {
+    expect(() => assertSafeArchiveMember('nested/rtk', dest)).not.toThrow();
+  });
+
+  it('rejects absolute Unix paths', () => {
+    expect(() => assertSafeArchiveMember('/etc/passwd', dest)).toThrow(/absolute/);
+  });
+
+  it('rejects absolute Windows paths', () => {
+    expect(() => assertSafeArchiveMember('C:\\Windows\\System32\\evil.exe', dest)).toThrow(
+      /absolute/,
+    );
+  });
+
+  it('rejects parent-traversal (..) that escapes dest', () => {
+    expect(() => assertSafeArchiveMember('../../etc/passwd', dest)).toThrow(/escapes/);
+  });
+
+  it('rejects mixed traversal paths', () => {
+    expect(() => assertSafeArchiveMember('subdir/../../../etc/evil', dest)).toThrow(/escapes/);
+  });
+});
+
+describe('shellQuoteUnix', () => {
+  it('quotes plain paths', () => {
+    expect(shellQuoteUnix('/usr/local/bin/rtk')).toBe("'/usr/local/bin/rtk'");
+  });
+
+  it('quotes paths containing spaces', () => {
+    expect(shellQuoteUnix('/Application Support/Dash/bin/rtk')).toBe(
+      "'/Application Support/Dash/bin/rtk'",
+    );
+  });
+
+  it('escapes embedded single quotes without leaving an injection hole', () => {
+    // The output must be a single concatenated shell token — decoding it
+    // should yield the exact input back.
+    const input = "/tmp/weird'dir/rtk";
+    const quoted = shellQuoteUnix(input);
+    expect(quoted).toBe("'/tmp/weird'\\''dir/rtk'");
+    // Sanity: the quoted form contains no unescaped bareword that could run.
+    expect(quoted).not.toMatch(/[^\\]\$\(/);
+    expect(quoted).not.toMatch(/[^\\]`/);
+  });
+
+  it('survives $, backtick, and backslash without expansion', () => {
+    const input = '/tmp/$(rm -rf ~)/`whoami`/rtk';
+    const quoted = shellQuoteUnix(input);
+    // With single quotes, none of these metachars get interpreted by sh.
+    expect(quoted.startsWith("'") && quoted.endsWith("'")).toBe(true);
+    expect(quoted).toContain('$(rm -rf ~)');
+    expect(quoted).toContain('`whoami`');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Settings-merge safety: user-authored hook entries must survive
+// write → cleanup round-trips. We build the same dash-tagged shapes the
+// ptyManager emits and exercise the filter logic directly.
+// ---------------------------------------------------------------------------
+
+type Hook = { type: string; __dash?: true } & Record<string, unknown>;
+type HookEntry = { matcher: string; hooks: Hook[] };
+
+function entryIsDashOwned(entry: unknown): boolean {
+  if (!entry || typeof entry !== 'object') return false;
+  const hooks = (entry as { hooks?: unknown }).hooks;
+  if (!Array.isArray(hooks)) return false;
+  return hooks.some(
+    (h) => !!h && typeof h === 'object' && (h as { __dash?: unknown }).__dash === true,
+  );
+}
+
+describe('settings.local.json merge safety (entryIsDashOwned)', () => {
+  it('recognises a tagged Dash entry', () => {
+    const entry: HookEntry = {
+      matcher: '*',
+      hooks: [{ type: 'http', url: 'x', __dash: true }],
+    };
+    expect(entryIsDashOwned(entry)).toBe(true);
+  });
+
+  it('ignores a user-authored entry without the tag', () => {
+    const entry: HookEntry = {
+      matcher: '*',
+      hooks: [{ type: 'command', command: 'echo hi' }],
+    };
+    expect(entryIsDashOwned(entry)).toBe(false);
+  });
+
+  it('considers entries with a mixed bag as Dash-owned (leaves conservative trail)', () => {
+    // If any hook is tagged, we treat the entry as ours; users shouldn't
+    // mix their hooks into a Dash entry, but if they do, cleanup erring on
+    // "remove" is safer than leaving a mystery tagged hook behind.
+    const entry: HookEntry = {
+      matcher: '*',
+      hooks: [
+        { type: 'command', command: 'user-thing' },
+        { type: 'http', url: 'x', __dash: true },
+      ],
+    };
+    expect(entryIsDashOwned(entry)).toBe(true);
+  });
+});

--- a/src/main/services/__tests__/rtk-unit.test.ts
+++ b/src/main/services/__tests__/rtk-unit.test.ts
@@ -1,55 +1,21 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// RtkService imports `app` from electron for userData paths, which isn't
+// available in the vitest Node env. The helpers we test don't touch it.
+vi.mock('electron', () => ({ default: {}, app: {} }));
+
+import { __test__ } from '../RtkService';
 
 // These unit tests exercise the URL allowlist, archive-member safety checks,
-// and JSON-extraction helpers in RtkService. The helpers are module-private;
-// we re-implement them here by re-exporting them from the service when needed.
-// The goal is invariants — not integration — so no binary is required.
+// and JSON-extraction helpers. Imported from RtkService's __test__ export so
+// the real module code is what's being verified — no re-implementation drift.
 
-import { resolve as pathResolve, sep } from 'node:path';
-
-// ---------------------------------------------------------------------------
-// Re-implementations that must stay in sync with RtkService's private helpers.
-// If either changes, these tests should fail loudly.
-// ---------------------------------------------------------------------------
-
-function assertTrustedDownloadUrl(raw: string): void {
-  let url: URL;
-  try {
-    url = new URL(raw);
-  } catch {
-    throw new Error(`Refusing malformed asset URL: ${raw}`);
-  }
-  if (url.protocol !== 'https:') {
-    throw new Error(`Refusing non-HTTPS asset URL: ${raw}`);
-  }
-  const host = url.hostname.toLowerCase();
-  const allowed =
-    host === 'github.com' ||
-    host === 'api.github.com' ||
-    host === 'objects.githubusercontent.com' ||
-    host.endsWith('.githubusercontent.com');
-  if (!allowed) {
-    throw new Error(`Refusing asset URL outside GitHub: ${raw}`);
-  }
-}
-
-function assertSafeArchiveMember(entry: string, destDir: string): void {
-  if (entry.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(entry)) {
-    throw new Error(`Archive contains absolute path: ${entry}`);
-  }
-  const normalized = entry.replace(/\\/g, '/');
-  const resolved = pathResolve(destDir, normalized);
-  const base = pathResolve(destDir) + sep;
-  if (resolved !== pathResolve(destDir) && !resolved.startsWith(base)) {
-    throw new Error(`Archive member escapes destDir: ${entry}`);
-  }
-}
-
-function shellQuoteUnix(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`;
-}
-
-// ---------------------------------------------------------------------------
+const {
+  assertTrustedDownloadUrl,
+  assertSafeArchiveMember,
+  shellQuoteUnix,
+  extractRewrittenCommand,
+} = __test__;
 
 describe('assertTrustedDownloadUrl', () => {
   it('accepts canonical github.com release URLs', () => {
@@ -123,6 +89,14 @@ describe('assertSafeArchiveMember', () => {
   it('rejects mixed traversal paths', () => {
     expect(() => assertSafeArchiveMember('subdir/../../../etc/evil', dest)).toThrow(/escapes/);
   });
+
+  it('rejects backslash-traversal (Windows-style) on any OS', () => {
+    // Regression guard: without normalize-to-forward-slashes in the real
+    // helper, POSIX pathResolve would treat the backslashes as literal
+    // filename chars and this entry would land inside destDir as a file
+    // literally named "..\\..\\etc\\passwd" — a security-sensitive false pass.
+    expect(() => assertSafeArchiveMember('..\\..\\etc\\passwd', dest)).toThrow(/escapes|absolute/);
+  });
 });
 
 describe('shellQuoteUnix', () => {
@@ -174,6 +148,38 @@ function entryIsDashOwned(entry: unknown): boolean {
     (h) => !!h && typeof h === 'object' && (h as { __dash?: unknown }).__dash === true,
   );
 }
+
+describe('extractRewrittenCommand', () => {
+  it('returns a null command for empty stdout (rtk pass-through)', () => {
+    const r = extractRewrittenCommand('');
+    expect(r).toEqual({ ok: true, command: null });
+  });
+
+  it('returns ok:false on unparseable JSON', () => {
+    const r = extractRewrittenCommand('<<not json>>');
+    expect(r.ok).toBe(false);
+  });
+
+  it('extracts from hookSpecificOutput.updatedInput.command (current schema)', () => {
+    const payload = JSON.stringify({
+      hookSpecificOutput: { updatedInput: { command: 'rtk-wrapped git status' } },
+    });
+    expect(extractRewrittenCommand(payload)).toEqual({
+      ok: true,
+      command: 'rtk-wrapped git status',
+    });
+  });
+
+  it('extracts from legacy modifiedToolInput at payload root', () => {
+    const payload = JSON.stringify({ modifiedToolInput: { command: 'legacy-shape' } });
+    expect(extractRewrittenCommand(payload)).toEqual({ ok: true, command: 'legacy-shape' });
+  });
+
+  it('returns command:null when the JSON is valid but matches no known path', () => {
+    const payload = JSON.stringify({ unknownField: { command: 'ignored' } });
+    expect(extractRewrittenCommand(payload)).toEqual({ ok: true, command: null });
+  });
+});
 
 describe('settings.local.json merge safety (entryIsDashOwned)', () => {
   it('recognises a tagged Dash entry', () => {

--- a/src/main/services/hookSettingsMerge.ts
+++ b/src/main/services/hookSettingsMerge.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure helpers for the settings.local.json merge — extracted so tests can
+ * exercise the user-content-preservation invariant without dragging in the
+ * full ptyManager dependency graph (DB, hookServer, native modules).
+ */
+
+export type HttpHook = { type: 'http'; url: string; async?: boolean };
+export type CommandHook = { type: 'command'; command: string };
+export type Hook = (HttpHook | CommandHook) & { __dash?: true };
+export type HookEntry = { matcher: string; hooks: Hook[] };
+
+/**
+ * All hook event names Dash writes to settings.local.json. Used to decide
+ * which existing entries are candidates for replacement vs. preservation.
+ */
+export const DASH_HOOK_EVENTS = [
+  'Stop',
+  'UserPromptSubmit',
+  'Notification',
+  'PreToolUse',
+  'PostToolUse',
+  'StopFailure',
+  'PreCompact',
+  'PostCompact',
+  'SessionStart',
+] as const;
+
+/**
+ * Recognise a Dash-authored hook entry. Primary signal is the explicit
+ * `__dash: true` brand. URL-prefix matching is a fallback for the rare case
+ * where a round-trip through another tool stripped the unknown field — without
+ * it, every refresh would append a duplicate of every Dash hook.
+ *
+ * `dashHookUrlPrefix` is injected (rather than read from the live hookServer
+ * port) so this module stays pure and easy to test.
+ */
+export function isDashOwnedHook(h: unknown, dashHookUrlPrefix: string | null): boolean {
+  if (!h || typeof h !== 'object') return false;
+  if ((h as { __dash?: unknown }).__dash === true) return true;
+  if (dashHookUrlPrefix) {
+    const url = (h as { url?: unknown }).url;
+    if (typeof url === 'string' && url.startsWith(dashHookUrlPrefix)) return true;
+  }
+  return false;
+}
+
+export function entryIsDashOwned(entry: unknown, dashHookUrlPrefix: string | null): boolean {
+  if (!entry || typeof entry !== 'object') return false;
+  const hooks = (entry as { hooks?: unknown }).hooks;
+  if (!Array.isArray(hooks)) return false;
+  return hooks.some((h) => isDashOwnedHook(h, dashHookUrlPrefix));
+}
+
+/**
+ * Merge existing hook entries with Dash-owned entries, preserving user-
+ * authored content verbatim:
+ * - For events Dash manages: drop Dash-owned entries (they get rewritten),
+ *   keep user-authored ones.
+ * - For events Dash doesn't touch: pass through unchanged.
+ * - Then append the fresh Dash entries.
+ */
+export function mergeHookEntries(
+  existing: Record<string, HookEntry[] | undefined>,
+  dash: Record<string, HookEntry[]>,
+  dashHookUrlPrefix: string | null,
+): Record<string, HookEntry[]> {
+  const merged: Record<string, HookEntry[]> = {};
+  const dashEventSet = new Set<string>(DASH_HOOK_EVENTS);
+  for (const [event, userEntries] of Object.entries(existing)) {
+    if (!Array.isArray(userEntries)) continue;
+    merged[event] = dashEventSet.has(event)
+      ? userEntries.filter((e) => !entryIsDashOwned(e, dashHookUrlPrefix))
+      : userEntries;
+  }
+  for (const [event, entries] of Object.entries(dash)) {
+    const preserved = merged[event] ?? [];
+    merged[event] = [...preserved, ...entries];
+  }
+  return merged;
+}

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -59,7 +59,15 @@ function hasAnySessionForCwd(cwd: string): boolean {
   }
 }
 
-type ForkResult = { kind: 'no-clear' } | { kind: 'forked'; newId: string } | { kind: 'clear-only' };
+type ForkResult =
+  | { kind: 'no-clear' }
+  | { kind: 'forked'; newId: string }
+  | { kind: 'clear-only' }
+  // Fork detected a /clear but couldn't produce a clean post-clear jsonl
+  // (write failed, or post-clear lines were corrupt). Caller MUST treat this
+  // as "skip resume" — falling back to the unforked jsonl would replay the
+  // pre-clear chat the user explicitly asked to forget.
+  | { kind: 'fork-failed'; error: string };
 
 const CLEAR_MARKER = '<command-name>/clear</command-name>';
 
@@ -75,6 +83,9 @@ const CLEAR_MARKER = '<command-name>/clear</command-name>';
  *   - 'clear-only' when /clear is the last interaction (caller should start
  *     a fresh session instead of resuming)
  *   - 'no-clear' when no /clear is present (caller should resume normally)
+ *   - 'fork-failed' when a /clear was found but we couldn't fork past it
+ *     (caller MUST skip resume — falling back to the original jsonl would
+ *     resurrect the pre-clear chat the user asked to forget)
  */
 function forkJsonlAtLastClear(cwd: string, sessionId: string): ForkResult {
   const projDir = findClaudeProjectDir(cwd);
@@ -100,7 +111,7 @@ function forkJsonlAtLastClear(cwd: string, sessionId: string): ForkResult {
         lastClearIdx = i;
       }
     } catch {
-      /* ignore unparseable line */
+      /* ignore unparseable line — best-effort scan for the marker */
     }
   }
   if (lastClearIdx < 0) return { kind: 'no-clear' };
@@ -123,11 +134,13 @@ function forkJsonlAtLastClear(cwd: string, sessionId: string): ForkResult {
   const newId = randomUUID();
   const rewritten: string[] = [];
   let parentReset = false;
+  let parseFailures = 0;
   for (let i = startIdx; i < lines.length; i++) {
     let obj: Record<string, unknown>;
     try {
       obj = JSON.parse(lines[i]);
     } catch {
+      parseFailures++;
       continue;
     }
     if ('sessionId' in obj) obj.sessionId = newId;
@@ -137,14 +150,36 @@ function forkJsonlAtLastClear(cwd: string, sessionId: string): ForkResult {
     }
     rewritten.push(JSON.stringify(obj));
   }
+  // Silently dropping corrupt lines from the rewritten transcript would mutate
+  // the user's history. Abort the fork — caller will skip resume and start
+  // fresh, which is safer than producing a quietly-edited transcript.
+  if (parseFailures > 0) {
+    console.error(
+      `[forkJsonlAtLastClear] ${parseFailures} unparseable post-clear line(s); aborting fork`,
+    );
+    return {
+      kind: 'fork-failed',
+      error: `${parseFailures} unparseable jsonl line(s) after /clear`,
+    };
+  }
   if (rewritten.length === 0) return { kind: 'clear-only' };
 
   const newPath = path.join(projDir, `${newId}.jsonl`);
   try {
-    fs.writeFileSync(newPath, rewritten.join('\n') + '\n');
+    // Atomic write: tmp + rename so a crash mid-write can't leave a half-
+    // forked jsonl behind that a future resume would happily load.
+    const tmpPath = `${newPath}.tmp-${process.pid}`;
+    fs.writeFileSync(tmpPath, rewritten.join('\n') + '\n');
+    fs.renameSync(tmpPath, newPath);
   } catch (err) {
     console.error('[forkJsonlAtLastClear] write failed:', err);
-    return { kind: 'no-clear' };
+    // Critical: do NOT fall back to 'no-clear'. The caller resuming the
+    // original jsonl would replay the user's pre-clear chat — a privacy
+    // regression. Surface the failure so the caller skips resume entirely.
+    return {
+      kind: 'fork-failed',
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
   return { kind: 'forked', newId };
 }
@@ -189,6 +224,12 @@ export function setCommitAttribution(value: string | undefined): void {
   const { failures } = refreshActivePtyHooks();
   if (failures.length > 0) {
     console.warn(`[setCommitAttribution] hook write failed for ${failures.length} active task(s)`);
+    // The IPC handler is fire-and-forget (`ipcMain.on`), so the renderer
+    // never sees the return value. Surface partial failures via toast so
+    // commits from those tasks don't silently use the old attribution.
+    broadcastToast(
+      `Commit attribution updated, but ${failures.length} active task${failures.length === 1 ? '' : 's'} couldn't pick it up — restart them to apply.`,
+    );
   }
 }
 
@@ -639,7 +680,7 @@ function writeHookSettings(cwd: string, ptyId: string): HookWriteResult {
       commitAttributionSetting === undefined ? DASH_DEFAULT_ATTRIBUTION : commitAttributionSetting;
     merged.attribution = { commit: effectiveAttribution };
 
-    fs.writeFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
+    atomicWriteFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
     writtenSettingsPaths.add(settingsPath);
     return { ok: true };
   } catch (err) {
@@ -654,13 +695,43 @@ function writeHookSettings(cwd: string, ptyId: string): HookWriteResult {
   }
 }
 
+/**
+ * Atomic write: stage to a sibling tmp file then rename over the target.
+ * POSIX rename is atomic, so a crash mid-write can never leave a half-written
+ * file at `target`. Important here because settings.local.json is rewritten
+ * frequently (every PTY spawn, every RTK toggle, every commit-attribution
+ * change) — without atomicity the corrupt-recovery path on the read side has
+ * to handle a wider class of partial-write failures than just user edits.
+ */
+function atomicWriteFileSync(target: string, data: string): void {
+  const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmp, data);
+  fs.renameSync(tmp, target);
+}
+
 function entryIsDashOwned(entry: unknown): boolean {
   if (!entry || typeof entry !== 'object') return false;
   const hooks = (entry as { hooks?: unknown }).hooks;
   if (!Array.isArray(hooks)) return false;
-  return hooks.some(
-    (h) => !!h && typeof h === 'object' && (h as { __dash?: unknown }).__dash === true,
-  );
+  return hooks.some((h) => isDashOwnedHook(h));
+}
+
+function isDashOwnedHook(h: unknown): boolean {
+  if (!h || typeof h !== 'object') return false;
+  // Primary: the explicit __dash brand we wrote.
+  if ((h as { __dash?: unknown }).__dash === true) return true;
+  // Fallback: if the brand was lost in a round-trip (Claude Code or a tool
+  // re-serialising the file may strip unknown fields), recognise hooks
+  // pointing at our HookServer's loopback URL by URL prefix. Without this
+  // fallback, every refresh would append a fresh tagged entry and the file
+  // would accumulate duplicate Dash hooks indefinitely.
+  const port = hookServer.port;
+  if (port > 0) {
+    const dashUrlPrefix = `http://127.0.0.1:${port}/hook/`;
+    const url = (h as { url?: unknown }).url;
+    if (typeof url === 'string' && url.startsWith(dashUrlPrefix)) return true;
+  }
+  return false;
 }
 
 function broadcastToast(message: string): void {
@@ -702,7 +773,7 @@ export function cleanupHookSettings(): void {
       if (Object.keys(raw).length === 0) {
         fs.unlinkSync(settingsPath);
       } else {
-        fs.writeFileSync(settingsPath, JSON.stringify(raw, null, 2) + '\n');
+        atomicWriteFileSync(settingsPath, JSON.stringify(raw, null, 2) + '\n');
       }
     } catch (err) {
       console.error(`[cleanupHookSettings] Failed for ${settingsPath}:`, err);
@@ -763,6 +834,7 @@ export async function startDirectPty(options: {
   // entirely if /clear was the last interaction). Otherwise `claude -r` would
   // reload pre-clear messages.
   let skipResume = false;
+  let forkFailedTaskName: string | null = null;
   const candidateIds = [resumeId, options.id].filter((id, i, arr) => id && arr.indexOf(id) === i);
   for (const id of candidateIds) {
     if (!hasSessionForId(options.cwd, id)) continue;
@@ -774,8 +846,17 @@ export async function startDirectPty(options: {
       } catch (err) {
         console.error('[spawnDirectClaude] persist forked session id failed:', err);
       }
-    } else if (fork.kind === 'clear-only') {
+    } else if (fork.kind === 'clear-only' || fork.kind === 'fork-failed') {
+      // Both states force a fresh session: 'clear-only' because there's
+      // nothing post-clear to resume, 'fork-failed' because resuming the
+      // original jsonl would resurrect the user's pre-clear chat.
       skipResume = true;
+      if (fork.kind === 'fork-failed') {
+        forkFailedTaskName = task?.name ?? options.id;
+        console.error(
+          `[spawnDirectClaude] fork past /clear failed for ${options.id}: ${fork.error}; starting fresh`,
+        );
+      }
     }
     break;
   }
@@ -810,6 +891,14 @@ export async function startDirectPty(options: {
         DatabaseService.setTaskLastSessionId(options.id, newSessionId);
       } catch (err) {
         console.error('[spawnDirectClaude] persist post-clear session id failed:', err);
+      }
+      if (forkFailedTaskName) {
+        // Privacy-relevant: the previous jsonl was kept on disk but we refuse
+        // to resume it. Tell the user so they're not surprised by the fresh
+        // session and can recover via /resume if needed.
+        broadcastToast(
+          `Couldn't fork past /clear for "${forkFailedTaskName}" — starting fresh. Previous chat is still on disk; use /resume to find it.`,
+        );
       }
     } else if (hadPriorUse && task) {
       // Task had prior use (snapshot or captured session id) but we couldn't

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -493,25 +493,17 @@ function writeHookSettings(cwd: string, ptyId: string): HookWriteResult {
             `[writeHookSettings] settings.local.json corrupt at ${settingsPath}; backed up to ${backupPath}`,
             err,
           );
-          for (const win of BrowserWindow.getAllWindows()) {
-            if (!win.isDestroyed()) {
-              win.webContents.send('app:toast', {
-                message: `settings.local.json was unreadable — backed up to ${path.basename(backupPath)} and rewritten.`,
-              });
-            }
-          }
+          broadcastToast(
+            `settings.local.json was unreadable — backed up to ${path.basename(backupPath)} and rewritten.`,
+          );
         } catch (renameErr) {
           console.error(
             '[writeHookSettings] Failed to back up corrupt file; leaving on-disk file intact:',
             renameErr,
           );
-          for (const win of BrowserWindow.getAllWindows()) {
-            if (!win.isDestroyed()) {
-              win.webContents.send('app:toast', {
-                message: `settings.local.json is corrupt and could not be backed up — hooks are off for this task. Fix or remove ${path.basename(settingsPath)} manually.`,
-              });
-            }
-          }
+          broadcastToast(
+            `settings.local.json is corrupt and could not be backed up — hooks are off for this task. Fix or remove ${path.basename(settingsPath)} manually.`,
+          );
           return {
             ok: false,
             settingsPath,
@@ -562,13 +554,7 @@ function writeHookSettings(cwd: string, ptyId: string): HookWriteResult {
   } catch (err) {
     console.error('[writeHookSettings] Failed:', err);
     // Without settings, all Dash-owned hooks silently don't run — notify the user.
-    for (const win of BrowserWindow.getAllWindows()) {
-      if (!win.isDestroyed()) {
-        win.webContents.send('app:toast', {
-          message: `Could not write ${path.basename(settingsPath)} — hooks are off for this task.`,
-        });
-      }
-    }
+    broadcastToast(`Could not write ${path.basename(settingsPath)} — hooks are off for this task.`);
     return {
       ok: false,
       settingsPath,
@@ -584,6 +570,14 @@ function entryIsDashOwned(entry: unknown): boolean {
   return hooks.some(
     (h) => !!h && typeof h === 'object' && (h as { __dash?: unknown }).__dash === true,
   );
+}
+
+function broadcastToast(message: string): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send('app:toast', { message });
+    }
+  }
 }
 
 /**

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -363,12 +363,11 @@ function prependUnique(dir: string, basePath: string, sep: string): string {
 }
 
 /**
- * Write .claude/settings.local.json with hooks for activity monitoring,
- * tool tracking, error detection, and context usage.
- *
- * Hooks use type: "http" — Claude Code POSTs the hook JSON body directly
- * to our local HookServer. The statusLine uses type: "command" with curl
- * (http type is not supported for statusLine).
+ * Write .claude/settings.local.json with Dash-owned hooks for activity
+ * monitoring, tool tracking, error detection, context usage, and optional
+ * RTK rewrite. Uses type: "http" where supported (Claude POSTs directly to
+ * HookServer); statusLine and hooks that need local binaries (RTK, base64
+ * context injection) use type: "command".
  */
 function writeHookSettings(cwd: string, ptyId: string): void {
   const port = hookServer.port;
@@ -449,9 +448,18 @@ function writeHookSettings(cwd: string, ptyId: string): void {
     let existing: Record<string, unknown> = {};
     if (fs.existsSync(settingsPath)) {
       try {
-        existing = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+        const parsed = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) as unknown;
+        // JSON.parse succeeds on "null", "42", "[]", etc. Only plain objects
+        // can be spread and merged safely; anything else is treated as corrupt.
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          existing = parsed as Record<string, unknown>;
+        } else {
+          throw new Error(`settings.local.json is not a JSON object (got ${typeof parsed})`);
+        }
       } catch (err) {
         // Back up the corrupt file before overwriting so the user can recover.
+        // If the backup rename fails, we MUST NOT proceed to overwrite — that
+        // would destroy the user's on-disk file with no copy left.
         const backupPath = `${settingsPath}.corrupt-${Date.now()}.bak`;
         try {
           fs.renameSync(settingsPath, backupPath);
@@ -467,7 +475,18 @@ function writeHookSettings(cwd: string, ptyId: string): void {
             }
           }
         } catch (renameErr) {
-          console.error('[writeHookSettings] Failed to back up corrupt file:', renameErr);
+          console.error(
+            '[writeHookSettings] Failed to back up corrupt file; leaving on-disk file intact:',
+            renameErr,
+          );
+          for (const win of BrowserWindow.getAllWindows()) {
+            if (!win.isDestroyed()) {
+              win.webContents.send('app:toast', {
+                message: `settings.local.json is corrupt and could not be backed up — hooks are off for this task. Fix or remove ${path.basename(settingsPath)} manually.`,
+              });
+            }
+          }
+          return;
         }
       }
     }
@@ -511,8 +530,7 @@ function writeHookSettings(cwd: string, ptyId: string): void {
     writtenSettingsPaths.add(settingsPath);
   } catch (err) {
     console.error('[writeHookSettings] Failed:', err);
-    // If hooks aren't written, Dash's activity monitor, context metering, and
-    // the RTK rewriter are all silently absent — notify the user.
+    // Without settings, all Dash-owned hooks silently don't run — notify the user.
     for (const win of BrowserWindow.getAllWindows()) {
       if (!win.isDestroyed()) {
         win.webContents.send('app:toast', {

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -95,14 +95,36 @@ const RESERVED_ENV_KEYS = new Set([
 
 export function setCommitAttribution(value: string | undefined): void {
   commitAttributionSetting = value;
-  refreshActivePtyHooks();
+  const { failures } = refreshActivePtyHooks();
+  if (failures.length > 0) {
+    console.warn(`[setCommitAttribution] hook write failed for ${failures.length} active task(s)`);
+  }
 }
 
-/** Claude Code re-reads settings.local.json per tool call, so rewriting it flips hooks live. */
-export function refreshActivePtyHooks(): void {
+export interface RefreshFailure {
+  settingsPath: string;
+  error: string;
+}
+
+export interface RefreshResult {
+  failures: RefreshFailure[];
+}
+
+/**
+ * Rewrite settings.local.json for every active PTY. Claude Code re-reads
+ * settings per tool call, so this flips hooks live. Returns per-task write
+ * failures so callers (IPC handlers) can surface a "saved, but N tasks
+ * didn't pick it up" message instead of silently returning success.
+ */
+export function refreshActivePtyHooks(): RefreshResult {
+  const failures: RefreshFailure[] = [];
   for (const [id, rec] of ptys) {
-    writeHookSettings(rec.cwd, id);
+    const result = writeHookSettings(rec.cwd, id);
+    if (!result.ok) {
+      failures.push({ settingsPath: result.settingsPath, error: result.error });
+    }
   }
+  return { failures };
 }
 
 export function setDesktopNotification(opts: { enabled: boolean }): void {
@@ -362,6 +384,8 @@ function prependUnique(dir: string, basePath: string, sep: string): string {
   return `${dir}${sep}${basePath}`;
 }
 
+type HookWriteResult = { ok: true } | { ok: false; settingsPath: string; error: string };
+
 /**
  * Write .claude/settings.local.json with Dash-owned hooks for activity
  * monitoring, tool tracking, error detection, context usage, and optional
@@ -369,9 +393,11 @@ function prependUnique(dir: string, basePath: string, sep: string): string {
  * HookServer); statusLine and hooks that need local binaries (RTK, base64
  * context injection) use type: "command".
  */
-function writeHookSettings(cwd: string, ptyId: string): void {
+function writeHookSettings(cwd: string, ptyId: string): HookWriteResult {
   const port = hookServer.port;
-  if (port === 0) return;
+  // Hook server not yet bound (startup transient) — treat as a no-op, not a
+  // failure. Callers that later refresh will succeed once the server is up.
+  if (port === 0) return { ok: true };
 
   const claudeDir = path.join(cwd, '.claude');
   const settingsPath = path.join(claudeDir, 'settings.local.json');
@@ -486,7 +512,11 @@ function writeHookSettings(cwd: string, ptyId: string): void {
               });
             }
           }
-          return;
+          return {
+            ok: false,
+            settingsPath,
+            error: `corrupt settings.local.json; backup rename failed: ${renameErr instanceof Error ? renameErr.message : String(renameErr)}`,
+          };
         }
       }
     }
@@ -528,6 +558,7 @@ function writeHookSettings(cwd: string, ptyId: string): void {
 
     fs.writeFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
     writtenSettingsPaths.add(settingsPath);
+    return { ok: true };
   } catch (err) {
     console.error('[writeHookSettings] Failed:', err);
     // Without settings, all Dash-owned hooks silently don't run — notify the user.
@@ -538,6 +569,11 @@ function writeHookSettings(cwd: string, ptyId: string): void {
         });
       }
     }
+    return {
+      ok: false,
+      settingsPath,
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
 }
 

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -1,6 +1,7 @@
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
+import { randomUUID } from 'crypto';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { type WebContents, app, BrowserWindow } from 'electron';
@@ -56,6 +57,96 @@ function hasAnySessionForCwd(cwd: string): boolean {
   } catch {
     return false;
   }
+}
+
+type ForkResult = { kind: 'no-clear' } | { kind: 'forked'; newId: string } | { kind: 'clear-only' };
+
+const CLEAR_MARKER = '<command-name>/clear</command-name>';
+
+/**
+ * Claude does not start a new session on /clear — it keeps appending to the
+ * same jsonl. Resuming with `claude -r` therefore replays pre-clear chat,
+ * which is not what the user expects after running /clear and reopening Dash.
+ *
+ * Walk the jsonl, find the LAST /clear user entry, and write a forked jsonl
+ * containing only entries after it (with sessionId rewritten and the new
+ * first entry's parentUuid reset to null). Returns:
+ *   - 'forked' (with new id) when post-clear entries exist
+ *   - 'clear-only' when /clear is the last interaction (caller should start
+ *     a fresh session instead of resuming)
+ *   - 'no-clear' when no /clear is present (caller should resume normally)
+ */
+function forkJsonlAtLastClear(cwd: string, sessionId: string): ForkResult {
+  const projDir = findClaudeProjectDir(cwd);
+  if (!projDir) return { kind: 'no-clear' };
+  const jsonlPath = path.join(projDir, `${sessionId}.jsonl`);
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(jsonlPath, 'utf-8');
+  } catch (err) {
+    console.error('[forkJsonlAtLastClear] read failed:', err);
+    return { kind: 'no-clear' };
+  }
+  const lines = raw.split('\n').filter((l) => l.length > 0);
+
+  let lastClearIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (!lines[i].includes(CLEAR_MARKER)) continue;
+    try {
+      const obj = JSON.parse(lines[i]);
+      const content = obj?.message?.content;
+      if (obj.type === 'user' && typeof content === 'string' && content.includes(CLEAR_MARKER)) {
+        lastClearIdx = i;
+      }
+    } catch {
+      /* ignore unparseable line */
+    }
+  }
+  if (lastClearIdx < 0) return { kind: 'no-clear' };
+
+  // Drop the local_command system response that immediately follows /clear,
+  // so the forked file doesn't start with an orphan response.
+  let startIdx = lastClearIdx + 1;
+  if (startIdx < lines.length) {
+    try {
+      const next = JSON.parse(lines[startIdx]);
+      if (next.type === 'system' && next.subtype === 'local_command') {
+        startIdx++;
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  if (startIdx >= lines.length) return { kind: 'clear-only' };
+
+  const newId = randomUUID();
+  const rewritten: string[] = [];
+  let parentReset = false;
+  for (let i = startIdx; i < lines.length; i++) {
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(lines[i]);
+    } catch {
+      continue;
+    }
+    if ('sessionId' in obj) obj.sessionId = newId;
+    if (!parentReset && 'parentUuid' in obj) {
+      obj.parentUuid = null;
+      parentReset = true;
+    }
+    rewritten.push(JSON.stringify(obj));
+  }
+  if (rewritten.length === 0) return { kind: 'clear-only' };
+
+  const newPath = path.join(projDir, `${newId}.jsonl`);
+  try {
+    fs.writeFileSync(newPath, rewritten.join('\n') + '\n');
+  } catch (err) {
+    console.error('[forkJsonlAtLastClear] write failed:', err);
+    return { kind: 'no-clear' };
+  }
+  return { kind: 'forked', newId };
 }
 
 interface PtyRecord {
@@ -664,14 +755,37 @@ export async function startDirectPty(options: {
   // Prefer the hook-captured lastSessionId (Claude may fork on /clear or
   // /compact, so the live session id can drift from task.id).
   const task = DatabaseService.getTask(options.id);
-  const resumeId = task?.lastSessionId ?? options.id;
+  let resumeId = task?.lastSessionId ?? options.id;
   const hadPriorUse =
     task?.lastSessionId != null || terminalSnapshotService.hasSnapshot(options.id);
-  if (hasSessionForId(options.cwd, resumeId)) {
+
+  // If the resumable jsonl contains a /clear, fork past it (or skip resume
+  // entirely if /clear was the last interaction). Otherwise `claude -r` would
+  // reload pre-clear messages.
+  let skipResume = false;
+  const candidateIds = [resumeId, options.id].filter((id, i, arr) => id && arr.indexOf(id) === i);
+  for (const id of candidateIds) {
+    if (!hasSessionForId(options.cwd, id)) continue;
+    const fork = forkJsonlAtLastClear(options.cwd, id);
+    if (fork.kind === 'forked') {
+      resumeId = fork.newId;
+      try {
+        DatabaseService.setTaskLastSessionId(options.id, fork.newId);
+      } catch (err) {
+        console.error('[spawnDirectClaude] persist forked session id failed:', err);
+      }
+    } else if (fork.kind === 'clear-only') {
+      skipResume = true;
+    }
+    break;
+  }
+
+  if (!skipResume && hasSessionForId(options.cwd, resumeId)) {
     args.push('-r', resumeId);
-  } else if (resumeId !== options.id && hasSessionForId(options.cwd, options.id)) {
+  } else if (!skipResume && resumeId !== options.id && hasSessionForId(options.cwd, options.id)) {
     args.push('-r', options.id);
   } else if (
+    !skipResume &&
     task &&
     task.lastSessionId === null &&
     DatabaseService.countTasksAtPath(options.cwd) === 1 &&
@@ -686,11 +800,21 @@ export async function startDirectPty(options: {
     // so future spawns pin correctly.
     args.push('-c', '-r');
   } else {
-    args.push('--session-id', options.id);
-    // Task had prior use (snapshot or captured session id) but we couldn't
-    // link any existing session — notify the user so they can recover via
-    // Claude's /resume command. Jsonl history is still on disk.
-    if (hadPriorUse && task) {
+    // When skipping resume because /clear was the last interaction, mint a
+    // fresh UUID so we don't reuse the jsonl that contains the /clear, and
+    // persist it so future restarts pin to this new session.
+    const newSessionId = skipResume ? randomUUID() : options.id;
+    args.push('--session-id', newSessionId);
+    if (skipResume) {
+      try {
+        DatabaseService.setTaskLastSessionId(options.id, newSessionId);
+      } catch (err) {
+        console.error('[spawnDirectClaude] persist post-clear session id failed:', err);
+      }
+    } else if (hadPriorUse && task) {
+      // Task had prior use (snapshot or captured session id) but we couldn't
+      // link any existing session — notify the user so they can recover via
+      // Claude's /resume command. Jsonl history is still on disk.
       for (const win of BrowserWindow.getAllWindows()) {
         if (!win.isDestroyed()) {
           win.webContents.send('app:toast', {

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -229,11 +229,18 @@ function buildDirectEnv(isDark: boolean): Record<string, string> {
     ? Object.fromEntries(Object.entries(process.env).filter((e): e is [string, string] => !!e[1]))
     : {};
 
+  // rtk's rewrite output invokes the bare name `rtk`; when the binary is
+  // Dash-managed (userData/bin), prepend that dir so the rewrite resolves.
+  const rtkBinDir = RtkService.getManagedBinDirForPath();
+  const pathSep = isWin ? ';' : ':';
+  const basePath = process.env.PATH || '';
+  const mergedPath = rtkBinDir ? `${rtkBinDir}${pathSep}${basePath}` : basePath;
+
   const env: Record<string, string> = {
     ...base,
     TERM_PROGRAM: 'dash',
     HOME: os.homedir(),
-    PATH: process.env.PATH || '',
+    PATH: mergedPath,
     // Tell CLI apps about terminal background (rxvt convention)
     // Format: "fg;bg" where higher values = lighter colors
     COLORFGBG: isDark ? '15;0' : '0;15',

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -11,6 +11,15 @@ import { contextUsageService } from './ContextUsageService';
 import { DatabaseService } from './DatabaseService';
 import { terminalSnapshotService } from './TerminalSnapshotService';
 import { RtkService } from './RtkService';
+import {
+  type Hook,
+  type HookEntry,
+  type HttpHook,
+  type CommandHook,
+  DASH_HOOK_EVENTS,
+  entryIsDashOwned as entryIsDashOwnedPure,
+  mergeHookEntries as mergeHookEntriesPure,
+} from './hookSettingsMerge';
 
 const execFileAsync = promisify(execFile);
 
@@ -23,11 +32,11 @@ function findClaudeProjectDir(cwd: string): string | null {
     const projectsDir = path.join(os.homedir(), '.claude', 'projects');
     if (!fs.existsSync(projectsDir)) return null;
 
-    // Path-based: slashes → hyphens (the primary naming scheme)
+    // Claude varies between full-path-with-hyphens and a truncated-suffix
+    // directory name across versions; check both shapes.
     const pathBased = path.join(projectsDir, cwd.replace(/\//g, '-'));
     if (fs.existsSync(pathBased)) return pathBased;
 
-    // Partial match: last 3 path segments
     const parts = cwd.split('/').filter((p) => p.length > 0);
     const suffix = parts.slice(-3).join('-');
     const dirs = fs.readdirSync(projectsDir);
@@ -471,27 +480,6 @@ function getTaskContextPrompt(taskId: string): string | null {
   }
 }
 
-/**
- * All hook event names that Dash writes to settings.local.json.
- * Used by both writeHookSettings and cleanupHookSettings.
- */
-const DASH_HOOK_EVENTS = [
-  'Stop',
-  'UserPromptSubmit',
-  'Notification',
-  'PreToolUse',
-  'PostToolUse',
-  'StopFailure',
-  'PreCompact',
-  'PostCompact',
-  'SessionStart',
-] as const;
-
-type HttpHook = { type: 'http'; url: string; async?: boolean };
-type CommandHook = { type: 'command'; command: string };
-type Hook = (HttpHook | CommandHook) & { __dash?: true };
-type HookEntry = { matcher: string; hooks: Hook[] };
-
 function buildPreToolUseHooks(
   httpHook: (endpoint: string, async?: boolean) => HttpHook,
 ): HookEntry[] {
@@ -602,7 +590,6 @@ function writeHookSettings(cwd: string, ptyId: string): HookWriteResult {
       fs.mkdirSync(claudeDir, { recursive: true });
     }
 
-    // Merge with existing settings to preserve user content.
     let existing: Record<string, unknown> = {};
     if (fs.existsSync(settingsPath)) {
       try {
@@ -650,20 +637,7 @@ function writeHookSettings(cwd: string, ptyId: string): HookWriteResult {
         ? (existing.hooks as Record<string, HookEntry[] | undefined>)
         : {};
 
-    const mergedHooks: Record<string, HookEntry[]> = {};
-    const dashEventSet = new Set<string>(DASH_HOOK_EVENTS);
-    for (const [event, userEntries] of Object.entries(existingHooks)) {
-      if (!Array.isArray(userEntries)) continue;
-      // For events Dash manages: keep only user-authored entries (ones we
-      // didn't tag). For other events: keep the user's entries as-is.
-      mergedHooks[event] = dashEventSet.has(event)
-        ? userEntries.filter((e) => !entryIsDashOwned(e))
-        : userEntries;
-    }
-    for (const [event, entries] of Object.entries(dashEntries)) {
-      const preserved = mergedHooks[event] ?? [];
-      mergedHooks[event] = [...preserved, ...entries];
-    }
+    const mergedHooks = mergeHookEntriesPure(existingHooks, dashEntries, dashHookUrlPrefix());
 
     const merged: Record<string, unknown> = {
       ...existing,
@@ -709,29 +683,15 @@ function atomicWriteFileSync(target: string, data: string): void {
   fs.renameSync(tmp, target);
 }
 
-function entryIsDashOwned(entry: unknown): boolean {
-  if (!entry || typeof entry !== 'object') return false;
-  const hooks = (entry as { hooks?: unknown }).hooks;
-  if (!Array.isArray(hooks)) return false;
-  return hooks.some((h) => isDashOwnedHook(h));
+/** Returns the Dash hook URL prefix once the HookServer has bound a port. */
+function dashHookUrlPrefix(): string | null {
+  const port = hookServer.port;
+  return port > 0 ? `http://127.0.0.1:${port}/hook/` : null;
 }
 
-function isDashOwnedHook(h: unknown): boolean {
-  if (!h || typeof h !== 'object') return false;
-  // Primary: the explicit __dash brand we wrote.
-  if ((h as { __dash?: unknown }).__dash === true) return true;
-  // Fallback: if the brand was lost in a round-trip (Claude Code or a tool
-  // re-serialising the file may strip unknown fields), recognise hooks
-  // pointing at our HookServer's loopback URL by URL prefix. Without this
-  // fallback, every refresh would append a fresh tagged entry and the file
-  // would accumulate duplicate Dash hooks indefinitely.
-  const port = hookServer.port;
-  if (port > 0) {
-    const dashUrlPrefix = `http://127.0.0.1:${port}/hook/`;
-    const url = (h as { url?: unknown }).url;
-    if (typeof url === 'string' && url.startsWith(dashUrlPrefix)) return true;
-  }
-  return false;
+/** Wrapper that closes over the live HookServer port for cleanup-time filtering. */
+function entryIsDashOwned(entry: unknown): boolean {
+  return entryIsDashOwnedPure(entry, dashHookUrlPrefix());
 }
 
 function broadcastToast(message: string): void {

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -98,12 +98,7 @@ export function setCommitAttribution(value: string | undefined): void {
   refreshActivePtyHooks();
 }
 
-/**
- * Re-write settings.local.json for every active PTY. Use when a setting that
- * participates in the hook JSON has changed (commit attribution, RTK toggle,
- * etc.) — Claude Code re-reads settings.local.json on each tool invocation,
- * so running sessions pick up the change without needing to be restarted.
- */
+/** Claude Code re-reads settings.local.json per tool call, so rewriting it flips hooks live. */
 export function refreshActivePtyHooks(): void {
   for (const [id, rec] of ptys) {
     writeHookSettings(rec.cwd, id);
@@ -234,7 +229,7 @@ function buildDirectEnv(isDark: boolean): Record<string, string> {
   const rtkBinDir = RtkService.getManagedBinDirForPath();
   const pathSep = isWin ? ';' : ':';
   const basePath = process.env.PATH || '';
-  const mergedPath = rtkBinDir ? `${rtkBinDir}${pathSep}${basePath}` : basePath;
+  const mergedPath = rtkBinDir ? prependUnique(rtkBinDir, basePath, pathSep) : basePath;
 
   const env: Record<string, string> = {
     ...base,
@@ -339,18 +334,32 @@ const DASH_HOOK_EVENTS = [
 ] as const;
 
 type HttpHook = { type: 'http'; url: string; async?: boolean };
-type HookEntry = { matcher: string; hooks: unknown[] };
+type CommandHook = { type: 'command'; command: string };
+type Hook = (HttpHook | CommandHook) & { __dash?: true };
+type HookEntry = { matcher: string; hooks: Hook[] };
 
-/** PreToolUse = Dash tool-start tracker, plus optional RTK Bash rewriter when enabled. */
 function buildPreToolUseHooks(
   httpHook: (endpoint: string, async?: boolean) => HttpHook,
 ): HookEntry[] {
-  const entries: HookEntry[] = [{ matcher: '*', hooks: [httpHook('/hook/tool-start', true)] }];
+  const entries: HookEntry[] = [
+    { matcher: '*', hooks: [tagDash(httpHook('/hook/tool-start', true))] },
+  ];
   const rtkCmd = RtkService.isEnabled() ? RtkService.getHookCommand() : null;
   if (rtkCmd) {
-    entries.push({ matcher: 'Bash', hooks: [{ type: 'command', command: rtkCmd }] });
+    entries.push({ matcher: 'Bash', hooks: [tagDash({ type: 'command', command: rtkCmd })] });
   }
   return entries;
+}
+
+function tagDash<T extends HttpHook | CommandHook>(hook: T): T & { __dash: true } {
+  return { ...hook, __dash: true };
+}
+
+function prependUnique(dir: string, basePath: string, sep: string): string {
+  if (!basePath) return dir;
+  const parts = basePath.split(sep);
+  if (parts.includes(dir)) return basePath;
+  return `${dir}${sep}${basePath}`;
 }
 
 /**
@@ -369,35 +378,26 @@ function writeHookSettings(cwd: string, ptyId: string): void {
   const settingsPath = path.join(claudeDir, 'settings.local.json');
   const base = `http://127.0.0.1:${port}`;
 
-  /** Shorthand: build an HTTP hook entry. */
-  const httpHook = (endpoint: string, async?: boolean) => ({
+  const httpHook = (endpoint: string, async?: boolean): HttpHook => ({
     type: 'http' as const,
     url: `${base}${endpoint}?ptyId=${ptyId}`,
     ...(async ? { async: true } : {}),
   });
 
-  const hookSettings: Record<string, unknown[]> = {
-    // ── Activity state signals ──────────────────────────────
-    Stop: [{ hooks: [httpHook('/hook/stop')] }],
-    UserPromptSubmit: [{ hooks: [httpHook('/hook/busy')] }],
+  const dashHttp = (endpoint: string, async?: boolean) => tagDash(httpHook(endpoint, async));
 
-    // ── Notification (permission prompt, idle) ──────────────
+  const dashEntries: Record<string, HookEntry[]> = {
+    Stop: [{ matcher: '', hooks: [dashHttp('/hook/stop')] }],
+    UserPromptSubmit: [{ matcher: '', hooks: [dashHttp('/hook/busy')] }],
     Notification: [
-      { matcher: 'permission_prompt', hooks: [httpHook('/hook/notification')] },
-      { matcher: 'idle_prompt', hooks: [httpHook('/hook/notification')] },
+      { matcher: 'permission_prompt', hooks: [dashHttp('/hook/notification')] },
+      { matcher: 'idle_prompt', hooks: [dashHttp('/hook/notification')] },
     ],
-
-    // ── Tool activity tracking ──────────────────────────────
-    // PreToolUse also carries the optional RTK Bash-rewrite hook when enabled.
     PreToolUse: buildPreToolUseHooks(httpHook),
-    PostToolUse: [{ matcher: '*', hooks: [httpHook('/hook/tool-end', true)] }],
-
-    // ── Error detection ─────────────────────────────────────
-    StopFailure: [{ matcher: '*', hooks: [httpHook('/hook/stop-failure')] }],
-
-    // ── Context compaction ──────────────────────────────────
-    PreCompact: [{ matcher: '*', hooks: [httpHook('/hook/compact-start', true)] }],
-    PostCompact: [{ matcher: '*', hooks: [httpHook('/hook/compact-end', true)] }],
+    PostToolUse: [{ matcher: '*', hooks: [dashHttp('/hook/tool-end', true)] }],
+    StopFailure: [{ matcher: '*', hooks: [dashHttp('/hook/stop-failure')] }],
+    PreCompact: [{ matcher: '*', hooks: [dashHttp('/hook/compact-start', true)] }],
+    PostCompact: [{ matcher: '*', hooks: [dashHttp('/hook/compact-end', true)] }],
   };
 
   // SessionStart hook fires on: startup (new session), resume (reattach by id),
@@ -432,10 +432,10 @@ function writeHookSettings(cwd: string, ptyId: string): void {
     contextHook = { type: 'command', command: decodeCmd };
   }
 
-  hookSettings.SessionStart = ['startup', 'resume', 'compact', 'clear'].map((matcher) => {
-    const hooks: unknown[] = [captureHook];
+  dashEntries.SessionStart = ['startup', 'resume', 'compact', 'clear'].map((matcher) => {
+    const hooks: Hook[] = [tagDash(captureHook)];
     if (contextHook && matcher !== 'resume') {
-      hooks.push(contextHook);
+      hooks.push(tagDash(contextHook));
     }
     return { matcher, hooks };
   });
@@ -445,56 +445,96 @@ function writeHookSettings(cwd: string, ptyId: string): void {
       fs.mkdirSync(claudeDir, { recursive: true });
     }
 
-    // Merge with existing settings to preserve non-hook config
+    // Merge with existing settings to preserve user content.
     let existing: Record<string, unknown> = {};
     if (fs.existsSync(settingsPath)) {
       try {
         existing = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
       } catch (err) {
-        console.error(
-          '[writeHookSettings] Corrupted settings.local.json at',
-          settingsPath,
-          '— overwriting:',
-          err,
-        );
+        // Back up the corrupt file before overwriting so the user can recover.
+        const backupPath = `${settingsPath}.corrupt-${Date.now()}.bak`;
+        try {
+          fs.renameSync(settingsPath, backupPath);
+          console.error(
+            `[writeHookSettings] settings.local.json corrupt at ${settingsPath}; backed up to ${backupPath}`,
+            err,
+          );
+          for (const win of BrowserWindow.getAllWindows()) {
+            if (!win.isDestroyed()) {
+              win.webContents.send('app:toast', {
+                message: `settings.local.json was unreadable — backed up to ${path.basename(backupPath)} and rewritten.`,
+              });
+            }
+          }
+        } catch (renameErr) {
+          console.error('[writeHookSettings] Failed to back up corrupt file:', renameErr);
+        }
       }
+    }
+
+    const existingHooks =
+      existing.hooks && typeof existing.hooks === 'object'
+        ? (existing.hooks as Record<string, HookEntry[] | undefined>)
+        : {};
+
+    const mergedHooks: Record<string, HookEntry[]> = {};
+    const dashEventSet = new Set<string>(DASH_HOOK_EVENTS);
+    for (const [event, userEntries] of Object.entries(existingHooks)) {
+      if (!Array.isArray(userEntries)) continue;
+      // For events Dash manages: keep only user-authored entries (ones we
+      // didn't tag). For other events: keep the user's entries as-is.
+      mergedHooks[event] = dashEventSet.has(event)
+        ? userEntries.filter((e) => !entryIsDashOwned(e))
+        : userEntries;
+    }
+    for (const [event, entries] of Object.entries(dashEntries)) {
+      const preserved = mergedHooks[event] ?? [];
+      mergedHooks[event] = [...preserved, ...entries];
     }
 
     const merged: Record<string, unknown> = {
       ...existing,
-      hooks: {
-        ...(existing.hooks && typeof existing.hooks === 'object'
-          ? (existing.hooks as Record<string, unknown>)
-          : {}),
-        ...hookSettings,
-      },
+      hooks: mergedHooks,
     };
 
-    // statusLine: command that pipes Claude Code's JSON context data to our hook server
     const contextUrl = `${base}/hook/context?ptyId=${ptyId}`;
     merged.statusLine = {
       type: 'command',
       command: `curl -s --connect-timeout 2 -X POST -H "Content-Type: application/json" -d @- "${contextUrl}" >/dev/null 2>&1`,
     };
 
-    // Commit attribution: undefined = Dash default, '' = suppress, other = custom.
     const effectiveAttribution =
       commitAttributionSetting === undefined ? DASH_DEFAULT_ATTRIBUTION : commitAttributionSetting;
     merged.attribution = { commit: effectiveAttribution };
 
     fs.writeFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
     writtenSettingsPaths.add(settingsPath);
-    console.error(
-      `[writeHookSettings] Wrote ${settingsPath} (attribution: ${commitAttributionSetting === undefined ? 'default' : commitAttributionSetting || 'none'})`,
-    );
   } catch (err) {
     console.error('[writeHookSettings] Failed:', err);
+    // If hooks aren't written, Dash's activity monitor, context metering, and
+    // the RTK rewriter are all silently absent — notify the user.
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) {
+        win.webContents.send('app:toast', {
+          message: `Could not write ${path.basename(settingsPath)} — hooks are off for this task.`,
+        });
+      }
+    }
   }
+}
+
+function entryIsDashOwned(entry: unknown): boolean {
+  if (!entry || typeof entry !== 'object') return false;
+  const hooks = (entry as { hooks?: unknown }).hooks;
+  if (!Array.isArray(hooks)) return false;
+  return hooks.some(
+    (h) => !!h && typeof h === 'object' && (h as { __dash?: unknown }).__dash === true,
+  );
 }
 
 /**
  * Remove Dash-written hooks and attribution from all settings.local.json files
- * that were written during this session. Called on app quit to prevent stale hooks.
+ * that were written during this session. Preserves user-authored entries.
  */
 export function cleanupHookSettings(): void {
   for (const settingsPath of writtenSettingsPaths) {
@@ -506,25 +546,24 @@ export function cleanupHookSettings(): void {
 
       if (hooks && typeof hooks === 'object') {
         for (const key of DASH_HOOK_EVENTS) {
-          delete hooks[key];
+          const entries = hooks[key];
+          if (!Array.isArray(entries)) continue;
+          const userOnly = entries.filter((e) => !entryIsDashOwned(e));
+          if (userOnly.length === 0) delete hooks[key];
+          else hooks[key] = userOnly;
         }
-        // Remove hooks object entirely if empty
         if (Object.keys(hooks).length === 0) {
           delete raw.hooks;
         }
       }
 
-      // Remove Dash statusLine and attribution
       delete raw.statusLine;
       delete raw.attribution;
 
-      // If nothing meaningful remains, delete the file
       if (Object.keys(raw).length === 0) {
         fs.unlinkSync(settingsPath);
-        console.error(`[cleanupHookSettings] Removed empty ${settingsPath}`);
       } else {
         fs.writeFileSync(settingsPath, JSON.stringify(raw, null, 2) + '\n');
-        console.error(`[cleanupHookSettings] Cleaned hooks from ${settingsPath}`);
       }
     } catch (err) {
       console.error(`[cleanupHookSettings] Failed for ${settingsPath}:`, err);

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -9,6 +9,7 @@ import { hookServer } from './HookServer';
 import { contextUsageService } from './ContextUsageService';
 import { DatabaseService } from './DatabaseService';
 import { terminalSnapshotService } from './TerminalSnapshotService';
+import { RtkService } from './RtkService';
 
 const execFileAsync = promisify(execFile);
 
@@ -94,7 +95,16 @@ const RESERVED_ENV_KEYS = new Set([
 
 export function setCommitAttribution(value: string | undefined): void {
   commitAttributionSetting = value;
-  // Re-write settings.local.json for all active PTYs so the change takes effect immediately
+  refreshActivePtyHooks();
+}
+
+/**
+ * Re-write settings.local.json for every active PTY. Use when a setting that
+ * participates in the hook JSON has changed (commit attribution, RTK toggle,
+ * etc.) — Claude Code re-reads settings.local.json on each tool invocation,
+ * so running sessions pick up the change without needing to be restarted.
+ */
+export function refreshActivePtyHooks(): void {
   for (const [id, rec] of ptys) {
     writeHookSettings(rec.cwd, id);
   }
@@ -321,6 +331,21 @@ const DASH_HOOK_EVENTS = [
   'SessionStart',
 ] as const;
 
+type HttpHook = { type: 'http'; url: string; async?: boolean };
+type HookEntry = { matcher: string; hooks: unknown[] };
+
+/** PreToolUse = Dash tool-start tracker, plus optional RTK Bash rewriter when enabled. */
+function buildPreToolUseHooks(
+  httpHook: (endpoint: string, async?: boolean) => HttpHook,
+): HookEntry[] {
+  const entries: HookEntry[] = [{ matcher: '*', hooks: [httpHook('/hook/tool-start', true)] }];
+  const rtkCmd = RtkService.isEnabled() ? RtkService.getHookCommand() : null;
+  if (rtkCmd) {
+    entries.push({ matcher: 'Bash', hooks: [{ type: 'command', command: rtkCmd }] });
+  }
+  return entries;
+}
+
 /**
  * Write .claude/settings.local.json with hooks for activity monitoring,
  * tool tracking, error detection, and context usage.
@@ -356,7 +381,8 @@ function writeHookSettings(cwd: string, ptyId: string): void {
     ],
 
     // ── Tool activity tracking ──────────────────────────────
-    PreToolUse: [{ matcher: '*', hooks: [httpHook('/hook/tool-start', true)] }],
+    // PreToolUse also carries the optional RTK Bash-rewrite hook when enabled.
+    PreToolUse: buildPreToolUseHooks(httpHook),
     PostToolUse: [{ matcher: '*', hooks: [httpHook('/hook/tool-end', true)] }],
 
     // ── Error detection ─────────────────────────────────────

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -37,6 +37,8 @@ import type {
   ActivityInfo,
   PixelAgentsConfig,
   PixelAgentsStatus,
+  RtkStatus,
+  RtkDownloadProgress,
 } from '../shared/types';
 import type { CreateTaskOptions } from './components/TaskModal';
 import { formatTaskContextPrompt } from '../shared/taskContext';
@@ -188,6 +190,25 @@ export function App() {
     });
     return window.electronAPI.onPixelAgentsStatusChanged((status) => {
       setPixelAgentsStatus(status);
+    });
+  }, []);
+
+  // RTK state
+  const [rtkStatus, setRtkStatus] = useState<RtkStatus | null>(null);
+  const [rtkDownloadProgress, setRtkDownloadProgress] = useState<RtkDownloadProgress | null>(null);
+
+  useEffect(() => {
+    window.electronAPI.rtkGetStatus().then((resp) => {
+      if (resp.success && resp.data) setRtkStatus(resp.data);
+    });
+    return window.electronAPI.onRtkDownloadProgress((progress) => {
+      setRtkDownloadProgress(progress);
+      // When the download finishes, refresh status so the toggle becomes usable
+      if (progress.phase === 'done') {
+        window.electronAPI.rtkGetStatus().then((resp) => {
+          if (resp.success && resp.data) setRtkStatus(resp.data);
+        });
+      }
     });
   }, []);
 
@@ -1730,6 +1751,16 @@ export function App() {
             window.electronAPI.pixelAgentsSaveConfig(config);
           }}
           pixelAgentsStatus={pixelAgentsStatus}
+          rtkStatus={rtkStatus}
+          onRtkEnabledChange={(enabled) => {
+            setRtkStatus((prev) => (prev ? { ...prev, enabled } : prev));
+            window.electronAPI.rtkSetEnabled(enabled);
+          }}
+          onRtkDownload={() => {
+            setRtkDownloadProgress({ phase: 'downloading', percent: 0 });
+            window.electronAPI.rtkDownload();
+          }}
+          rtkDownloadProgress={rtkDownloadProgress}
           latestRateLimits={latestRateLimits}
           usageThresholds={usageThresholds}
           onUsageThresholdsChange={setUsageThresholds}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -203,7 +203,6 @@ export function App() {
     });
     return window.electronAPI.onRtkDownloadProgress((progress) => {
       setRtkDownloadProgress(progress);
-      // When the download finishes, refresh status so the toggle becomes usable
       if (progress.phase === 'done') {
         window.electronAPI.rtkGetStatus().then((resp) => {
           if (resp.success && resp.data) setRtkStatus(resp.data);
@@ -1754,7 +1753,14 @@ export function App() {
           rtkStatus={rtkStatus}
           onRtkEnabledChange={(enabled) => {
             setRtkStatus((prev) => (prev ? { ...prev, enabled } : prev));
-            window.electronAPI.rtkSetEnabled(enabled);
+            window.electronAPI.rtkSetEnabled(enabled).then((resp) => {
+              if (!resp.success) {
+                // Roll back the optimistic toggle and reflect the real state.
+                window.electronAPI.rtkGetStatus().then((s) => {
+                  if (s.success && s.data) setRtkStatus(s.data);
+                });
+              }
+            });
           }}
           onRtkDownload={() => {
             setRtkDownloadProgress({ phase: 'downloading', percent: 0 });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -536,7 +536,7 @@ export function App() {
   }, [tasksByProject]);
 
   // Threshold alerts — fires toast notifications when usage exceeds thresholds
-  useThresholdAlerts(statusLineData, usageThresholds, taskNames);
+  useThresholdAlerts(statusLineData, latestRateLimits, usageThresholds, taskNames);
 
   // Persist usage thresholds
   useEffect(() => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -213,8 +213,9 @@ export function App() {
         } else {
           console.error('[rtk:getStatus] gave up after retry:', resp.error);
           // Surface a sentinel so the Settings card can show a manual retry
-          // button instead of an infinite spinner.
-          setRtkStatus({ installed: false, enabled: false, downloadable: false });
+          // button instead of an infinite spinner. `enabled` is unrepresentable
+          // on the not-installed arm by design.
+          setRtkStatus({ installed: false, downloadable: false });
         }
       });
     };
@@ -1775,7 +1776,10 @@ export function App() {
           pixelAgentsStatus={pixelAgentsStatus}
           rtkStatus={rtkStatus}
           onRtkEnabledChange={(enabled) => {
-            setRtkStatus((prev) => (prev ? { ...prev, enabled } : prev));
+            // Optimistic update only applies to the installed arm — the type
+            // forbids `enabled` on { installed: false }, and the toggle UI is
+            // disabled in that case anyway.
+            setRtkStatus((prev) => (prev?.installed ? { ...prev, enabled } : prev));
             window.electronAPI.rtkSetEnabled(enabled).then((resp) => {
               if (!resp.success) {
                 toast.error(resp.error ?? 'Failed to toggle RTK');

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -198,11 +198,28 @@ export function App() {
   const [rtkDownloadProgress, setRtkDownloadProgress] = useState<RtkDownloadProgress | null>(null);
 
   useEffect(() => {
-    window.electronAPI.rtkGetStatus().then((resp) => {
-      if (resp.success && resp.data) setRtkStatus(resp.data);
-      else console.error('[rtk:getStatus]', resp.error);
-    });
-    return window.electronAPI.onRtkDownloadProgress((progress) => {
+    // Retry once on transient failure — without it, a single flake at startup
+    // leaves rtkStatus null forever and the Settings card stays stuck on
+    // "loading…". Manual retry is exposed in the UI via a `loadRtkError` flag.
+    let cancelled = false;
+    const tryFetch = (attempt: number): void => {
+      window.electronAPI.rtkGetStatus().then((resp) => {
+        if (cancelled) return;
+        if (resp.success && resp.data) {
+          setRtkStatus(resp.data);
+        } else if (attempt < 1) {
+          console.warn('[rtk:getStatus] retrying after transient failure:', resp.error);
+          setTimeout(() => tryFetch(attempt + 1), 500);
+        } else {
+          console.error('[rtk:getStatus] gave up after retry:', resp.error);
+          // Surface a sentinel so the Settings card can show a manual retry
+          // button instead of an infinite spinner.
+          setRtkStatus({ installed: false, enabled: false, downloadable: false });
+        }
+      });
+    };
+    tryFetch(0);
+    const cleanup = window.electronAPI.onRtkDownloadProgress((progress) => {
       setRtkDownloadProgress(progress);
       if (progress.phase === 'done') {
         window.electronAPI.rtkGetStatus().then((resp) => {
@@ -211,6 +228,10 @@ export function App() {
         });
       }
     });
+    return () => {
+      cancelled = true;
+      cleanup();
+    };
   }, []);
 
   // Sync desktop notification settings to main process
@@ -1781,6 +1802,12 @@ export function App() {
               // bypasses the progress stream — surface it here too.
               if (!resp.success) {
                 setRtkDownloadProgress({ phase: 'error', error: resp.error ?? 'download failed' });
+                return;
+              }
+              // Install succeeded; surface a partial-refresh warning if any
+              // active task couldn't pick up the new hook live.
+              if (resp.data?.warning) {
+                toast.warning(resp.data.warning);
               }
             });
           }}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1763,6 +1763,13 @@ export function App() {
                   if (s.success && s.data) setRtkStatus(s.data);
                   else console.error('[rtk:getStatus after setEnabled failure]', s.error);
                 });
+                return;
+              }
+              // Flag saved but some tasks couldn't be refreshed live — the
+              // setting is persisted and next-spawn will pick it up; flag the
+              // partial state without rolling back.
+              if (resp.data?.warning) {
+                toast.warning(resp.data.warning);
               }
             });
           }}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -200,12 +200,14 @@ export function App() {
   useEffect(() => {
     window.electronAPI.rtkGetStatus().then((resp) => {
       if (resp.success && resp.data) setRtkStatus(resp.data);
+      else console.error('[rtk:getStatus]', resp.error);
     });
     return window.electronAPI.onRtkDownloadProgress((progress) => {
       setRtkDownloadProgress(progress);
       if (progress.phase === 'done') {
         window.electronAPI.rtkGetStatus().then((resp) => {
           if (resp.success && resp.data) setRtkStatus(resp.data);
+          else console.error('[rtk:getStatus after download]', resp.error);
         });
       }
     });
@@ -1755,16 +1757,25 @@ export function App() {
             setRtkStatus((prev) => (prev ? { ...prev, enabled } : prev));
             window.electronAPI.rtkSetEnabled(enabled).then((resp) => {
               if (!resp.success) {
+                toast.error(resp.error ?? 'Failed to toggle RTK');
                 // Roll back the optimistic toggle and reflect the real state.
                 window.electronAPI.rtkGetStatus().then((s) => {
                   if (s.success && s.data) setRtkStatus(s.data);
+                  else console.error('[rtk:getStatus after setEnabled failure]', s.error);
                 });
               }
             });
           }}
           onRtkDownload={() => {
             setRtkDownloadProgress({ phase: 'downloading', percent: 0 });
-            window.electronAPI.rtkDownload();
+            window.electronAPI.rtkDownload().then((resp) => {
+              // doDownload emits phase:'error' on its own failures, but any
+              // throw outside that loop (IPC plumbing, refreshActivePtyHooks)
+              // bypasses the progress stream — surface it here too.
+              if (!resp.success) {
+                setRtkDownloadProgress({ phase: 'error', error: resp.error ?? 'download failed' });
+              }
+            });
           }}
           rtkDownloadProgress={rtkDownloadProgress}
           latestRateLimits={latestRateLimits}

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -34,6 +34,9 @@ import type {
   PixelAgentsOfficeStatus,
   RateLimits,
   UsageThresholds,
+  RtkStatus,
+  RtkDownloadProgress,
+  RtkTestResult,
 } from '../../shared/types';
 import { formatResetTime } from '../../shared/format';
 import { UsageBar } from './ui/UsageBar';
@@ -47,7 +50,8 @@ type SettingsTab =
   | 'claude-code'
   | 'keybindings'
   | 'usage'
-  | 'pixel-agents';
+  | 'pixel-agents'
+  | 'rtk';
 
 interface SettingsModalProps {
   initialTab?: string;
@@ -92,6 +96,10 @@ interface SettingsModalProps {
   pixelAgentsConfig: PixelAgentsConfig | null;
   onPixelAgentsConfigChange: (config: PixelAgentsConfig) => void;
   pixelAgentsStatus: PixelAgentsStatus;
+  rtkStatus: RtkStatus | null;
+  onRtkEnabledChange: (enabled: boolean) => void;
+  onRtkDownload: () => void;
+  rtkDownloadProgress: RtkDownloadProgress | null;
   latestRateLimits?: RateLimits;
   usageThresholds: UsageThresholds;
   onUsageThresholdsChange: (thresholds: UsageThresholds) => void;
@@ -958,6 +966,251 @@ function ClaudeCodeTab({
   );
 }
 
+function RtkSection({
+  status,
+  onEnabledChange,
+  onDownload,
+  progress,
+}: {
+  status: RtkStatus | null;
+  onEnabledChange: (enabled: boolean) => void;
+  onDownload: () => void;
+  progress: RtkDownloadProgress | null;
+}) {
+  const installing = progress?.phase === 'downloading' || progress?.phase === 'extracting';
+  const loading = !status;
+
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<RtkTestResult | null>(null);
+
+  async function runTest() {
+    setTesting(true);
+    setTestResult(null);
+    const resp = await window.electronAPI.rtkTest();
+    setTesting(false);
+    if (resp.success && resp.data) {
+      setTestResult(resp.data);
+    } else {
+      setTestResult({ ok: false, error: resp.error ?? 'unknown IPC error' });
+    }
+  }
+
+  let installLabel = 'Install RTK';
+  if (progress?.phase === 'extracting') installLabel = 'Extracting…';
+  else if (progress?.phase === 'downloading')
+    installLabel = `Downloading… ${progress.percent ?? 0}%`;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="text-[11px] text-foreground/60 leading-relaxed">
+          RTK compresses common shell-command output (git, ls, test runners, tsc…) before Claude
+          sees it, typically cutting <b>60–90% of tokens</b> per command. When enabled, Dash injects
+          RTK&rsquo;s PreToolUse hook into every task automatically.{' '}
+          <a
+            href="https://github.com/rtk-ai/rtk"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-0.5 text-primary hover:underline"
+          >
+            Learn more
+            <ExternalLink size={9} strokeWidth={1.8} />
+          </a>
+        </p>
+      </div>
+
+      {/* Install status card */}
+      <div
+        className="flex items-start gap-3.5 p-4 rounded-xl border border-border/40"
+        style={{ background: 'hsl(var(--surface-2))' }}
+      >
+        <div
+          className={`w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 ${
+            status?.installed
+              ? 'bg-[hsl(var(--git-added)/0.12)]'
+              : 'bg-[hsl(var(--git-modified)/0.12)]'
+          }`}
+        >
+          {status?.installed ? (
+            <Check size={14} className="text-[hsl(var(--git-added))]" strokeWidth={1.8} />
+          ) : (
+            <AlertCircle size={14} className="text-[hsl(var(--git-modified))]" strokeWidth={1.8} />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          {loading ? (
+            <p className="text-[11px] text-foreground/60">Checking…</p>
+          ) : status?.installed ? (
+            <div className="space-y-0.5">
+              <p className="text-[11px] text-foreground/60 font-mono">
+                {status.version ?? 'installed'}
+                <span className="ml-2 text-foreground/40">
+                  ({status.source === 'managed' ? 'managed by Dash' : 'on $PATH'})
+                </span>
+              </p>
+              {status.path && (
+                <p className="text-[11px] text-foreground/40 font-mono truncate">{status.path}</p>
+              )}
+            </div>
+          ) : status?.downloadable ? (
+            <p className="text-[11px] text-foreground/60 leading-relaxed">
+              Not installed. Dash can fetch the latest release directly — no sudo, no global $PATH
+              changes, binary stays scoped to this app.
+            </p>
+          ) : (
+            <p className="text-[11px] text-foreground/60 leading-relaxed">
+              Not installed, and no prebuilt release is available for this platform. Install
+              manually from{' '}
+              <a
+                href="https://github.com/rtk-ai/rtk"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                github.com/rtk-ai/rtk
+              </a>
+              .
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Install button (only when not installed and platform is supported) */}
+      {!loading && !status?.installed && status?.downloadable && (
+        <div>
+          <button
+            onClick={onDownload}
+            disabled={installing}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg text-[12px] border border-primary/40 bg-primary/8 text-foreground hover:bg-primary/12 transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Download size={12} strokeWidth={1.8} />
+            {installLabel}
+          </button>
+          {progress?.phase === 'error' && (
+            <p className="text-[11px] text-destructive mt-2">{progress.error}</p>
+          )}
+          {progress?.phase === 'done' && (
+            <p className="text-[11px] text-[hsl(var(--git-added))] mt-2">
+              Installed {progress.version ?? ''} — you can enable it below.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Enable toggle (requires install) */}
+      <div>
+        <label className="block text-[12px] font-medium text-foreground mb-3">
+          Inject RTK hook in tasks
+        </label>
+        <ToggleSwitch
+          enabled={!!status?.enabled}
+          onToggle={onEnabledChange}
+          disabled={!status?.installed}
+          label="Compress Bash output via rtk before Claude reads it"
+        />
+        <p className="text-[10px] text-foreground/80 mt-2">
+          Takes effect on the next command in every running task — no restart needed. Dash writes
+          the hook into each task&rsquo;s local settings; your global{' '}
+          <code className="px-1 py-0.5 rounded bg-accent/60 text-[9px] font-mono">
+            ~/.claude/settings.json
+          </code>{' '}
+          is not modified. Do not also run{' '}
+          <code className="px-1 py-0.5 rounded bg-accent/60 text-[9px] font-mono">rtk init -g</code>{' '}
+          or the hook will run twice.
+        </p>
+      </div>
+
+      {/* In-process verification — runs `rtk hook claude` against a synthetic
+          `ls -la /tmp` payload and renders the rewrite it would emit. */}
+      {status?.installed && (
+        <div>
+          <label className="block text-[12px] font-medium text-foreground mb-3">Verify</label>
+          <button
+            onClick={runTest}
+            disabled={testing}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg text-[12px] border border-border/60 text-foreground/80 hover:bg-accent/40 hover:text-foreground transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {testing ? 'Testing…' : 'Test RTK'}
+          </button>
+          <p className="text-[10px] text-foreground/80 mt-2">
+            Pipes a synthetic{' '}
+            <code className="px-1 py-0.5 rounded bg-accent/60 text-[9px] font-mono">
+              git status
+            </code>{' '}
+            through the same rtk binary Dash hands to Claude. Green means rtk rewrote the command —
+            that&rsquo;s the compression path firing.
+          </p>
+
+          {testResult && <RtkTestResultCard result={testResult} />}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RtkTestResultCard({ result }: { result: RtkTestResult }) {
+  if (!result.ok) {
+    return (
+      <div
+        className="mt-3 flex items-start gap-3 p-3 rounded-lg border border-destructive/40"
+        style={{ background: 'hsl(var(--destructive) / 0.06)' }}
+      >
+        <AlertCircle size={14} className="text-destructive mt-0.5" strokeWidth={1.8} />
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] font-medium text-destructive">Test failed</p>
+          <p className="text-[11px] text-foreground/70 font-mono mt-1 break-all">{result.error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (result.wouldCompress) {
+    return (
+      <div
+        className="mt-3 flex items-start gap-3 p-3 rounded-lg border border-[hsl(var(--git-added))]/40"
+        style={{ background: 'hsl(var(--git-added) / 0.06)' }}
+      >
+        <Check size={14} className="text-[hsl(var(--git-added))] mt-0.5" strokeWidth={1.8} />
+        <div className="min-w-0 flex-1 space-y-1">
+          <p className="text-[11px] font-medium text-foreground">
+            Compression active — rtk would rewrite this command.
+          </p>
+          <div className="text-[11px] text-foreground/70 font-mono space-y-0.5">
+            <div>
+              <span className="text-foreground/40">in: </span>
+              {result.testedCommand}
+            </div>
+            <div>
+              <span className="text-foreground/40">out:</span> {result.rewrittenCommand}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // rtk ran cleanly but chose pass-through for our test command.
+  return (
+    <div
+      className="mt-3 flex items-start gap-3 p-3 rounded-lg border border-border/40"
+      style={{ background: 'hsl(var(--surface-2))' }}
+    >
+      <AlertCircle size={14} className="text-[hsl(var(--git-modified))] mt-0.5" strokeWidth={1.8} />
+      <div className="min-w-0 flex-1">
+        <p className="text-[11px] font-medium text-foreground">
+          rtk ran without crashing, but chose not to rewrite this command.
+        </p>
+        <p className="text-[10px] text-foreground/60 mt-1">
+          That&rsquo;s valid — rtk only compresses commands in its rewrite list. The hook plumbing
+          is working; it would compress commands like{' '}
+          <code className="text-foreground/80">git status</code> or{' '}
+          <code className="text-foreground/80">cargo test</code> during real use.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 export function SettingsModal({
   initialTab,
   theme,
@@ -1001,6 +1254,10 @@ export function SettingsModal({
   pixelAgentsConfig,
   onPixelAgentsConfigChange,
   pixelAgentsStatus,
+  rtkStatus,
+  onRtkEnabledChange,
+  onRtkDownload,
+  rtkDownloadProgress,
   latestRateLimits,
   usageThresholds,
   onUsageThresholdsChange,
@@ -1129,6 +1386,7 @@ export function SettingsModal({
               { id: 'keybindings', label: 'Keybindings' },
               { id: 'claude-code', label: 'Claude' },
               { id: 'usage', label: 'Usage' },
+              { id: 'rtk', label: 'RTK' },
               { id: 'pixel-agents', label: 'Pixel Agents' },
             ] as const
           ).map((t) => (
@@ -1669,6 +1927,17 @@ export function SettingsModal({
                 config={pixelAgentsConfig}
                 onChange={onPixelAgentsConfigChange}
                 status={pixelAgentsStatus}
+              />
+            </div>
+          )}
+
+          {tab === 'rtk' && (
+            <div className="space-y-6 animate-fade-in">
+              <RtkSection
+                status={rtkStatus}
+                onEnabledChange={onRtkEnabledChange}
+                onDownload={onRtkDownload}
+                progress={rtkDownloadProgress}
               />
             </div>
           )}

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -1020,7 +1020,10 @@ function RtkSection({
   onDownload: () => void;
   progress: RtkDownloadProgress | null;
 }) {
-  const installing = progress?.phase === 'downloading' || progress?.phase === 'extracting';
+  const installing =
+    progress?.phase === 'downloading' ||
+    progress?.phase === 'extracting' ||
+    progress?.phase === 'verifying';
   const loading = !status;
 
   const [testing, setTesting] = useState(false);
@@ -1040,8 +1043,8 @@ function RtkSection({
 
   let installLabel = 'Install RTK';
   if (progress?.phase === 'extracting') installLabel = 'Extracting…';
-  else if (progress?.phase === 'downloading')
-    installLabel = `Downloading… ${progress.percent ?? 0}%`;
+  else if (progress?.phase === 'verifying') installLabel = 'Verifying…';
+  else if (progress?.phase === 'downloading') installLabel = `Downloading… ${progress.percent}%`;
 
   return (
     <div className="space-y-6">
@@ -1174,7 +1177,35 @@ function RtkTestResultCard({ result }: { result: RtkTestResult }) {
     );
   }
 
-  if (result.wouldCompress) {
+  if (result.blocked) {
+    return (
+      <div
+        className="mt-3 flex items-start gap-3 p-3 rounded-lg border border-[hsl(var(--git-modified))]/40"
+        style={{ background: 'hsl(var(--git-modified) / 0.06)' }}
+      >
+        <AlertCircle
+          size={14}
+          className="text-[hsl(var(--git-modified))] mt-0.5"
+          strokeWidth={1.8}
+        />
+        <div className="min-w-0 flex-1 space-y-1">
+          <p className="text-[11px] font-medium text-foreground">
+            rtk blocked this command (exit 2).
+          </p>
+          {result.blocked.stderr && (
+            <p className="text-[11px] text-foreground/70 font-mono break-all">
+              {result.blocked.stderr}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  const wouldCompress =
+    result.rewrittenCommand !== null && result.rewrittenCommand !== result.testedCommand;
+
+  if (wouldCompress) {
     return (
       <div
         className="mt-3 flex items-start gap-3 p-3 rounded-lg border border-[hsl(var(--git-added))]/40"

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -1130,7 +1130,7 @@ function RtkSection({
           Inject RTK hook in tasks
         </label>
         <ToggleSwitch
-          enabled={!!status?.enabled}
+          enabled={status?.installed ? status.enabled : false}
           onToggle={onEnabledChange}
           disabled={!status?.installed}
           label="Compress Bash output via rtk before Claude reads it"
@@ -1191,129 +1191,134 @@ function RtkTestResultCard({ result }: { result: RtkTestResult }) {
     );
   }
 
-  if (result.blocked) {
-    return (
-      <div
-        className="mt-3 flex items-start gap-3 p-3 rounded-lg border border-[hsl(var(--git-modified))]/40"
-        style={{ background: 'hsl(var(--git-modified) / 0.06)' }}
-      >
-        <AlertCircle
-          size={14}
-          className="text-[hsl(var(--git-modified))] mt-0.5"
-          strokeWidth={1.8}
-        />
-        <div className="min-w-0 flex-1 space-y-1">
-          <p className="text-[11px] font-medium text-foreground">
-            rtk blocked this command (exit 2).
-          </p>
-          {result.blocked.stderr && (
-            <p className="text-[11px] text-foreground/70 font-mono break-all">
-              {result.blocked.stderr}
-            </p>
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  const wouldCompress =
-    result.rewrittenCommand !== null && result.rewrittenCommand !== result.testedCommand;
-
-  if (wouldCompress) {
-    const diff = result.execDiff;
-    const okDiff = diff && diff.kind === 'ok' ? diff : null;
-    const failedDiff = diff && diff.kind === 'failed' ? diff : null;
-    const savedBytes = okDiff ? okDiff.rawBytes - okDiff.compressedBytes : 0;
-    const savedPct =
-      okDiff && okDiff.rawBytes > 0 ? Math.round((savedBytes / okDiff.rawBytes) * 100) : 0;
-
-    return (
-      <div
-        className="mt-3 p-3 rounded-lg border border-[hsl(var(--git-added))]/40 space-y-3"
-        style={{ background: 'hsl(var(--git-added) / 0.06)' }}
-      >
-        <div className="flex items-start gap-3">
-          <Check size={14} className="text-[hsl(var(--git-added))] mt-0.5" strokeWidth={1.8} />
+  switch (result.outcome.kind) {
+    case 'blocked':
+      return (
+        <div
+          className="mt-3 flex items-start gap-3 p-3 rounded-lg border border-[hsl(var(--git-modified))]/40"
+          style={{ background: 'hsl(var(--git-modified) / 0.06)' }}
+        >
+          <AlertCircle
+            size={14}
+            className="text-[hsl(var(--git-modified))] mt-0.5"
+            strokeWidth={1.8}
+          />
           <div className="min-w-0 flex-1 space-y-1">
             <p className="text-[11px] font-medium text-foreground">
-              Compression active — rtk would rewrite this command.
+              rtk blocked this command (exit 2).
             </p>
-            <div className="text-[11px] text-foreground/70 font-mono space-y-0.5">
-              <div>
-                <span className="text-foreground/40">in: </span>
-                {result.testedCommand}
-              </div>
-              <div>
-                <span className="text-foreground/40">out:</span> {result.rewrittenCommand}
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {okDiff && (
-          <div className="space-y-2 pt-2 border-t border-border/40">
-            <div className="flex items-center justify-between">
-              <span className="text-[10px] font-medium uppercase tracking-wide text-foreground/60">
-                Actual output diff
-              </span>
-              {okDiff.rawBytes > 0 && (
-                <span className="text-[10px] font-mono text-[hsl(var(--git-added))]">
-                  {okDiff.rawBytes} → {okDiff.compressedBytes} bytes
-                  {savedBytes > 0 && ` (−${savedPct}%)`}
-                  {okDiff.truncated && ' · truncated'}
-                </span>
-              )}
-            </div>
-            <div className="grid grid-cols-2 gap-2">
-              <OutputPanel label="raw" body={okDiff.rawStdout} />
-              <OutputPanel label="via rtk" body={okDiff.compressedStdout} accented />
-            </div>
-          </div>
-        )}
-
-        {failedDiff && (
-          // The rewrite-directive check still passed, so rtk's hook plumbing
-          // is fine — but we couldn't capture the before/after. Surface it as
-          // a warning rather than the green "all good" pass-through banner.
-          <div
-            className="space-y-1 pt-2 border-t border-border/40"
-            style={{ borderColor: 'hsl(var(--git-modified) / 0.3)' }}
-          >
-            <span className="text-[10px] font-medium uppercase tracking-wide text-[hsl(var(--git-modified))]">
-              Couldn&rsquo;t capture diff
-            </span>
-            <p className="text-[11px] text-foreground/70">{failedDiff.reason}</p>
-            {failedDiff.stderr && (
-              <pre className="text-[10px] text-foreground/50 font-mono whitespace-pre-wrap break-words">
-                {failedDiff.stderr}
-              </pre>
+            {result.outcome.stderr && (
+              <p className="text-[11px] text-foreground/70 font-mono break-all">
+                {result.outcome.stderr}
+              </p>
             )}
           </div>
-        )}
-      </div>
-    );
-  }
+        </div>
+      );
 
-  // rtk ran cleanly but chose pass-through for our test command.
-  return (
-    <div
-      className="mt-3 flex items-start gap-3 p-3 rounded-lg border border-border/40"
-      style={{ background: 'hsl(var(--surface-2))' }}
-    >
-      <AlertCircle size={14} className="text-[hsl(var(--git-modified))] mt-0.5" strokeWidth={1.8} />
-      <div className="min-w-0 flex-1">
-        <p className="text-[11px] font-medium text-foreground">
-          rtk ran without crashing, but chose not to rewrite this command.
-        </p>
-        <p className="text-[10px] text-foreground/60 mt-1">
-          That&rsquo;s valid — rtk only compresses commands in its rewrite list. The hook plumbing
-          is working; it would compress commands like{' '}
-          <code className="text-foreground/80">git status</code> or{' '}
-          <code className="text-foreground/80">cargo test</code> during real use.
-        </p>
-      </div>
-    </div>
-  );
+    case 'rewritten': {
+      const diff = result.outcome.execDiff;
+      const okDiff = diff && diff.kind === 'ok' ? diff : null;
+      const failedDiff = diff && diff.kind === 'failed' ? diff : null;
+      const savedBytes = okDiff ? okDiff.rawBytes - okDiff.compressedBytes : 0;
+      const savedPct =
+        okDiff && okDiff.rawBytes > 0 ? Math.round((savedBytes / okDiff.rawBytes) * 100) : 0;
+
+      return (
+        <div
+          className="mt-3 p-3 rounded-lg border border-[hsl(var(--git-added))]/40 space-y-3"
+          style={{ background: 'hsl(var(--git-added) / 0.06)' }}
+        >
+          <div className="flex items-start gap-3">
+            <Check size={14} className="text-[hsl(var(--git-added))] mt-0.5" strokeWidth={1.8} />
+            <div className="min-w-0 flex-1 space-y-1">
+              <p className="text-[11px] font-medium text-foreground">
+                Compression active — rtk would rewrite this command.
+              </p>
+              <div className="text-[11px] text-foreground/70 font-mono space-y-0.5">
+                <div>
+                  <span className="text-foreground/40">in: </span>
+                  {result.testedCommand}
+                </div>
+                <div>
+                  <span className="text-foreground/40">out:</span> {result.outcome.rewrittenCommand}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {okDiff && (
+            <div className="space-y-2 pt-2 border-t border-border/40">
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] font-medium uppercase tracking-wide text-foreground/60">
+                  Actual output diff
+                </span>
+                {okDiff.rawBytes > 0 && (
+                  <span className="text-[10px] font-mono text-[hsl(var(--git-added))]">
+                    {okDiff.rawBytes} → {okDiff.compressedBytes} bytes
+                    {savedBytes > 0 && ` (−${savedPct}%)`}
+                    {okDiff.truncated && ' · truncated'}
+                  </span>
+                )}
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <OutputPanel label="raw" body={okDiff.rawStdout} />
+                <OutputPanel label="via rtk" body={okDiff.compressedStdout} accented />
+              </div>
+            </div>
+          )}
+
+          {failedDiff && (
+            <div
+              className="space-y-1 pt-2 border-t border-border/40"
+              style={{ borderColor: 'hsl(var(--git-modified) / 0.3)' }}
+            >
+              <span className="text-[10px] font-medium uppercase tracking-wide text-[hsl(var(--git-modified))]">
+                Couldn&rsquo;t capture diff
+              </span>
+              <p className="text-[11px] text-foreground/70">{failedDiff.reason}</p>
+              {failedDiff.stderr && (
+                <pre className="text-[10px] text-foreground/50 font-mono whitespace-pre-wrap break-words">
+                  {failedDiff.stderr}
+                </pre>
+              )}
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    case 'pass-through':
+      return (
+        <div
+          className="mt-3 flex items-start gap-3 p-3 rounded-lg border border-border/40"
+          style={{ background: 'hsl(var(--surface-2))' }}
+        >
+          <AlertCircle
+            size={14}
+            className="text-[hsl(var(--git-modified))] mt-0.5"
+            strokeWidth={1.8}
+          />
+          <div className="min-w-0 flex-1">
+            <p className="text-[11px] font-medium text-foreground">
+              rtk ran without crashing, but chose not to rewrite this command.
+            </p>
+            <p className="text-[10px] text-foreground/60 mt-1">
+              That&rsquo;s valid — rtk only compresses commands in its rewrite list. The hook
+              plumbing is working; it would compress commands like{' '}
+              <code className="text-foreground/80">git status</code> or{' '}
+              <code className="text-foreground/80">cargo test</code> during real use.
+            </p>
+          </div>
+        </div>
+      );
+
+    default: {
+      const _exhaustive: never = result.outcome;
+      void _exhaustive;
+      return null;
+    }
+  }
 }
 
 function OutputPanel({

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -974,14 +974,12 @@ function RtkStatusCardBody({ status }: { status: RtkStatus | null }) {
     return (
       <div className="space-y-0.5">
         <p className="text-[11px] text-foreground/60 font-mono">
-          {status.version ?? 'installed'}
+          {status.version}
           <span className="ml-2 text-foreground/40">
             ({status.source === 'managed' ? 'managed by Dash' : 'on $PATH'})
           </span>
         </p>
-        {status.path && (
-          <p className="text-[11px] text-foreground/40 font-mono truncate">{status.path}</p>
-        )}
+        <p className="text-[11px] text-foreground/40 font-mono truncate">{status.path}</p>
       </div>
     );
   }
@@ -1009,6 +1007,29 @@ function RtkStatusCardBody({ status }: { status: RtkStatus | null }) {
   );
 }
 
+function labelForProgress(progress: RtkDownloadProgress | null): {
+  installing: boolean;
+  installLabel: string;
+} {
+  if (!progress) return { installing: false, installLabel: 'Install RTK' };
+  switch (progress.phase) {
+    case 'downloading':
+      return { installing: true, installLabel: `Downloading… ${progress.percent}%` };
+    case 'verifying':
+      return { installing: true, installLabel: 'Verifying…' };
+    case 'extracting':
+      return { installing: true, installLabel: 'Extracting…' };
+    case 'done':
+    case 'error':
+      return { installing: false, installLabel: 'Install RTK' };
+    default: {
+      const _exhaustive: never = progress;
+      void _exhaustive;
+      return { installing: false, installLabel: 'Install RTK' };
+    }
+  }
+}
+
 function RtkSection({
   status,
   onEnabledChange,
@@ -1020,10 +1041,6 @@ function RtkSection({
   onDownload: () => void;
   progress: RtkDownloadProgress | null;
 }) {
-  const installing =
-    progress?.phase === 'downloading' ||
-    progress?.phase === 'extracting' ||
-    progress?.phase === 'verifying';
   const loading = !status;
 
   const [testing, setTesting] = useState(false);
@@ -1041,10 +1058,7 @@ function RtkSection({
     }
   }
 
-  let installLabel = 'Install RTK';
-  if (progress?.phase === 'extracting') installLabel = 'Extracting…';
-  else if (progress?.phase === 'verifying') installLabel = 'Verifying…';
-  else if (progress?.phase === 'downloading') installLabel = `Downloading… ${progress.percent}%`;
+  const { installing, installLabel } = labelForProgress(progress);
 
   return (
     <div className="space-y-6">
@@ -1311,6 +1325,7 @@ export function SettingsModal({
     'keybindings',
     'usage',
     'pixel-agents',
+    'rtk',
   ];
   const [tab, setTab] = useState<SettingsTab>(
     initialTab && validTabs.includes(initialTab as SettingsTab)

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -966,6 +966,49 @@ function ClaudeCodeTab({
   );
 }
 
+function RtkStatusCardBody({ status }: { status: RtkStatus | null }) {
+  if (!status) {
+    return <p className="text-[11px] text-foreground/60">Checking…</p>;
+  }
+  if (status.installed) {
+    return (
+      <div className="space-y-0.5">
+        <p className="text-[11px] text-foreground/60 font-mono">
+          {status.version ?? 'installed'}
+          <span className="ml-2 text-foreground/40">
+            ({status.source === 'managed' ? 'managed by Dash' : 'on $PATH'})
+          </span>
+        </p>
+        {status.path && (
+          <p className="text-[11px] text-foreground/40 font-mono truncate">{status.path}</p>
+        )}
+      </div>
+    );
+  }
+  if (status.downloadable) {
+    return (
+      <p className="text-[11px] text-foreground/60 leading-relaxed">
+        Not installed. Dash can fetch the latest release directly — no sudo, no global $PATH
+        changes, binary stays scoped to this app.
+      </p>
+    );
+  }
+  return (
+    <p className="text-[11px] text-foreground/60 leading-relaxed">
+      Not installed, and no prebuilt release is available for this platform. Install manually from{' '}
+      <a
+        href="https://github.com/rtk-ai/rtk"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary hover:underline"
+      >
+        github.com/rtk-ai/rtk
+      </a>
+      .
+    </p>
+  );
+}
+
 function RtkSection({
   status,
   onEnabledChange,
@@ -1038,40 +1081,7 @@ function RtkSection({
           )}
         </div>
         <div className="min-w-0 flex-1">
-          {loading ? (
-            <p className="text-[11px] text-foreground/60">Checking…</p>
-          ) : status?.installed ? (
-            <div className="space-y-0.5">
-              <p className="text-[11px] text-foreground/60 font-mono">
-                {status.version ?? 'installed'}
-                <span className="ml-2 text-foreground/40">
-                  ({status.source === 'managed' ? 'managed by Dash' : 'on $PATH'})
-                </span>
-              </p>
-              {status.path && (
-                <p className="text-[11px] text-foreground/40 font-mono truncate">{status.path}</p>
-              )}
-            </div>
-          ) : status?.downloadable ? (
-            <p className="text-[11px] text-foreground/60 leading-relaxed">
-              Not installed. Dash can fetch the latest release directly — no sudo, no global $PATH
-              changes, binary stays scoped to this app.
-            </p>
-          ) : (
-            <p className="text-[11px] text-foreground/60 leading-relaxed">
-              Not installed, and no prebuilt release is available for this platform. Install
-              manually from{' '}
-              <a
-                href="https://github.com/rtk-ai/rtk"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary hover:underline"
-              >
-                github.com/rtk-ai/rtk
-              </a>
-              .
-            </p>
-          )}
+          <RtkStatusCardBody status={status} />
         </div>
       </div>
 

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -1221,8 +1221,11 @@ function RtkTestResultCard({ result }: { result: RtkTestResult }) {
 
   if (wouldCompress) {
     const diff = result.execDiff;
-    const savedBytes = diff ? diff.rawBytes - diff.compressedBytes : 0;
-    const savedPct = diff && diff.rawBytes > 0 ? Math.round((savedBytes / diff.rawBytes) * 100) : 0;
+    const okDiff = diff && diff.kind === 'ok' ? diff : null;
+    const failedDiff = diff && diff.kind === 'failed' ? diff : null;
+    const savedBytes = okDiff ? okDiff.rawBytes - okDiff.compressedBytes : 0;
+    const savedPct =
+      okDiff && okDiff.rawBytes > 0 ? Math.round((savedBytes / okDiff.rawBytes) * 100) : 0;
 
     return (
       <div
@@ -1247,23 +1250,44 @@ function RtkTestResultCard({ result }: { result: RtkTestResult }) {
           </div>
         </div>
 
-        {diff && (
+        {okDiff && (
           <div className="space-y-2 pt-2 border-t border-border/40">
             <div className="flex items-center justify-between">
               <span className="text-[10px] font-medium uppercase tracking-wide text-foreground/60">
                 Actual output diff
               </span>
-              {diff.rawBytes > 0 && (
+              {okDiff.rawBytes > 0 && (
                 <span className="text-[10px] font-mono text-[hsl(var(--git-added))]">
-                  {diff.rawBytes} → {diff.compressedBytes} bytes
+                  {okDiff.rawBytes} → {okDiff.compressedBytes} bytes
                   {savedBytes > 0 && ` (−${savedPct}%)`}
+                  {okDiff.truncated && ' · truncated'}
                 </span>
               )}
             </div>
             <div className="grid grid-cols-2 gap-2">
-              <OutputPanel label="raw" body={diff.rawStdout} />
-              <OutputPanel label="via rtk" body={diff.compressedStdout} accented />
+              <OutputPanel label="raw" body={okDiff.rawStdout} />
+              <OutputPanel label="via rtk" body={okDiff.compressedStdout} accented />
             </div>
+          </div>
+        )}
+
+        {failedDiff && (
+          // The rewrite-directive check still passed, so rtk's hook plumbing
+          // is fine — but we couldn't capture the before/after. Surface it as
+          // a warning rather than the green "all good" pass-through banner.
+          <div
+            className="space-y-1 pt-2 border-t border-border/40"
+            style={{ borderColor: 'hsl(var(--git-modified) / 0.3)' }}
+          >
+            <span className="text-[10px] font-medium uppercase tracking-wide text-[hsl(var(--git-modified))]">
+              Couldn&rsquo;t capture diff
+            </span>
+            <p className="text-[11px] text-foreground/70">{failedDiff.reason}</p>
+            {failedDiff.stderr && (
+              <pre className="text-[10px] text-foreground/50 font-mono whitespace-pre-wrap break-words">
+                {failedDiff.stderr}
+              </pre>
+            )}
           </div>
         )}
       </div>

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -1220,26 +1220,52 @@ function RtkTestResultCard({ result }: { result: RtkTestResult }) {
     result.rewrittenCommand !== null && result.rewrittenCommand !== result.testedCommand;
 
   if (wouldCompress) {
+    const diff = result.execDiff;
+    const savedBytes = diff ? diff.rawBytes - diff.compressedBytes : 0;
+    const savedPct = diff && diff.rawBytes > 0 ? Math.round((savedBytes / diff.rawBytes) * 100) : 0;
+
     return (
       <div
-        className="mt-3 flex items-start gap-3 p-3 rounded-lg border border-[hsl(var(--git-added))]/40"
+        className="mt-3 p-3 rounded-lg border border-[hsl(var(--git-added))]/40 space-y-3"
         style={{ background: 'hsl(var(--git-added) / 0.06)' }}
       >
-        <Check size={14} className="text-[hsl(var(--git-added))] mt-0.5" strokeWidth={1.8} />
-        <div className="min-w-0 flex-1 space-y-1">
-          <p className="text-[11px] font-medium text-foreground">
-            Compression active — rtk would rewrite this command.
-          </p>
-          <div className="text-[11px] text-foreground/70 font-mono space-y-0.5">
-            <div>
-              <span className="text-foreground/40">in: </span>
-              {result.testedCommand}
-            </div>
-            <div>
-              <span className="text-foreground/40">out:</span> {result.rewrittenCommand}
+        <div className="flex items-start gap-3">
+          <Check size={14} className="text-[hsl(var(--git-added))] mt-0.5" strokeWidth={1.8} />
+          <div className="min-w-0 flex-1 space-y-1">
+            <p className="text-[11px] font-medium text-foreground">
+              Compression active — rtk would rewrite this command.
+            </p>
+            <div className="text-[11px] text-foreground/70 font-mono space-y-0.5">
+              <div>
+                <span className="text-foreground/40">in: </span>
+                {result.testedCommand}
+              </div>
+              <div>
+                <span className="text-foreground/40">out:</span> {result.rewrittenCommand}
+              </div>
             </div>
           </div>
         </div>
+
+        {diff && (
+          <div className="space-y-2 pt-2 border-t border-border/40">
+            <div className="flex items-center justify-between">
+              <span className="text-[10px] font-medium uppercase tracking-wide text-foreground/60">
+                Actual output diff
+              </span>
+              {diff.rawBytes > 0 && (
+                <span className="text-[10px] font-mono text-[hsl(var(--git-added))]">
+                  {diff.rawBytes} → {diff.compressedBytes} bytes
+                  {savedBytes > 0 && ` (−${savedPct}%)`}
+                </span>
+              )}
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <OutputPanel label="raw" body={diff.rawStdout} />
+              <OutputPanel label="via rtk" body={diff.compressedStdout} accented />
+            </div>
+          </div>
+        )}
       </div>
     );
   }
@@ -1262,6 +1288,39 @@ function RtkTestResultCard({ result }: { result: RtkTestResult }) {
           <code className="text-foreground/80">cargo test</code> during real use.
         </p>
       </div>
+    </div>
+  );
+}
+
+function OutputPanel({
+  label,
+  body,
+  accented,
+}: {
+  label: string;
+  body: string;
+  accented?: boolean;
+}) {
+  const displayBody = body.trim().length > 0 ? body : '(empty)';
+  return (
+    <div
+      className={`rounded-md border text-[10px] font-mono leading-[1.35] overflow-hidden ${
+        accented ? 'border-[hsl(var(--git-added))]/40' : 'border-border/50'
+      }`}
+      style={{ background: 'hsl(var(--surface-1))' }}
+    >
+      <div
+        className={`px-2 py-1 text-[9px] font-sans uppercase tracking-wide ${
+          accented
+            ? 'text-[hsl(var(--git-added))] bg-[hsl(var(--git-added))]/5'
+            : 'text-foreground/50 bg-[hsl(var(--surface-2))]'
+        }`}
+      >
+        {label}
+      </div>
+      <pre className="px-2 py-1.5 max-h-48 overflow-auto whitespace-pre-wrap break-words text-foreground/80">
+        {displayBody}
+      </pre>
     </div>
   );
 }

--- a/src/renderer/components/ui/ToggleSwitch.tsx
+++ b/src/renderer/components/ui/ToggleSwitch.tsx
@@ -4,15 +4,20 @@ export function ToggleSwitch({
   enabled,
   onToggle,
   label,
+  disabled,
 }: {
   enabled: boolean;
   onToggle: (value: boolean) => void;
   label: string;
+  disabled?: boolean;
 }) {
   return (
     <button
-      onClick={() => onToggle(!enabled)}
+      onClick={() => !disabled && onToggle(!enabled)}
+      disabled={disabled}
       className={`flex items-center gap-3 w-full px-4 py-3 rounded-lg text-[13px] border transition-all duration-150 ${
+        disabled ? 'opacity-50 cursor-not-allowed' : ''
+      } ${
         enabled
           ? 'border-primary/40 bg-primary/8 text-foreground ring-1 ring-primary/20'
           : 'border-border/60 text-foreground/60 hover:bg-accent/40 hover:text-foreground'

--- a/src/renderer/components/ui/ToggleSwitch.tsx
+++ b/src/renderer/components/ui/ToggleSwitch.tsx
@@ -13,7 +13,7 @@ export function ToggleSwitch({
 }) {
   return (
     <button
-      onClick={() => !disabled && onToggle(!enabled)}
+      onClick={() => onToggle(!enabled)}
       disabled={disabled}
       className={`flex items-center gap-3 w-full px-4 py-3 rounded-lg text-[13px] border transition-all duration-150 ${
         disabled ? 'opacity-50 cursor-not-allowed' : ''

--- a/src/renderer/hooks/useThresholdAlerts.ts
+++ b/src/renderer/hooks/useThresholdAlerts.ts
@@ -1,60 +1,67 @@
 import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
-import type { StatusLineData, UsageThresholds } from '../../shared/types';
+import type { RateLimits, StatusLineData, UsageThresholds } from '../../shared/types';
 
 export function useThresholdAlerts(
   statusLineData: Record<string, StatusLineData>,
+  latestRateLimits: RateLimits | undefined,
   usageThresholds: UsageThresholds,
   taskNames: Record<string, string>,
 ) {
   const firedRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    // Prune fired keys for PTYs that no longer exist
+    // Prune fired context keys for PTYs that no longer exist. Global
+    // rate-limit keys ('global:*') are kept across PTY churn.
     for (const key of firedRef.current) {
+      if (key.startsWith('global:')) continue;
       const ptyId = key.split(':')[0];
       if (!statusLineData[ptyId]) {
         firedRef.current.delete(key);
       }
     }
 
-    for (const [ptyId, sl] of Object.entries(statusLineData)) {
-      const checks: [string, number, number | null][] = [
-        ['context', sl.contextUsage.percentage, usageThresholds.contextPercentage],
-        [
-          'fiveHour',
-          sl.rateLimits?.fiveHour?.usedPercentage ?? 0,
-          usageThresholds.fiveHourPercentage,
-        ],
-        [
-          'sevenDay',
-          sl.rateLimits?.sevenDay?.usedPercentage ?? 0,
-          usageThresholds.sevenDayPercentage,
-        ],
-      ];
-      const taskName = taskNames[ptyId];
-      for (const [kind, value, threshold] of checks) {
-        if (threshold === null || threshold <= 0) continue;
-        const key = `${ptyId}:${kind}`;
-
-        // Hysteresis: clear fired state when value drops below 90% of threshold
-        if (value < threshold * 0.9) {
-          firedRef.current.delete(key);
-          continue;
-        }
-
-        if (value >= threshold && !firedRef.current.has(key)) {
-          firedRef.current.add(key);
-          const pct = Math.round(value);
-          const labels: Record<string, string> = {
-            context: `Context window at ${pct}%`,
-            fiveHour: `5-hour rate limit at ${pct}%`,
-            sevenDay: `7-day rate limit at ${pct}%`,
-          };
-          const base = labels[kind] || `Usage threshold reached: ${kind}`;
-          toast.warning(taskName ? `${taskName}: ${base}` : base);
-        }
+    const fire = (key: string, value: number, threshold: number | null, label: string) => {
+      if (threshold === null || threshold <= 0) return;
+      if (value < threshold * 0.9) {
+        firedRef.current.delete(key);
+        return;
       }
+      if (value >= threshold && !firedRef.current.has(key)) {
+        firedRef.current.add(key);
+        toast.warning(label);
+      }
+    };
+
+    // Context window is per-session, so check each PTY independently.
+    for (const [ptyId, sl] of Object.entries(statusLineData)) {
+      const taskName = taskNames[ptyId];
+      const pct = Math.round(sl.contextUsage.percentage);
+      const base = `Context window at ${pct}%`;
+      fire(
+        `${ptyId}:context`,
+        sl.contextUsage.percentage,
+        usageThresholds.contextPercentage,
+        taskName ? `${taskName}: ${base}` : base,
+      );
     }
-  }, [statusLineData, usageThresholds, taskNames]);
+
+    // Rate limits are account-wide. Per-PTY status-line snapshots can be
+    // stale (e.g. a resumed old chat reports a stale rate_limits value),
+    // so check against the most-recent snapshot only.
+    const fh = latestRateLimits?.fiveHour?.usedPercentage ?? 0;
+    fire(
+      'global:fiveHour',
+      fh,
+      usageThresholds.fiveHourPercentage,
+      `5-hour rate limit at ${Math.round(fh)}%`,
+    );
+    const sd = latestRateLimits?.sevenDay?.usedPercentage ?? 0;
+    fire(
+      'global:sevenDay',
+      sd,
+      usageThresholds.sevenDayPercentage,
+      `7-day rate limit at ${Math.round(sd)}%`,
+    );
+  }, [statusLineData, latestRateLimits, usageThresholds, taskNames]);
 }

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -779,12 +779,18 @@ export class TerminalSessionManager {
     if (this.disposed || !this.opened) return;
     try {
       const data = this.serializeAddon.serialize();
+      // Skip empty serializations — happens when detach() fires while the
+      // container is un-laid-out. Writing "" would clobber the good snapshot
+      // and the pane would look blank on re-open.
+      if (!data) return;
       const dims = this.fitAddon.proposeDimensions();
+      const cols = Number.isFinite(dims?.cols) ? (dims!.cols as number) : 120;
+      const rows = Number.isFinite(dims?.rows) ? (dims!.rows as number) : 30;
       const snapshot: TerminalSnapshot = {
         version: 1,
         createdAt: new Date().toISOString(),
-        cols: dims?.cols ?? 120,
-        rows: dims?.rows ?? 30,
+        cols,
+        rows,
         data,
       };
       window.electronAPI.ptySaveSnapshot(this.id, snapshot);

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -160,7 +160,11 @@ export class TerminalSessionManager {
         const sel = this.terminal.getSelection() || (isExplicitCopy ? this.lastSelection : '');
         if (sel) {
           e.preventDefault();
-          window.electronAPI.clipboardWriteText(sel);
+          // Surface clipboard write failures — fire-and-forget would let the
+          // user paste stale content elsewhere with no signal that copy failed.
+          window.electronAPI.clipboardWriteText(sel).catch((err: unknown) => {
+            console.warn('[terminal] clipboardWriteText failed:', err);
+          });
           return false;
         }
       }
@@ -171,9 +175,16 @@ export class TerminalSessionManager {
         (!isMac && e.ctrlKey && e.shiftKey && isKeyV)
       ) {
         e.preventDefault();
-        window.electronAPI.clipboardReadText().then((text) => {
-          if (text) window.electronAPI.ptyInput({ id: this.id, data: text });
-        });
+        window.electronAPI
+          .clipboardReadText()
+          .then((text) => {
+            if (text) window.electronAPI.ptyInput({ id: this.id, data: text });
+          })
+          .catch((err: unknown) => {
+            // Without this catch the rejection becomes an unhandled promise
+            // and the user sees "paste did nothing" with no diagnostic.
+            console.warn('[terminal] clipboardReadText failed:', err);
+          });
         return false;
       }
 

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -42,6 +42,11 @@ export class TerminalSessionManager {
   private savedViewportY: number | null = null;
   readonly shellOnly: boolean;
   private themeId: string;
+  // Claude Code's TUI rewrites cells continuously, which causes xterm to drop
+  // the visible selection before the user can press the copy shortcut. Cache
+  // the last non-empty selection on every change so Ctrl+Shift+C / Cmd+C can
+  // still copy it even after xterm has cleared the highlight.
+  private lastSelection = '';
   constructor(opts: {
     id: string;
     cwd: string;
@@ -108,6 +113,13 @@ export class TerminalSessionManager {
       ),
     );
 
+    // Cache selection on every change — Claude Code's TUI rewrites cells as the
+    // user drags, which clears xterm's selection before the copy shortcut fires.
+    this.terminal.onSelectionChange(() => {
+      const sel = this.terminal.getSelection();
+      if (sel) this.lastSelection = sel;
+    });
+
     // Track cwd via OSC 7 (emitted by zsh on macOS by default)
     this.terminal.parser.registerOscHandler(7, (data) => {
       try {
@@ -130,29 +142,36 @@ export class TerminalSessionManager {
 
       const isMac = navigator.userAgent.includes('Mac');
 
-      // Copy: Cmd+C (macOS) or Ctrl+Shift+C (Linux) — copy terminal selection
+      // Match by physical key (e.code) so alternate keyboard layouts where
+      // Ctrl+Shift+C reports e.key as something other than 'C' still work.
+      const isKeyC = e.code === 'KeyC';
+      const isKeyV = e.code === 'KeyV';
+
+      // Copy: Cmd+C (macOS) or Ctrl+Shift+C (Linux) — copy terminal selection.
       // Also Ctrl+C on any platform when there's an active selection (matches
-      // native terminal behaviour: Ctrl+C copies when selected, sends SIGINT otherwise)
-      if (
-        (isMac && e.metaKey && e.key === 'c') ||
-        (!isMac && e.ctrlKey && e.shiftKey && e.key === 'C') ||
-        (e.ctrlKey && !e.shiftKey && e.key === 'c' && this.terminal.hasSelection())
-      ) {
-        const sel = this.terminal.getSelection();
+      // native terminal behaviour: Ctrl+C copies when selected, sends SIGINT
+      // otherwise). Explicit shortcuts fall back to lastSelection so users can
+      // still copy after the TUI has cleared xterm's highlight.
+      const isExplicitCopy =
+        (isMac && e.metaKey && isKeyC && !e.ctrlKey) ||
+        (!isMac && e.ctrlKey && e.shiftKey && isKeyC);
+      const isPlainCtrlC = e.ctrlKey && !e.shiftKey && isKeyC && this.terminal.hasSelection();
+      if (isExplicitCopy || isPlainCtrlC) {
+        const sel = this.terminal.getSelection() || (isExplicitCopy ? this.lastSelection : '');
         if (sel) {
           e.preventDefault();
-          navigator.clipboard.writeText(sel);
+          window.electronAPI.clipboardWriteText(sel);
           return false;
         }
       }
 
       // Paste: Cmd+V (macOS) or Ctrl+Shift+V (Linux)
       if (
-        (isMac && e.metaKey && e.key === 'v') ||
-        (!isMac && e.ctrlKey && e.shiftKey && e.key === 'V')
+        (isMac && e.metaKey && isKeyV && !e.ctrlKey) ||
+        (!isMac && e.ctrlKey && e.shiftKey && isKeyV)
       ) {
         e.preventDefault();
-        navigator.clipboard.readText().then((text) => {
+        window.electronAPI.clipboardReadText().then((text) => {
           if (text) window.electronAPI.ptyInput({ id: this.id, data: text });
         });
         return false;

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -113,8 +113,6 @@ export class TerminalSessionManager {
       ),
     );
 
-    // Cache selection on every change — Claude Code's TUI rewrites cells as the
-    // user drags, which clears xterm's selection before the copy shortcut fires.
     this.terminal.onSelectionChange(() => {
       const sel = this.terminal.getSelection();
       if (sel) this.lastSelection = sel;
@@ -330,8 +328,11 @@ export class TerminalSessionManager {
           if (snapshotResp.success && snapshotResp.data) {
             existingSnapshot = snapshotResp.data;
           }
-        } catch {
-          // Best effort
+        } catch (err) {
+          // Snapshot fetch via IPC: legitimate "no snapshot" arrives as a
+          // success with empty data, so reaching the catch means IPC itself
+          // misbehaved — log so a permanently broken bridge is debuggable.
+          console.warn('[terminal] ptyGetSnapshot failed:', err);
         }
         if (gen !== this.attachGeneration) return;
 
@@ -349,8 +350,11 @@ export class TerminalSessionManager {
         if (existingSnapshot && !reattached) {
           try {
             this.terminal.write(existingSnapshot.data);
-          } catch {
-            // Best effort
+          } catch (err) {
+            // xterm rejected the buffered bytes — usually a corrupt or
+            // malformed control sequence in the snapshot. Without logging,
+            // the user just sees a half-rendered terminal with no clue why.
+            console.warn('[terminal] writing snapshot to xterm failed:', err);
           }
         }
       } else {
@@ -363,8 +367,11 @@ export class TerminalSessionManager {
           if (snapshotResp.success && snapshotResp.data) {
             existingSnapshot = snapshotResp.data;
           }
-        } catch {
-          // Best effort
+        } catch (err) {
+          // Snapshot fetch via IPC: legitimate "no snapshot" arrives as a
+          // success with empty data, so reaching the catch means IPC itself
+          // misbehaved — log so a permanently broken bridge is debuggable.
+          console.warn('[terminal] ptyGetSnapshot failed:', err);
         }
         if (gen !== this.attachGeneration) return;
 
@@ -398,8 +405,11 @@ export class TerminalSessionManager {
         if (existingSnapshot && !result.reattached) {
           try {
             this.terminal.write(existingSnapshot.data);
-          } catch {
-            // Best effort
+          } catch (err) {
+            // xterm rejected the buffered bytes — usually a corrupt or
+            // malformed control sequence in the snapshot. Without logging,
+            // the user just sees a half-rendered terminal with no clue why.
+            console.warn('[terminal] writing snapshot to xterm failed:', err);
           }
         }
       }
@@ -806,8 +816,10 @@ export class TerminalSessionManager {
       };
       window.electronAPI.ptySaveSnapshot(this.id, snapshot);
       this.snapshotDirty = false;
-    } catch {
-      // Best effort
+    } catch (err) {
+      // Serialize / IPC failure. If snapshots are silently broken, the user
+      // sees a blank terminal on next reload with no way to attribute it.
+      console.warn('[terminal] saveSnapshot failed:', err);
     }
   }
 
@@ -818,8 +830,8 @@ export class TerminalSessionManager {
         this.terminal.write(resp.data.data);
         return true;
       }
-    } catch {
-      // Best effort
+    } catch (err) {
+      console.warn('[terminal] restoreSnapshot failed:', err);
     }
     return false;
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -376,48 +376,35 @@ export interface PixelAgentsStatus {
 
 // ── RTK (Rust Token Killer) Types ───────────────────────────
 
-/** Where the rtk binary was resolved from. */
 export type RtkSource = 'path' | 'managed' | 'none';
 
 export interface RtkStatus {
-  /** Whether an rtk binary is resolvable right now. */
   installed: boolean;
-  /** Version string from `rtk --version`, if resolvable. */
   version: string | null;
-  /** Absolute path to the resolved binary, or null. */
   path: string | null;
-  /** 'path' = user-installed on $PATH, 'managed' = downloaded by Dash, 'none' = not installed. */
   source: RtkSource;
-  /** User has flipped the "inject RTK hook per task" toggle on. */
   enabled: boolean;
-  /** Whether Dash can auto-download rtk for this platform (no Windows release upstream). */
   downloadable: boolean;
 }
 
-export type RtkDownloadPhase = 'idle' | 'downloading' | 'extracting' | 'done' | 'error';
+export type RtkDownloadProgress =
+  | { phase: 'idle' }
+  | { phase: 'downloading'; percent: number }
+  | { phase: 'verifying' }
+  | { phase: 'extracting' }
+  | { phase: 'done'; version: string }
+  | { phase: 'error'; error: string };
 
-export interface RtkDownloadProgress {
-  phase: RtkDownloadPhase;
-  /** 0–100 for 'downloading', undefined otherwise. */
-  percent?: number;
-  /** Set when phase === 'error'. */
-  error?: string;
-  /** Resolved tag (e.g. "v0.42.0") when phase === 'done'. */
-  version?: string;
-}
+export type RtkDownloadPhase = RtkDownloadProgress['phase'];
 
-/** Result of invoking `rtk hook claude` against a synthetic PreToolUse payload. */
-export interface RtkTestResult {
-  /** Whether rtk ran without crashing — even "no rewrite" is a valid pass. */
-  ok: boolean;
-  /** Command we fed rtk (shown in UI so the user knows what was tested). */
-  testedCommand?: string;
-  /** Command rtk would substitute in, or null if it chose pass-through. */
-  rewrittenCommand?: string | null;
-  /** True when rtk actually emitted a rewrite directive (proof of compression). */
-  wouldCompress?: boolean;
-  /** Trimmed stdout for the debug disclosure. Max ~2 KB. */
-  rawOutput?: string;
-  /** Populated on crash / missing binary / stderr panic. */
-  error?: string;
-}
+export type RtkTestResult =
+  | { ok: false; testedCommand?: string; error: string }
+  | {
+      ok: true;
+      testedCommand: string;
+      rewrittenCommand: string | null;
+      rawOutput: string;
+      // rtk hooks use exit 2 to *block* a command (never the health case for us,
+      // but surface it so the UI can explain the state rather than say "works").
+      blocked?: { stderr: string };
+    };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -378,6 +378,10 @@ export interface PixelAgentsStatus {
 
 export type RtkSource = 'path' | 'managed';
 
+// `enabled` only makes sense when a binary is installed — RtkService.setEnabled
+// throws if you try to enable without resolution. Encoding the rule in the
+// type means TS prevents the impossible state at construction; the IPC
+// pre-flight check that previously enforced it at runtime can be dropped.
 export type RtkStatus =
   | {
       installed: true;
@@ -387,11 +391,7 @@ export type RtkStatus =
       enabled: boolean;
       downloadable: boolean;
     }
-  | {
-      installed: false;
-      enabled: boolean;
-      downloadable: boolean;
-    };
+  | { installed: false; downloadable: boolean };
 
 export type RtkDownloadProgress =
   | { phase: 'downloading'; percent: number }
@@ -430,16 +430,24 @@ export type RtkExecDiff =
       reason: string;
     };
 
+// Three orthogonal optionals (`rewrittenCommand: string | null`, `blocked?`,
+// `execDiff?`) admitted impossible combinations in production code (e.g.
+// blocked AND rewritten). A nested outcome discriminant collapses them so
+// the renderer's three branches map 1:1 to representable states.
 export type RtkTestResult =
   | { ok: false; testedCommand?: string; error: string }
   | {
       ok: true;
       testedCommand: string;
-      rewrittenCommand: string | null;
       rawOutput: string;
-      // rtk uses exit 2 to *block* a tool call — surface it so the UI can
-      // explain the state rather than collapse to a binary ok/fail.
-      blocked?: { stderr: string };
-      /** Real before/after captured by actually running both commands. */
-      execDiff?: RtkExecDiff;
+      outcome: RtkTestOutcome;
     };
+
+export type RtkTestOutcome =
+  // rtk ran cleanly and chose pass-through (no rewrite for this command).
+  | { kind: 'pass-through' }
+  // rtk used exit 2 to block the tool call. Distinct from a failure.
+  | { kind: 'blocked'; stderr: string }
+  // rtk emitted a rewrite. execDiff is best-effort visualization, not a
+  // correctness signal — its absence/failure does not invalidate the rewrite.
+  | { kind: 'rewritten'; rewrittenCommand: string; execDiff?: RtkExecDiff };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -373,3 +373,51 @@ export interface PixelAgentsStatus {
   running: boolean;
   offices: Record<string, PixelAgentsOfficeStatus>;
 }
+
+// ── RTK (Rust Token Killer) Types ───────────────────────────
+
+/** Where the rtk binary was resolved from. */
+export type RtkSource = 'path' | 'managed' | 'none';
+
+export interface RtkStatus {
+  /** Whether an rtk binary is resolvable right now. */
+  installed: boolean;
+  /** Version string from `rtk --version`, if resolvable. */
+  version: string | null;
+  /** Absolute path to the resolved binary, or null. */
+  path: string | null;
+  /** 'path' = user-installed on $PATH, 'managed' = downloaded by Dash, 'none' = not installed. */
+  source: RtkSource;
+  /** User has flipped the "inject RTK hook per task" toggle on. */
+  enabled: boolean;
+  /** Whether Dash can auto-download rtk for this platform (no Windows release upstream). */
+  downloadable: boolean;
+}
+
+export type RtkDownloadPhase = 'idle' | 'downloading' | 'extracting' | 'done' | 'error';
+
+export interface RtkDownloadProgress {
+  phase: RtkDownloadPhase;
+  /** 0–100 for 'downloading', undefined otherwise. */
+  percent?: number;
+  /** Set when phase === 'error'. */
+  error?: string;
+  /** Resolved tag (e.g. "v0.42.0") when phase === 'done'. */
+  version?: string;
+}
+
+/** Result of invoking `rtk hook claude` against a synthetic PreToolUse payload. */
+export interface RtkTestResult {
+  /** Whether rtk ran without crashing — even "no rewrite" is a valid pass. */
+  ok: boolean;
+  /** Command we fed rtk (shown in UI so the user knows what was tested). */
+  testedCommand?: string;
+  /** Command rtk would substitute in, or null if it chose pass-through. */
+  rewrittenCommand?: string | null;
+  /** True when rtk actually emitted a rewrite directive (proof of compression). */
+  wouldCompress?: boolean;
+  /** Trimmed stdout for the debug disclosure. Max ~2 KB. */
+  rawOutput?: string;
+  /** Populated on crash / missing binary / stderr panic. */
+  error?: string;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -376,26 +376,29 @@ export interface PixelAgentsStatus {
 
 // ── RTK (Rust Token Killer) Types ───────────────────────────
 
-export type RtkSource = 'path' | 'managed' | 'none';
+export type RtkSource = 'path' | 'managed';
 
-export interface RtkStatus {
-  installed: boolean;
-  version: string | null;
-  path: string | null;
-  source: RtkSource;
-  enabled: boolean;
-  downloadable: boolean;
-}
+export type RtkStatus =
+  | {
+      installed: true;
+      version: string;
+      path: string;
+      source: RtkSource;
+      enabled: boolean;
+      downloadable: boolean;
+    }
+  | {
+      installed: false;
+      enabled: boolean;
+      downloadable: boolean;
+    };
 
 export type RtkDownloadProgress =
-  | { phase: 'idle' }
   | { phase: 'downloading'; percent: number }
   | { phase: 'verifying' }
   | { phase: 'extracting' }
   | { phase: 'done'; version: string }
   | { phase: 'error'; error: string };
-
-export type RtkDownloadPhase = RtkDownloadProgress['phase'];
 
 export type RtkTestResult =
   | { ok: false; testedCommand?: string; error: string }
@@ -404,7 +407,7 @@ export type RtkTestResult =
       testedCommand: string;
       rewrittenCommand: string | null;
       rawOutput: string;
-      // rtk hooks use exit 2 to *block* a command (never the health case for us,
-      // but surface it so the UI can explain the state rather than say "works").
+      // rtk uses exit 2 to *block* a tool call — surface it so the UI can
+      // explain the state rather than collapse to a binary ok/fail.
       blocked?: { stderr: string };
     };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -400,6 +400,16 @@ export type RtkDownloadProgress =
   | { phase: 'done'; version: string }
   | { phase: 'error'; error: string };
 
+export interface RtkExecDiff {
+  /** Stdout of the raw tested command, capped for IPC payload size. */
+  rawStdout: string;
+  /** Stdout of the rtk-rewritten command, capped for IPC payload size. */
+  compressedStdout: string;
+  /** Untruncated byte counts, so the UI can show honest savings math. */
+  rawBytes: number;
+  compressedBytes: number;
+}
+
 export type RtkTestResult =
   | { ok: false; testedCommand?: string; error: string }
   | {
@@ -410,4 +420,6 @@ export type RtkTestResult =
       // rtk uses exit 2 to *block* a tool call — surface it so the UI can
       // explain the state rather than collapse to a binary ok/fail.
       blocked?: { stderr: string };
+      /** Real before/after captured by actually running both commands. */
+      execDiff?: RtkExecDiff;
     };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -400,15 +400,35 @@ export type RtkDownloadProgress =
   | { phase: 'done'; version: string }
   | { phase: 'error'; error: string };
 
-export interface RtkExecDiff {
-  /** Stdout of the raw tested command, capped for IPC payload size. */
-  rawStdout: string;
-  /** Stdout of the rtk-rewritten command, capped for IPC payload size. */
-  compressedStdout: string;
-  /** Untruncated byte counts, so the UI can show honest savings math. */
-  rawBytes: number;
-  compressedBytes: number;
-}
+export type RtkExecDiff =
+  | {
+      kind: 'ok';
+      /** Stdout of the raw tested command, capped for IPC payload size. */
+      rawStdout: string;
+      /** Stdout of the rtk-rewritten command, capped for IPC payload size. */
+      compressedStdout: string;
+      /** Untruncated byte counts, so the UI can show honest savings math. */
+      rawBytes: number;
+      compressedBytes: number;
+      /** True when stdout was truncated at the runShell cap; bytes counts
+       *  reflect the truncated buffer in that case (we stop reading). */
+      truncated: boolean;
+    }
+  | {
+      /** Diff capture itself failed — distinct from "rtk chose pass-through".
+       *  UI must NOT render this as a successful no-op rewrite. */
+      kind: 'failed';
+      /** Which stage broke: `setup` (mkdtemp/git init), `raw` (the original
+       *  command), `rewritten` (the rtk-rewritten command), or `unknown`. */
+      stage: 'setup' | 'raw' | 'rewritten' | 'unknown';
+      /** Exit code when the command exited non-zero; absent when the failure
+       *  happened before spawn (mkdtemp, git init, etc.). */
+      exitCode?: number;
+      /** Truncated stderr for the failed stage, when available. */
+      stderr?: string;
+      /** Human-readable reason — what to show in the UI. */
+      reason: string;
+    };
 
 export type RtkTestResult =
   | { ok: false; testedCommand?: string; error: string }

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -32,6 +32,8 @@ export interface ElectronAPI {
   // Dialogs
   showOpenDialog: () => Promise<IpcResponse<string[]>>;
   openExternal: (url: string) => Promise<void>;
+  clipboardWriteText: (text: string) => void;
+  clipboardReadText: () => Promise<string>;
   openInEditor: (args: {
     cwd: string;
     filePath: string;

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -261,7 +261,7 @@ export interface ElectronAPI {
 
   // RTK (Rust Token Killer)
   rtkGetStatus: () => Promise<IpcResponse<RtkStatus>>;
-  rtkSetEnabled: (enabled: boolean) => Promise<IpcResponse<void>>;
+  rtkSetEnabled: (enabled: boolean) => Promise<IpcResponse<{ warning?: string }>>;
   rtkDownload: () => Promise<IpcResponse<void>>;
   rtkTest: () => Promise<IpcResponse<RtkTestResult>>;
   onRtkDownloadProgress: (callback: (progress: RtkDownloadProgress) => void) => () => void;

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -32,7 +32,7 @@ export interface ElectronAPI {
   // Dialogs
   showOpenDialog: () => Promise<IpcResponse<string[]>>;
   openExternal: (url: string) => Promise<void>;
-  clipboardWriteText: (text: string) => void;
+  clipboardWriteText: (text: string) => Promise<void>;
   clipboardReadText: () => Promise<string>;
   openInEditor: (args: {
     cwd: string;
@@ -264,7 +264,7 @@ export interface ElectronAPI {
   // RTK (Rust Token Killer)
   rtkGetStatus: () => Promise<IpcResponse<RtkStatus>>;
   rtkSetEnabled: (enabled: boolean) => Promise<IpcResponse<{ warning?: string }>>;
-  rtkDownload: () => Promise<IpcResponse<void>>;
+  rtkDownload: () => Promise<IpcResponse<{ warning?: string } | undefined>>;
   rtkTest: () => Promise<IpcResponse<RtkTestResult>>;
   onRtkDownloadProgress: (callback: (progress: RtkDownloadProgress) => void) => () => void;
 

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -19,6 +19,9 @@ import type {
   PixelAgentsConfig,
   PixelAgentsStatus,
   ActivityInfo,
+  RtkStatus,
+  RtkDownloadProgress,
+  RtkTestResult,
 } from '../shared/types';
 
 export interface ElectronAPI {
@@ -255,6 +258,13 @@ export interface ElectronAPI {
   pixelAgentsStart: () => Promise<IpcResponse<void>>;
   pixelAgentsStop: () => Promise<IpcResponse<void>>;
   onPixelAgentsStatusChanged: (callback: (status: PixelAgentsStatus) => void) => () => void;
+
+  // RTK (Rust Token Killer)
+  rtkGetStatus: () => Promise<IpcResponse<RtkStatus>>;
+  rtkSetEnabled: (enabled: boolean) => Promise<IpcResponse<void>>;
+  rtkDownload: () => Promise<IpcResponse<void>>;
+  rtkTest: () => Promise<IpcResponse<RtkTestResult>>;
+  onRtkDownloadProgress: (callback: (progress: RtkDownloadProgress) => void) => () => void;
 
   // Telemetry
   telemetryCapture: (event: string, properties?: Record<string, unknown>) => Promise<void>;


### PR DESCRIPTION
## Summary
First-class RTK (Rust Token Killer) integration: Dash manages the rtk binary end-to-end and injects its PreToolUse Bash-rewrite hook into every task on demand, typically cutting 60–90% of tokens on common shell commands without touching the user's global Claude Code settings.

- **Binary lifecycle** — resolve from `userData/bin` (Dash-managed) or `$PATH`; auto-download the correct release from `github.com/rtk-ai/rtk` into `userData/bin` on supported platforms (macOS arm64/x64, Linux x64/arm64). Windows has no prebuilt release upstream, so it shows manual-install guidance instead of a broken button.
- **Per-task hook injection** — write rtk's PreToolUse hook (`matcher: "Bash"`) into each task's `.claude/settings.local.json` alongside Dash's existing tool-start tracker. Global `~/.claude/settings.json` is never modified, so uninstalling Dash is clean and `rtk init -g` won't double-fire.
- **Live toggle** — `rtk:setEnabled` calls `refreshActivePtyHooks()`, which re-writes every active PTY's `settings.local.json`. Claude Code re-reads that file per tool invocation, so running tasks pick up the change without restart. Factored as a shared helper so `setCommitAttribution` can use the same path.
- **Settings → RTK tab** — install-status card, install button with streaming download progress, enable toggle (disabled until a binary resolves), and a **Verify** button that runs rtk in-process.

## Security hardening
- **URL allowlist** — asset downloads refuse non-HTTPS and any host outside `github.com`, `api.github.com`, `objects.githubusercontent.com`, and `*.githubusercontent.com`. Prevents redirect-chain hijacks.
- **SHA-256 checksum verification** — release `checksums.txt` is fetched and every downloaded tarball is hashed before extraction; mismatch aborts the install.
- **Archive-member safety** — every `tar -tzf` entry is rejected if it uses an absolute path, contains `..` traversal, or would escape `userData/bin` after `normalize(join(dest, name))`.
- **Download concurrency guard** — `download()` is single-flight; double-clicks await the same promise instead of racing on the tmp archive.
- **Cross-platform timeouts** — API fetch, body read, and tar invocations each have hard walls so a hung CDN can't leave the single-flight promise pending.
- **Refuse enable-without-binary** — `rtk:setEnabled(true)` rejects when no binary resolves, so the UI toggle can't drift out of sync with what `buildPreToolUseHooks` actually injects.
- **Partial-failure surfacing** — if `refreshActivePtyHooks` succeeds for some PTYs and fails for others, the failures are reported up through IPC instead of silently swallowed.

## Verify flow — in-app proof, no API tokens
Click **Verify** and Dash:
1. Pipes a synthetic `git status` PreToolUse payload to the resolved rtk binary on stdin and parses the rewrite directive out of stdout (covers the handful of shapes rtk has shipped across releases).
2. Creates a throwaway git repo in `tmpdir()/dash-rtk-verify-*` with files sprinkled across `src/` and `tests/` subdirs so `git status` emits something non-trivial.
3. Runs **both** the raw command (`git status`) and rtk's rewrite (`rtk git status`) in parallel and captures stdout.
4. Renders a green card with `in:`/`out:` plus a side-by-side panel: **raw** vs **via rtk** with a honest byte-savings badge (untruncated counts; display capped at 8 KB).

Live run against the installed binary during this PR: `246 → 110 bytes (−55%)`.

Best-effort: if the exec step fails (no git, sandbox restriction, etc.) the rewrite-directive card still renders — exec diff is visualization, not the pass/fail gate.

## Fixed during review
When `rtk` is resolved from `userData/bin`, the hook invokes it via absolute path — but rtk's rewrite references the bare name `rtk`, which doesn't resolve in the PTY's shell without the managed bin dir on `$PATH`. Symptom: Bash tools failing with `rtk: command not found` (repro: `gh pr create` inside a task). Fixed by prepending the managed bin dir to the PTY's `PATH` in `buildDirectEnv`; no-op when rtk is already on the user's own `$PATH`.

## Terminal copy/paste on Linux
Bundled in this PR because it surfaced while testing RTK: terminal copy was silently broken on Linux (Wayland in particular).

- **Root cause** — `navigator.clipboard.writeText` rejects silently on Wayland when the renderer doesn't hold the clipboard permission, and we never awaited the returned promise. Paste went through `navigator.clipboard.readText` with the same problem.
- **Fix** — route clipboard writes/reads through Electron's main-process `clipboard` module (`app:clipboardWriteText` / `app:clipboardReadText` IPC). That uses Electron's native bindings and doesn't depend on web-platform focus/permission state.
- **TUI-cleared-selection fallback** — Claude Code's TUI redraws cells continuously, which makes xterm drop the visible selection before the user can press the copy shortcut. Cache the last non-empty selection on `onSelectionChange` and fall back to it when `getSelection()` is empty at copy time.
- **Layout-independent key match** — copy/paste shortcuts now match on `e.code === 'KeyC'` / `'KeyV'` so non-QWERTY keyboard layouts still trigger them.
- **Caveat** — plain drag inside a Claude task still goes to the TUI's mouse reporting; users need **Shift+drag** to select (xterm's standard override), then **Ctrl+Shift+C**.

## Testing
Two vitest suites under `src/main/services/__tests__/`.

**`rtk-unit.test.ts`** (26 tests, always run):
- URL allowlist: HTTPS + allowed hosts accepted; HTTP, non-GitHub hosts, malformed URLs rejected with specific errors.
- Archive-member safety: absolute paths, `..` traversal, symlinks pointing outside dest, null bytes — all rejected.
- JSON rewrite-extraction: walks `hookSpecificOutput.updatedInput`/`.modifiedToolInput`/`.updatedToolInput` plus root-level variants so the extractor stays resilient if rtk's output shape shifts.

**`rtk-integration.test.ts`** (3 tests, auto-skips on missing prereqs):
- *Suite A* (needs rtk, no API key): `rtk hook claude` given a `git status` PreToolUse payload on stdin must emit non-empty JSON stdout referencing `rtk` — proves the compression path fires. Companion test for a non-rewritten command (`echo hi`) asserts no panic.
- *Suite B* (needs `ANTHROPIC_API_KEY` + rtk + claude): spins up a temp cwd, writes a `settings.local.json` whose hook is `sh -c 'tee -a in.log | rtk hook claude | tee -a out.log'`, runs a real `claude -p "use Bash: ls -la /tmp; then echo done > marker"` session, and asserts the in-log captured the PreToolUse payload, the out-log references `rtk` (rewrite emitted), the marker file exists (tool call completed through the hook), and the model finished its turn.

The tests also resolve rtk from Dash's managed `bin/` dir, matching the production resolution order — so machines where rtk was installed via Dash's Install button also run Suite A.

## Test plan
- [ ] Fresh install (no `rtk` on `$PATH`): Settings → RTK → Install; confirm streaming progress, binary lands under `userData/bin`, status flips to installed, source reads `managed by Dash`.
- [ ] Enable the toggle with a task already running; run `git status` inside the task; confirm compressed output without restarting.
- [ ] Disable the toggle; confirm subsequent Bash calls in the same task revert to uncompressed output.
- [ ] With `rtk` already on `$PATH`, confirm status reports `source: path` and no download is attempted.
- [ ] Click **Verify** with the binary installed: green card, `in: git status` / `out: rtk git status`, actual output diff panel shows raw vs via-rtk with a negative byte-savings percentage.
- [ ] Click **Verify** before installing rtk: red "rtk is not installed" card.
- [ ] Run `pnpm test` locally — all 71 unit+integration tests pass (Suite B skips without `ANTHROPIC_API_KEY`).
- [ ] Run `ANTHROPIC_API_KEY=... pnpm test` — Suite B runs end-to-end, asserts hook fired and rtk emitted a rewrite during a real claude -p session.
- [ ] With only a Dash-managed rtk, enable the toggle and run `gh pr create` inside a task — command succeeds (verifies the managed-bin-dir PATH fix).
- [ ] On Windows, confirm the install card shows the "no prebuilt release" manual-install message instead of a broken download button.
- [ ] **Linux copy/paste**: Shift+drag to select text in a Claude terminal on Linux (tested on Wayland), press Ctrl+Shift+C, paste into another app — confirm the selected text is on the clipboard. Ctrl+Shift+V pastes the system clipboard into the terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
