### PR TITLE
Fix invalid hooks breaking settings file and stop startup keychain prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/main/services/ConnectionConfigService.ts
+++ b/src/main/services/ConnectionConfigService.ts
@@ -160,6 +160,16 @@ export class ConnectionConfigService {
     this.writeConfig(config);
   }
 
+  /**
+   * Office IDs that have a stored token, without touching safeStorage.
+   * Used for presence checks on startup so we don't trigger an OS keychain
+   * prompt just to populate token placeholders (GH #127).
+   */
+  static getPixelAgentsTokenIds(): Set<string> {
+    const config = this.readConfig();
+    return new Set((config.pixelAgentsTokens || []).map((t) => t.officeId));
+  }
+
   static getAllPixelAgentsTokens(): Record<string, string> {
     const config = this.readConfig();
     const result: Record<string, string> = {};

--- a/src/main/services/PixelAgentsService.ts
+++ b/src/main/services/PixelAgentsService.ts
@@ -30,7 +30,9 @@ export class PixelAgentsService {
     try {
       if (!existsSync(getConfigPath())) return null;
       const raw = JSON.parse(readFileSync(getConfigPath(), 'utf-8'));
-      const encryptedTokens = ConnectionConfigService.getAllPixelAgentsTokens();
+      // Presence-only check — decrypting here would trigger a macOS keychain
+      // prompt on every startup for users who configured tokens (GH #127).
+      const tokenIds = ConnectionConfigService.getPixelAgentsTokenIds();
       return {
         name: raw.name || '',
         palette: raw.palette,
@@ -40,8 +42,7 @@ export class PixelAgentsService {
           (o: { id: string; url: string; token?: string; enabled: boolean }) => ({
             id: o.id,
             url: o.url,
-            // Check encrypted storage for token presence (file may have been scrubbed)
-            token: encryptedTokens[o.id] ? '••••••••' : null,
+            token: tokenIds.has(o.id) ? '••••••••' : null,
             enabled: o.enabled,
           }),
         ),

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -305,6 +305,35 @@ const DASH_HOOK_EVENTS = [
 ] as const;
 
 /**
+ * Claude Code rejects an entire settings.local.json if any top-level hook key
+ * is unknown to the running CLI version. Newer hook events must be gated so
+ * older Claude Code installs don't lose ALL Dash hooks (see GH #127).
+ *
+ * Returns false when the version is unknown, which keeps the new keys out of
+ * the file — the safer default. main.ts populates claudeCliCache after the
+ * async --version probe; by the time a PTY spawns, it's almost always set.
+ */
+function isClaudeVersionAtLeast(major: number, minor: number, patch: number): boolean {
+  let version: string | null = null;
+  try {
+    // Lazy require to avoid the circular import that a static import of main.ts
+    // would create (main → ptyManager → main). At call time, main is fully loaded.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+    const main = require('../main') as typeof import('../main');
+    version = main.claudeCliCache.version;
+  } catch {
+    return false;
+  }
+  if (!version) return false;
+  const m = version.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return false;
+  const [a, b, c] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  if (a !== major) return a > major;
+  if (b !== minor) return b > minor;
+  return c >= patch;
+}
+
+/**
  * Write .claude/settings.local.json with hooks for activity monitoring,
  * tool tracking, error detection, and context usage.
  *
@@ -342,13 +371,20 @@ function writeHookSettings(cwd: string, ptyId: string): void {
     PreToolUse: [{ matcher: '*', hooks: [httpHook('/hook/tool-start', true)] }],
     PostToolUse: [{ matcher: '*', hooks: [httpHook('/hook/tool-end', true)] }],
 
-    // ── Error detection ─────────────────────────────────────
-    StopFailure: [{ matcher: '*', hooks: [httpHook('/hook/stop-failure')] }],
-
     // ── Context compaction ──────────────────────────────────
     PreCompact: [{ matcher: '*', hooks: [httpHook('/hook/compact-start', true)] }],
-    PostCompact: [{ matcher: '*', hooks: [httpHook('/hook/compact-end', true)] }],
   };
+
+  // PostCompact added in Claude Code 2.1.76; older CLIs reject the key and
+  // skip the entire settings file (GH #127), losing all Dash hooks.
+  if (isClaudeVersionAtLeast(2, 1, 76)) {
+    hookSettings.PostCompact = [{ matcher: '*', hooks: [httpHook('/hook/compact-end', true)] }];
+  }
+
+  // StopFailure added in Claude Code 2.1.78.
+  if (isClaudeVersionAtLeast(2, 1, 78)) {
+    hookSettings.StopFailure = [{ matcher: '*', hooks: [httpHook('/hook/stop-failure')] }];
+  }
 
   // SessionStart hook re-injects task context (linked issue/work-item prompt)
   // on startup, compact, and clear — NOT resume, since resumed sessions
@@ -397,12 +433,22 @@ function writeHookSettings(cwd: string, ptyId: string): void {
       }
     }
 
+    // Drop any prior Dash-written hook keys before merging. A previous Dash
+    // version may have written events the current Claude Code CLI doesn't
+    // recognize (e.g. PostCompact pre-2.1.76), which would cause Claude to
+    // reject the entire settings file.
+    const existingHooks: Record<string, unknown> =
+      existing.hooks && typeof existing.hooks === 'object'
+        ? { ...(existing.hooks as Record<string, unknown>) }
+        : {};
+    for (const key of DASH_HOOK_EVENTS) {
+      delete existingHooks[key];
+    }
+
     const merged: Record<string, unknown> = {
       ...existing,
       hooks: {
-        ...(existing.hooks && typeof existing.hooks === 'object'
-          ? (existing.hooks as Record<string, unknown>)
-          : {}),
+        ...existingHooks,
         ...hookSettings,
       },
     };


### PR DESCRIPTION
## Summary

Closes #127.

Two distinct bugs reported in #127 — the keychain prompt was the visible symptom, but the invalid-hook bug is the more critical one because it silently breaks **all** Dash hooks (activity, tool tracking, status line, attribution) on any Claude Code older than 2.1.78.

- **Invalid hook keys breaking the entire settings file.** Dash wrote `PostCompact` (added in CC 2.1.76) and `StopFailure` (added in CC 2.1.78) unconditionally. Older Claude Code versions reject the unknown keys, and per Claude's behavior the *whole* `.claude/settings.local.json` is then skipped — so every hook Dash relies on stops firing. Now gated behind a version check on `claudeCliCache.version`. Already-broken settings files self-heal because we strip `DASH_HOOK_EVENTS` from `existing.hooks` before merging.
- **Unwanted macOS keychain prompt on every startup.** `PixelAgentsService.readConfig()` decrypted every stored token via `safeStorage` just to populate `'••••••••'` placeholders — a presence check shouldn't need plaintext. Added `ConnectionConfigService.getPixelAgentsTokenIds()` which lists office IDs without touching `safeStorage`; `readConfig()` now uses it.

Active Pixel Agents users will still see the keychain prompt the first time the watcher starts after a re-signed install (`hydrateConfigTokens` needs the real tokens for the watcher's config file). Eliminating that would require a larger storage rework. Users who configured Pixel Agents but don't actively run it no longer get prompted.

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm test` — 43/43 pass
- [x] ESLint clean on touched files
- [x] Standalone unit-tested the version comparator across `"2.1.123 (Claude Code)"`, `2.1.75`, `2.1.76`, `2.1.77`, `2.1.78`, `2.0.99`, `3.0.0`, `null`, `""`, malformed strings — 11/11
- [x] Manual: install on a machine with CC ≤ 2.1.75, spawn a task, confirm `.claude/settings.local.json` no longer contains `PostCompact`/`StopFailure` and Dash hooks fire (activity dot, status line update)
- [x] Manual: open Dash on macOS with prior Pixel Agents tokens stored — no keychain prompt on startup; prompt still appears when actually starting the watcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)