### PR TITLE
Refactor session management: delegate to Claude CLI, harden with hadMessages and fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.9.11",
+  "version": "0.9.13",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/main/db/migrate.ts
+++ b/src/main/db/migrate.ts
@@ -1,5 +1,4 @@
-import { existsSync, readdirSync } from 'fs';
-import { homedir } from 'os';
+import { existsSync } from 'fs';
 import { join } from 'path';
 import { getRawDb } from './client';
 
@@ -140,32 +139,6 @@ export function runMigrations(): void {
     rawDb.exec(`ALTER TABLE tasks ADD COLUMN had_messages INTEGER DEFAULT 0`);
   } catch {
     /* already exists */
-  }
-
-  // Backfill last_session_id for pre-refactor tasks: old Dash spawned with
-  // --session-id task.id, so the JSONL is named after task.id. If lastSessionId
-  // is still null but we can confirm the JSONL exists, pin it now so future
-  // spawns use --resume rather than falling back to the task.id shim.
-  try {
-    const nullSessionTasks = rawDb
-      .prepare(`SELECT id FROM tasks WHERE last_session_id IS NULL`)
-      .all() as { id: string }[];
-    if (nullSessionTasks.length > 0) {
-      const projectsDir = join(homedir(), '.claude', 'projects');
-      if (existsSync(projectsDir)) {
-        const dirs = readdirSync(projectsDir);
-        for (const task of nullSessionTasks) {
-          const jsonlExists = dirs.some((d) =>
-            existsSync(join(projectsDir, d, `${task.id}.jsonl`)),
-          );
-          if (jsonlExists) {
-            rawDb.prepare(`UPDATE tasks SET last_session_id = id WHERE id = ?`).run(task.id);
-          }
-        }
-      }
-    }
-  } catch {
-    /* best effort */
   }
 
   // Backfill: sync is_git_repo with actual filesystem state

--- a/src/main/db/migrate.ts
+++ b/src/main/db/migrate.ts
@@ -137,8 +137,11 @@ export function runMigrations(): void {
 
   try {
     rawDb.exec(`ALTER TABLE tasks ADD COLUMN had_messages INTEGER DEFAULT 0`);
-  } catch {
-    /* already exists */
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.includes('duplicate column')) {
+      console.error('[migrate] Failed to add had_messages column:', err);
+    }
   }
 
   // Backfill: sync is_git_repo with actual filesystem state

--- a/src/main/db/migrate.ts
+++ b/src/main/db/migrate.ts
@@ -1,4 +1,5 @@
-import { existsSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
+import { homedir } from 'os';
 import { join } from 'path';
 import { getRawDb } from './client';
 
@@ -131,6 +132,38 @@ export function runMigrations(): void {
     rawDb.exec(`ALTER TABLE tasks ADD COLUMN last_session_id TEXT`);
   } catch {
     /* already exists */
+  }
+
+  try {
+    rawDb.exec(`ALTER TABLE tasks ADD COLUMN had_messages INTEGER DEFAULT 0`);
+  } catch {
+    /* already exists */
+  }
+
+  // Backfill last_session_id for pre-refactor tasks: old Dash spawned with
+  // --session-id task.id, so the JSONL is named after task.id. If lastSessionId
+  // is still null but we can confirm the JSONL exists, pin it now so future
+  // spawns use --resume rather than falling back to the task.id shim.
+  try {
+    const nullSessionTasks = rawDb
+      .prepare(`SELECT id FROM tasks WHERE last_session_id IS NULL`)
+      .all() as { id: string }[];
+    if (nullSessionTasks.length > 0) {
+      const projectsDir = join(homedir(), '.claude', 'projects');
+      if (existsSync(projectsDir)) {
+        const dirs = readdirSync(projectsDir);
+        for (const task of nullSessionTasks) {
+          const jsonlExists = dirs.some((d) =>
+            existsSync(join(projectsDir, d, `${task.id}.jsonl`)),
+          );
+          if (jsonlExists) {
+            rawDb.prepare(`UPDATE tasks SET last_session_id = id WHERE id = ?`).run(task.id);
+          }
+        }
+      }
+    }
+  } catch {
+    /* best effort */
   }
 
   // Backfill: sync is_git_repo with actual filesystem state

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -37,6 +37,7 @@ export const tasks = sqliteTable(
     contextPrompt: text('context_prompt'),
     branchCreatedByDash: integer('branch_created_by_dash', { mode: 'boolean' }).default(false),
     lastSessionId: text('last_session_id'),
+    hadMessages: integer('had_messages', { mode: 'boolean' }).default(false),
     archivedAt: text('archived_at'),
     createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`),
     updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`),

--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -1,4 +1,4 @@
-import { eq, desc, sql } from 'drizzle-orm';
+import { eq, desc } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
 import { initDb, getDb } from '../db/client';
 import { runMigrations } from '../db/migrate';
@@ -124,22 +124,6 @@ export class DatabaseService {
     const db = getDb();
     const row = db.select().from(tasks).where(eq(tasks.id, id)).get();
     return row ? this.mapTask(row) : undefined;
-  }
-
-  /**
-   * Count tasks (including archived) that share a given working directory.
-   * Used to gate the legacy `-c -r` resume fallback: safe only when the task
-   * is the sole occupant of its cwd, otherwise we could hijack another task's
-   * session.
-   */
-  static countTasksAtPath(path: string): number {
-    const db = getDb();
-    const row = db
-      .select({ count: sql<number>`count(*)` })
-      .from(tasks)
-      .where(eq(tasks.path, path))
-      .get();
-    return row?.count ?? 0;
   }
 
   static setTaskContextPrompt(id: string, prompt: string): void {

--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -134,6 +134,14 @@ export class DatabaseService {
       .run();
   }
 
+  static setTaskHadMessages(id: string): void {
+    const db = getDb();
+    db.update(tasks)
+      .set({ hadMessages: true, updatedAt: new Date().toISOString() })
+      .where(eq(tasks.id, id))
+      .run();
+  }
+
   static setTaskLastSessionId(id: string, sessionId: string): void {
     const db = getDb();
     const result = db
@@ -244,6 +252,7 @@ export class DatabaseService {
       linkedItems,
       contextPrompt: row.contextPrompt ?? null,
       lastSessionId: row.lastSessionId ?? null,
+      hadMessages: row.hadMessages ?? false,
       archivedAt: row.archivedAt,
       createdAt: row.createdAt ?? '',
       updatedAt: row.updatedAt ?? '',

--- a/src/main/services/HookServer.ts
+++ b/src/main/services/HookServer.ts
@@ -176,6 +176,11 @@ class HookServerImpl {
           if (pathname === '/hook/busy') {
             this.readJsonBody(req, res, MAX_HOOK_BODY_BYTES, () => {
               activityMonitor.setBusy(ptyId);
+              try {
+                DatabaseService.setTaskHadMessages(ptyId);
+              } catch (err) {
+                console.warn('[HookServer] setTaskHadMessages failed:', err);
+              }
               res.writeHead(200);
               res.end();
             });

--- a/src/main/services/HookServer.ts
+++ b/src/main/services/HookServer.ts
@@ -14,8 +14,8 @@ class HookServerImpl {
   private server: http.Server | null = null;
   private _port: number = 0;
   private _desktopNotificationEnabled = false;
-  // Permissive default until setPtyValidator is called during boot
-  private _hasPty: (id: string) => boolean = () => true;
+  // Fail-closed default — setPtyValidator is called in main.ts before the server starts
+  private _hasPty: (id: string) => boolean = () => false;
 
   get port(): number {
     return this._port;

--- a/src/main/services/HookServer.ts
+++ b/src/main/services/HookServer.ts
@@ -2,7 +2,6 @@ import * as http from 'http';
 import { BrowserWindow, Notification } from 'electron';
 import { eq } from 'drizzle-orm';
 import { activityMonitor } from './ActivityMonitor';
-import { DatabaseService } from './DatabaseService';
 import { contextUsageService } from './ContextUsageService';
 import { getDb } from '../db/client';
 import { tasks } from '../db/schema';

--- a/src/main/services/PixelAgentsService.ts
+++ b/src/main/services/PixelAgentsService.ts
@@ -178,6 +178,17 @@ export class PixelAgentsService {
       });
     }
 
+    child.on('error', (err) => {
+      console.error(`[pixel-agents] Spawn error (cmd=${cmd}):`, err);
+      PixelAgentsService.child = null;
+      if (PixelAgentsService.running) {
+        PixelAgentsService.respawnTimer = setTimeout(() => {
+          console.log('[pixel-agents] Respawning after spawn error...');
+          PixelAgentsService.start();
+        }, RESPAWN_DELAY);
+      }
+    });
+
     child.on('exit', (code, signal) => {
       console.log(`[pixel-agents] Watcher exited (code=${code}, signal=${signal})`);
       PixelAgentsService.child = null;
@@ -302,15 +313,19 @@ export class PixelAgentsService {
 
   private static resolveBinPath(): string | null {
     // In dev: node_modules/.bin/pixel-agents-watcher (shell wrapper on Unix, .cmd on Windows)
+    // Check .cmd first on Windows — pnpm creates both the extensionless wrapper and a .cmd
+    // shim, and the extensionless file cannot be executed directly on Windows.
     const devBase = join(app.getAppPath(), 'node_modules', '.bin', 'pixel-agents-watcher');
-    if (existsSync(devBase)) return devBase;
     if (process.platform === 'win32' && existsSync(devBase + '.cmd')) return devBase + '.cmd';
+    if (existsSync(devBase)) return devBase;
 
-    // Packaged app or dev fallback: resolve the bundled CJS file
+    // Packaged app: resolve the bundled CJS file from asarUnpack so it can execute outside the archive.
+    // Also used as a dev fallback when no bin shim is present.
     try {
       const resolved = require.resolve('@syv-ai/pixel-agents-watcher/dist/watcher.cjs');
       return resolved.replace('app.asar', 'app.asar.unpacked');
-    } catch {
+    } catch (err) {
+      console.error('[pixel-agents] require.resolve failed for watcher.cjs:', err);
       return null;
     }
   }

--- a/src/main/services/PixelAgentsService.ts
+++ b/src/main/services/PixelAgentsService.ts
@@ -130,17 +130,32 @@ export class PixelAgentsService {
 
     // In packaged builds, the watcher lives in app.asar.unpacked and can't be
     // executed directly. Use Electron as a plain Node process via ELECTRON_RUN_AS_NODE.
-    const args = app.isPackaged
-      ? [binPath, '--config', getConfigPath()]
-      : ['--config', getConfigPath()];
-    const cmd = app.isPackaged ? process.execPath : binPath;
+    // In dev on Windows, .cmd shims and .cjs scripts also can't be executed directly.
+    const isCjsScript = binPath.endsWith('.cjs');
+    const isCmdScript = binPath.endsWith('.cmd');
+
+    let cmd: string;
+    let args: string[];
+    let extraEnv: Record<string, string> = {};
+
+    if (app.isPackaged || isCjsScript) {
+      cmd = process.execPath;
+      args = [binPath, '--config', getConfigPath()];
+      extraEnv = { ELECTRON_RUN_AS_NODE: '1' };
+    } else if (isCmdScript) {
+      cmd = 'cmd.exe';
+      args = ['/c', binPath, '--config', getConfigPath()];
+    } else {
+      cmd = binPath;
+      args = ['--config', getConfigPath()];
+    }
 
     const child = spawn(cmd, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: {
         ...process.env,
         NODE_NO_WARNINGS: '1',
-        ...(app.isPackaged ? { ELECTRON_RUN_AS_NODE: '1' } : {}),
+        ...extraEnv,
       },
     });
 
@@ -285,11 +300,12 @@ export class PixelAgentsService {
   }
 
   private static resolveBinPath(): string | null {
-    // In dev: node_modules/.bin/pixel-agents-watcher (shell wrapper)
-    const devPath = join(app.getAppPath(), 'node_modules', '.bin', 'pixel-agents-watcher');
-    if (existsSync(devPath)) return devPath;
+    // In dev: node_modules/.bin/pixel-agents-watcher (shell wrapper on Unix, .cmd on Windows)
+    const devBase = join(app.getAppPath(), 'node_modules', '.bin', 'pixel-agents-watcher');
+    if (existsSync(devBase)) return devBase;
+    if (process.platform === 'win32' && existsSync(devBase + '.cmd')) return devBase + '.cmd';
 
-    // Packaged app: resolve the bundled CJS file from asarUnpack
+    // Packaged app or dev fallback: resolve the bundled CJS file
     try {
       const resolved = require.resolve('@syv-ai/pixel-agents-watcher/dist/watcher.cjs');
       return resolved.replace('app.asar', 'app.asar.unpacked');

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -3,57 +3,77 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { type WebContents, app, BrowserWindow } from 'electron';
+import { type WebContents, app } from 'electron';
 import { activityMonitor } from './ActivityMonitor';
 import { hookServer } from './HookServer';
 import { contextUsageService } from './ContextUsageService';
 import { DatabaseService } from './DatabaseService';
-import { terminalSnapshotService } from './TerminalSnapshotService';
 
 const execFileAsync = promisify(execFile);
 
 /**
- * Locate the Claude projects directory for a given cwd.
- * Claude stores sessions under ~/.claude/projects/<encoded-cwd>/.
+ * Find the first resumable session ID from a list of candidates by checking
+ * whether a JSONL exists for each under ~/.claude/projects/. Searches all
+ * project subdirectories so no path-encoding is required — Claude resolves
+ * the encoded directory name internally when given --resume <id>.
+ * Returns the first candidate ID whose JSONL is found, or null if none exist.
  */
-function findClaudeProjectDir(cwd: string): string | null {
+function findResumableSession(candidateIds: string[]): string | null {
   try {
     const projectsDir = path.join(os.homedir(), '.claude', 'projects');
     if (!fs.existsSync(projectsDir)) return null;
-
-    // Path-based: slashes → hyphens (the primary naming scheme)
-    const pathBased = path.join(projectsDir, cwd.replace(/\//g, '-'));
-    if (fs.existsSync(pathBased)) return pathBased;
-
-    // Partial match: last 3 path segments
-    const parts = cwd.split('/').filter((p) => p.length > 0);
-    const suffix = parts.slice(-3).join('-');
-    const dirs = fs.readdirSync(projectsDir);
-    const match = dirs.find((d) => d.endsWith(suffix));
-    if (match) return path.join(projectsDir, match);
-
-    return null;
-  } catch (err) {
-    console.error('[findClaudeProjectDir] Failed to scan projects dir:', err);
-    return null;
-  }
-}
-
-/** Check whether Claude has a session file for the given UUID in this cwd. */
-function hasSessionForId(cwd: string, sessionId: string): boolean {
-  const projDir = findClaudeProjectDir(cwd);
-  if (!projDir) return false;
-  return fs.existsSync(path.join(projDir, `${sessionId}.jsonl`));
-}
-
-/** Check whether Claude has any jsonl history for this cwd. */
-function hasAnySessionForCwd(cwd: string): boolean {
-  const projDir = findClaudeProjectDir(cwd);
-  if (!projDir) return false;
-  try {
-    return fs.readdirSync(projDir).some((f) => f.endsWith('.jsonl'));
+    for (const dir of fs.readdirSync(projectsDir)) {
+      for (const id of candidateIds) {
+        if (fs.existsSync(path.join(projectsDir, dir, `${id}.jsonl`))) return id;
+      }
+    }
   } catch {
-    return false;
+    // Best effort
+  }
+  return null;
+}
+
+/**
+ * Remove session claims before spawning. Claude tracks active sessions in two places:
+ *   1. ~/.claude/sessions/<pid>.json — a registry entry per running process
+ *   2. ~/.claude/tasks/<sessionId>/.lock — a lock directory per session
+ * Both are abandoned when the process is killed. We unconditionally remove any registry
+ * entry matching the session ID — if Dash is spawning a session, there should be no other
+ * live Claude process with that ID (Dash owns all spawns via the ptys Map).
+ * Note: process.kill(pid, 0) is unreliable on Windows (silently succeeds for dead PIDs),
+ * so we skip the PID liveness check entirely.
+ */
+function clearStaleSessionClaims(sessionId: string): void {
+  // 1. Sessions registry: remove any <pid>.json whose sessionId matches
+  try {
+    const sessionsDir = path.join(os.homedir(), '.claude', 'sessions');
+    if (fs.existsSync(sessionsDir)) {
+      for (const file of fs.readdirSync(sessionsDir)) {
+        if (!file.endsWith('.json')) continue;
+        try {
+          const filePath = path.join(sessionsDir, file);
+          const entry = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+          if (entry.sessionId !== sessionId) continue;
+          fs.unlinkSync(filePath);
+          console.error(`[clearStaleSessionClaims] Removed session registry ${file}`);
+        } catch {
+          // Skip unreadable or malformed files
+        }
+      }
+    }
+  } catch (err) {
+    console.error('[clearStaleSessionClaims] sessions scan failed:', err);
+  }
+
+  // 2. Task lock directory: ~/.claude/tasks/<sessionId>/.lock
+  try {
+    const lockPath = path.join(os.homedir(), '.claude', 'tasks', sessionId, '.lock');
+    if (fs.existsSync(lockPath)) {
+      fs.rmSync(lockPath, { recursive: true, force: true });
+      console.error(`[clearStaleSessionClaims] Removed stale lock for ${sessionId}`);
+    }
+  } catch (err) {
+    console.error('[clearStaleSessionClaims] lock removal failed:', err);
   }
 }
 
@@ -539,47 +559,22 @@ export async function startDirectPty(options: {
 
   const args: string[] = [];
 
-  // Pin each task to its own Claude session so tasks sharing the same cwd
-  // (e.g. multiple tasks in the main worktree) never resume each other.
-  // Prefer the hook-captured lastSessionId (Claude may fork on /clear or
-  // /compact, so the live session id can drift from task.id).
+  // Resume only when we can confirm the session JSONL exists on disk.
+  // lastSessionId is set by the SessionStart hook on every spawn, but Claude writes
+  // the JSONL lazily (only after the first message), so a task that was opened but
+  // never messaged has lastSessionId set with no file yet. Spawning with no flags
+  // starts a fresh session in that case; SessionStart will update lastSessionId.
+  // Build candidate list: prefer lastSessionId (most recent after /clear or /compact),
+  // fall back to task.id (session created by original --session-id spawns).
   const task = DatabaseService.getTask(options.id);
-  const resumeId = task?.lastSessionId ?? options.id;
-  const hadPriorUse =
-    task?.lastSessionId != null || terminalSnapshotService.hasSnapshot(options.id);
-  if (hasSessionForId(options.cwd, resumeId)) {
-    args.push('-r', resumeId);
-  } else if (resumeId !== options.id && hasSessionForId(options.cwd, options.id)) {
-    args.push('-r', options.id);
-  } else if (
-    task &&
-    task.lastSessionId === null &&
-    DatabaseService.countTasksAtPath(options.cwd) === 1 &&
-    hasAnySessionForCwd(options.cwd)
-  ) {
-    // Legacy task created before session pinning: its jsonl is named with a
-    // Claude-generated UUID, not task.id, so we can't resume by id. Safe to
-    // fall back to `-c -r` only when this is the sole task at its cwd — no
-    // other task's session to hijack — AND jsonl history actually exists,
-    // otherwise Claude exits with "No conversation found to continue".
-    // The SessionStart hook will capture the real session_id on this spawn,
-    // so future spawns pin correctly.
-    args.push('-c', '-r');
-  } else {
-    args.push('--session-id', options.id);
-    // Task had prior use (snapshot or captured session id) but we couldn't
-    // link any existing session — notify the user so they can recover via
-    // Claude's /resume command. Jsonl history is still on disk.
-    if (hadPriorUse && task) {
-      for (const win of BrowserWindow.getAllWindows()) {
-        if (!win.isDestroyed()) {
-          win.webContents.send('app:toast', {
-            message: `Couldn't link previous Claude session for "${task.name}" — use /resume in the terminal to find it.`,
-          });
-        }
-      }
-    }
+  const candidates = [task?.lastSessionId, options.id].filter((id): id is string => !!id);
+  const sessionToResume = findResumableSession(candidates);
+
+  if (sessionToResume) {
+    clearStaleSessionClaims(sessionToResume);
+    args.push('--resume', sessionToResume);
   }
+  // No session flags: Claude starts a fresh interactive session.
 
   if (options.autoApprove) {
     args.push('--dangerously-skip-permissions');

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -572,8 +572,8 @@ export async function startDirectPty(options: {
     if (!task?.hadMessages) {
       try {
         DatabaseService.setTaskHadMessages(options.id);
-      } catch {
-        // Best effort
+      } catch (err) {
+        console.error('[startDirectPty] Failed to set hadMessages for task', options.id, err);
       }
     }
   } else if (task?.hadMessages) {

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { type WebContents, app } from 'electron';
+import { type WebContents, app, BrowserWindow } from 'electron';
 import { activityMonitor } from './ActivityMonitor';
 import { hookServer } from './HookServer';
 import { contextUsageService } from './ContextUsageService';
@@ -22,59 +22,14 @@ function findResumableSession(candidateIds: string[]): string | null {
   try {
     const projectsDir = path.join(os.homedir(), '.claude', 'projects');
     if (!fs.existsSync(projectsDir)) return null;
-    for (const dir of fs.readdirSync(projectsDir)) {
-      for (const id of candidateIds) {
-        if (fs.existsSync(path.join(projectsDir, dir, `${id}.jsonl`))) return id;
-      }
+    const dirs = fs.readdirSync(projectsDir);
+    for (const id of candidateIds) {
+      if (dirs.some((d) => fs.existsSync(path.join(projectsDir, d, `${id}.jsonl`)))) return id;
     }
   } catch {
     // Best effort
   }
   return null;
-}
-
-/**
- * Remove session claims before spawning. Claude tracks active sessions in two places:
- *   1. ~/.claude/sessions/<pid>.json — a registry entry per running process
- *   2. ~/.claude/tasks/<sessionId>/.lock — a lock directory per session
- * Both are abandoned when the process is killed. We unconditionally remove any registry
- * entry matching the session ID — if Dash is spawning a session, there should be no other
- * live Claude process with that ID (Dash owns all spawns via the ptys Map).
- * Note: process.kill(pid, 0) is unreliable on Windows (silently succeeds for dead PIDs),
- * so we skip the PID liveness check entirely.
- */
-function clearStaleSessionClaims(sessionId: string): void {
-  // 1. Sessions registry: remove any <pid>.json whose sessionId matches
-  try {
-    const sessionsDir = path.join(os.homedir(), '.claude', 'sessions');
-    if (fs.existsSync(sessionsDir)) {
-      for (const file of fs.readdirSync(sessionsDir)) {
-        if (!file.endsWith('.json')) continue;
-        try {
-          const filePath = path.join(sessionsDir, file);
-          const entry = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-          if (entry.sessionId !== sessionId) continue;
-          fs.unlinkSync(filePath);
-          console.error(`[clearStaleSessionClaims] Removed session registry ${file}`);
-        } catch {
-          // Skip unreadable or malformed files
-        }
-      }
-    }
-  } catch (err) {
-    console.error('[clearStaleSessionClaims] sessions scan failed:', err);
-  }
-
-  // 2. Task lock directory: ~/.claude/tasks/<sessionId>/.lock
-  try {
-    const lockPath = path.join(os.homedir(), '.claude', 'tasks', sessionId, '.lock');
-    if (fs.existsSync(lockPath)) {
-      fs.rmSync(lockPath, { recursive: true, force: true });
-      console.error(`[clearStaleSessionClaims] Removed stale lock for ${sessionId}`);
-    }
-  } catch (err) {
-    console.error('[clearStaleSessionClaims] lock removal failed:', err);
-  }
 }
 
 interface PtyRecord {
@@ -559,22 +514,37 @@ export async function startDirectPty(options: {
 
   const args: string[] = [];
 
-  // Resume only when we can confirm the session JSONL exists on disk.
-  // lastSessionId is set by the SessionStart hook on every spawn, but Claude writes
-  // the JSONL lazily (only after the first message), so a task that was opened but
-  // never messaged has lastSessionId set with no file yet. Spawning with no flags
-  // starts a fresh session in that case; SessionStart will update lastSessionId.
-  // Build candidate list: prefer lastSessionId (most recent after /clear or /compact),
-  // fall back to task.id (session created by original --session-id spawns).
+  // Decide how to spawn based on whether a prior session JSONL exists on disk.
+  // Claude writes JNSONLs lazily — only after the first message — so we check
+  // before using --resume (which fails hard if the JSONL is absent).
+  //
+  // Candidate priority:
+  //   1. lastSessionId — most recent session after /clear or /compact
+  //   2. options.id    — migration shim: pre-refactor Dash used --session-id task.id,
+  //                      so legacy JNSONLs are named after the task UUID
   const task = DatabaseService.getTask(options.id);
   const candidates = [task?.lastSessionId, options.id].filter((id): id is string => !!id);
   const sessionToResume = findResumableSession(candidates);
 
   if (sessionToResume) {
-    clearStaleSessionClaims(sessionToResume);
     args.push('--resume', sessionToResume);
+  } else if (!task?.lastSessionId) {
+    // Truly new task: claim task.id as the session ID so task.id === session.id.
+    // SessionStart hook will capture it as lastSessionId after first spawn.
+    args.push('--session-id', options.id);
+  } else {
+    // lastSessionId is set but no JSONL found — session history is gone (wiped ~/.claude,
+    // migrated machine, etc.). Start fresh and notify the user if they had real history.
+    if (task.hadMessages) {
+      for (const win of BrowserWindow.getAllWindows()) {
+        if (!win.isDestroyed()) {
+          win.webContents.send('app:toast', {
+            message: `Couldn't resume previous session for "${task.name}" — history may have been cleared. Starting fresh.`,
+          });
+        }
+      }
+    }
   }
-  // No session flags: Claude starts a fresh interactive session.
 
   if (options.autoApprove) {
     args.push('--dangerously-skip-permissions');

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -50,6 +50,7 @@ export interface Task {
   linkedItems: LinkedItem[] | null;
   contextPrompt: string | null;
   lastSessionId: string | null;
+  hadMessages: boolean;
   archivedAt: string | null;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Problem

Dash had grown its own session management layer that reverse-engineered Claude Code's private filesystem layout to decide how to spawn each task. This caused a cascade of bugs that were difficult to fix reliably:

- **Windows broken by design** — `findClaudeProjectDir` converted CWD slashes to hyphens, which is wrong on Windows (backslashes, drive letters with colons). Sessions couldn't be found on Windows regardless of what else worked.
- **"Session ID already in use"** — `--session-id X` is CREATE-only; it fails hard if the JSONL already exists. Using it unconditionally on restart caused this error.
- **"No conversation found to continue"** — the `-c -r` legacy fallback fired for brand-new tasks in fresh worktrees where no history exists yet.
- **Session hijacking risk** — the `-c -r` fallback was gated on `countTasksAtPath === 1` (a global DB check), which could transiently allow one task to resume another's session in a shared CWD.
- **`hasSnapshot` false positives** — terminal snapshots are written even for failed spawns (Claude banner gets captured), so using them as a proxy for "task had real history" was unreliable.

## Root cause

Claude CLI session flags have strict semantics that the old code didn't model correctly:
- `--session-id X` — CREATE-only. Fails if JSONL exists.
- `--resume X` — ATTACH-only. Fails if JSONL absent.
- No flags — always starts fresh; Claude generates its own UUID.
- `--continue` / `-c -r` — resume most-recent for CWD; fails if no history.

Claude also writes JNSONLs **lazily** — only after the first user message. A task that was opened but never messaged has `lastSessionId` set (via `SessionStart` hook) but no JSONL on disk yet.

## Solution

Replace the four-branch spawn ladder and three filesystem-probing helpers with a single `findResumableSession` check that scans `~/.claude/projects/*/` by filename (no path encoding required — UUID filenames are unique), then uses `--resume` only when the JSONL actually exists.

### Spawn logic (new)

| Condition | Action |
|---|---|
| JSONL found for `lastSessionId` or `task.id` | `--resume <sessionId>` |
| No JSONL + `lastSessionId` null (brand new task) | `--session-id task.id` (pins task.id = session.id) |
| No JSONL + `lastSessionId` set + `hadMessages = true` | Start fresh + show toast (history was lost) |
| No JSONL + `lastSessionId` set + `hadMessages = false` | Start fresh silently (task was never used) |

## Changes

### `ptyManager.ts`
- **Deleted** `findClaudeProjectDir`, `hasSessionForId`, `hasAnySessionForCwd` — the path-encoding reverse-engineering layer
- **Deleted** `clearStaleSessionClaims` — Dash was mutating Claude's private `~/.claude/sessions/` registry and `~/.claude/tasks/` lock dirs. These are Claude's responsibility; Dash deleting them was masking a Claude-side bug and introduced a path traversal risk on the lock removal path.
- **Added** `findResumableSession(candidateIds)` — scans all project subdirs for a matching JSONL by filename; candidates are the outer loop so `lastSessionId` is always preferred over the `task.id` fallback regardless of directory sort order.
- **New tasks** now pass `--session-id options.id` instead of no flags, keeping `task.id === session.id` as an invariant for the lifetime of the session (until `/clear` or `/compact` forks it).
- **Toast restored** — gated on `task.hadMessages` so it only fires when history genuinely existed, not for tasks that were opened but never used.

### `HookServer.ts`
- `/hook/busy` (fired by `UserPromptSubmit`) now calls `DatabaseService.setTaskHadMessages(ptyId)` to record that real conversation activity occurred.
- `_hasPty` default changed from `() => true` to `() => false` (fail-closed security fix).

### `DatabaseService.ts`
- **Deleted** `countTasksAtPath` — only existed to gate the unsafe `-c -r` legacy branch.
- **Added** `setTaskHadMessages(id)` — sets `had_messages = true` on first user message.

### `src/main/db/schema.ts` + `migrate.ts`
- **New column** `had_messages INTEGER DEFAULT 0` on `tasks`, with `ALTER TABLE` migration.
- **Startup backfill** — for any pre-refactor task with `last_session_id IS NULL`, scans `~/.claude/projects/` for a JSONL named after `task.id` and backfills `last_session_id = id`. This means users upgrading from before this refactor get their sessions linked on first app open, without waiting for a spawn.

### `PixelAgentsService.ts`
- Windows fix: `.cmd` shims are now invoked via `cmd.exe /c`; `.cjs` scripts use `ELECTRON_RUN_AS_NODE=1` + `process.execPath`. Unrelated to session management but on the same branch.

## Backward compatibility

- **Tasks with `lastSessionId` set** (created after session pinning in `b5acbf0`): `lastSessionId = task.id` because old Dash used `--session-id task.id` and SessionStart captured it. `findResumableSession` finds the JSONL → `--resume task.id`. Fully compatible.
- **Tasks with `lastSessionId = null`** but JSONL at `task.id`: handled by the startup backfill (pins `lastSessionId = task.id`) and the `task.id` fallback candidate as a safety net.
- **Very old tasks** (pre-session-pinning, JSONL named with a Claude-generated UUID): not automatically linkable — fresh session on next open. History remains on disk and can be accessed via `/resume` in the terminal. This was also not working reliably in the old code.

## Test plan

- [ ] **New task** — create a task, open it. No errors. Terminal opens with a fresh Claude session. After sending a message, confirm `had_messages = true` in DB and `lastSessionId` is set.
- [ ] **App restart after real use** — close and reopen Dash. Same task resumes the correct session with history intact. No "Session ID already in use" error.
- [ ] **`/clear` then restart** — run `/clear` in a task, close Dash, reopen. Task resumes the post-`/clear` session (not pre-`/clear` history).
- [ ] **Empty task restart** — open a task, close without sending any message, reopen. Fresh session opens silently. No toast.
- [ ] **Multiple tasks at same CWD** — create two tasks in the same directory. Each must stay in its own session; neither resumes the other's history.
- [ ] **Legacy task (pre-refactor)** — on first open after upgrade, session links correctly via the startup backfill. Confirm `lastSessionId` is populated in DB after migration runs.
- [ ] **Lost history toast** — simulate by manually deleting a JSONL for a task that has `hadMessages = true`. Reopen the task. Toast appears explaining history couldn't be resumed.
- [ ] **Type-check passes** — `pnpm type-check` shows zero errors.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)