### PR TITLE
Fix ECONNREFUSED accumulation in settings.local.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/main/services/__tests__/hookSettingsMerge.test.ts
+++ b/src/main/services/__tests__/hookSettingsMerge.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type HookEntry,
+  entryIsDashOwned,
+  isDashOwnedHook,
+  mergeHookEntries,
+} from '../hookSettingsMerge';
+
+// ---------------------------------------------------------------------------
+// Settings-merge safety. The load-bearing promise of writeHookSettings is
+// "merge with existing settings to preserve user content" — these tests
+// guard the user-authored-hook-survival invariant. A regression here is a
+// silent data-loss bug (user's own hooks vanish without warning), so this
+// is one of the highest-value test surfaces in the project.
+//
+// The merge module is pure (no DB, no electron, no native deps), so we can
+// exercise it directly against the real exported function — no mocking, no
+// re-implementation drift.
+// ---------------------------------------------------------------------------
+
+const dashHttp = (endpoint: string): HookEntry => ({
+  matcher: '*',
+  hooks: [{ type: 'http', url: `http://127.0.0.1:55123/hook/${endpoint}`, __dash: true }],
+});
+
+describe('isDashOwnedHook', () => {
+  it('recognises an explicitly tagged hook', () => {
+    expect(isDashOwnedHook({ type: 'http', url: 'x', __dash: true })).toBe(true);
+  });
+
+  it('recognises an untagged hook by the loopback /hook/<endpoint> shape (brand-loss fallback)', () => {
+    // Round-tripping through another tool can strip unknown fields. Without
+    // this fallback, every refresh would append a fresh tagged entry while
+    // the prior entry stayed unmatched — the file would accumulate duplicates.
+    expect(isDashOwnedHook({ type: 'http', url: 'http://127.0.0.1:55123/hook/tool-start' })).toBe(
+      true,
+    );
+  });
+
+  it('recognises a stale-port URL from a prior Dash session', () => {
+    // The matcher is port-agnostic — every Dash launch picks a new ephemeral
+    // port, so prior-session URLs always have a dead port. They must still
+    // be cleaned up or each restart adds another ECONNREFUSED-on-every-tool-
+    // call set of hooks.
+    expect(
+      isDashOwnedHook({ type: 'http', url: 'http://127.0.0.1:53317/hook/tool-start?ptyId=abc' }),
+    ).toBe(true);
+  });
+
+  it('recognises a curl-command hook targeting a Dash endpoint', () => {
+    // Older Dash versions wrote some hooks as `command: curl ...` rather
+    // than `type: http`. Those must still be recognized for cleanup.
+    const command =
+      'curl -s --connect-timeout 2 -X POST -H "Content-Type: application/json" ' +
+      '-d @- http://127.0.0.1:58903/hook/post-tool-use-failure?ptyId=xyz || exit 0';
+    expect(isDashOwnedHook({ type: 'command', command })).toBe(true);
+  });
+
+  it('recognises an untagged SessionStart base64-decode context hook (unix)', () => {
+    // Dash injects task context via an `echo '<base64>' | base64 -D` hook
+    // under SessionStart. Pre-brand versions wrote it without __dash; we
+    // need to still recognize the structural shape so an upgrade doesn't
+    // duplicate the context hook on every spawn.
+    const macOS = "echo 'eyJob29rIjoidGVzdCJ9' | base64 -D";
+    const linux = "echo 'eyJob29rIjoidGVzdCJ9' | base64 -d";
+    expect(isDashOwnedHook({ type: 'command', command: macOS })).toBe(true);
+    expect(isDashOwnedHook({ type: 'command', command: linux })).toBe(true);
+  });
+
+  it('recognises an untagged SessionStart base64-decode context hook (windows)', () => {
+    const win =
+      'powershell.exe -NoProfile -Command "[Console]::Out.Write([System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String(\'eyJ4Ijp0cnVlfQ==\')))"';
+    expect(isDashOwnedHook({ type: 'command', command: win })).toBe(true);
+  });
+
+  it('does not match a user command that incidentally mentions base64', () => {
+    // The regex is anchored to the exact echo|base64 shape Dash writes, so
+    // a user command that uses base64 differently is not stolen.
+    expect(isDashOwnedHook({ type: 'command', command: 'cat file.txt | base64 -D > out' })).toBe(
+      false,
+    );
+    expect(isDashOwnedHook({ type: 'command', command: 'echo "hello"' })).toBe(false);
+  });
+
+  it('does not match a user hook pointing at localhost on a non-/hook path', () => {
+    expect(isDashOwnedHook({ type: 'http', url: 'http://127.0.0.1:9999/something' })).toBe(false);
+  });
+
+  it('does not match a user hook on /hook/ but with an unknown endpoint', () => {
+    // If a user happened to author their own hook at /hook/something-else,
+    // we must not steal it. The endpoint list is the discriminator.
+    expect(isDashOwnedHook({ type: 'http', url: 'http://127.0.0.1:9999/hook/my-thing' })).toBe(
+      false,
+    );
+  });
+
+  it('treats command hooks without a Dash URL as user-owned', () => {
+    expect(isDashOwnedHook({ type: 'command', command: 'echo hi' })).toBe(false);
+  });
+
+  it('returns false for null/non-object values', () => {
+    expect(isDashOwnedHook(null)).toBe(false);
+    expect(isDashOwnedHook(undefined)).toBe(false);
+    expect(isDashOwnedHook('string')).toBe(false);
+  });
+});
+
+describe('entryIsDashOwned', () => {
+  it('returns true if any hook in the entry is Dash-owned', () => {
+    const mixed: HookEntry = {
+      matcher: '*',
+      hooks: [
+        { type: 'command', command: 'user-thing' },
+        { type: 'http', url: 'x', __dash: true },
+      ],
+    };
+    // Conservative: entries with a mix get treated as ours. Users shouldn't
+    // splice their hooks into a Dash-owned entry; if they do, we'd rather
+    // remove the whole entry on cleanup than leave a mystery tagged hook.
+    expect(entryIsDashOwned(mixed)).toBe(true);
+  });
+
+  it('returns false for an entry containing only user hooks', () => {
+    const userOnly: HookEntry = {
+      matcher: '*',
+      hooks: [{ type: 'command', command: 'echo hi' }],
+    };
+    expect(entryIsDashOwned(userOnly)).toBe(false);
+  });
+
+  it('returns false for malformed entries (no hooks array)', () => {
+    expect(entryIsDashOwned({ matcher: '*' })).toBe(false);
+    expect(entryIsDashOwned(null)).toBe(false);
+  });
+});
+
+describe('mergeHookEntries — user content preservation', () => {
+  it('preserves a user-authored hook on a Dash-managed event (PreToolUse)', () => {
+    const userHook: HookEntry = {
+      matcher: 'Bash',
+      hooks: [{ type: 'command', command: 'echo from-user' }],
+    };
+    const existing = { PreToolUse: [userHook] };
+    const dash = { PreToolUse: [dashHttp('tool-start')] };
+
+    const merged = mergeHookEntries(existing, dash);
+
+    expect(merged.PreToolUse).toHaveLength(2);
+    // User entry must survive verbatim (deep equality).
+    expect(merged.PreToolUse[0]).toEqual(userHook);
+    // Dash entry appended after.
+    expect(merged.PreToolUse[1].hooks[0]).toMatchObject({ __dash: true });
+  });
+
+  it('drops Dash-owned entries from existing so refreshes don’t accumulate duplicates', () => {
+    // Simulate a refresh: prior write left a tagged Dash entry; the next
+    // write must replace it, not add a sibling.
+    const stale: HookEntry = {
+      matcher: '*',
+      hooks: [{ type: 'http', url: 'http://127.0.0.1:55123/hook/tool-start', __dash: true }],
+    };
+    const existing = { PreToolUse: [stale] };
+    const dash = { PreToolUse: [dashHttp('tool-start')] };
+
+    const merged = mergeHookEntries(existing, dash);
+
+    expect(merged.PreToolUse).toHaveLength(1);
+  });
+
+  it('drops Dash-owned entries even when the brand was lost in round-trip (URL fallback)', () => {
+    // Same as above but `__dash` was stripped — the URL fallback in
+    // isDashOwnedHook is what stops duplicate accumulation here.
+    const orphan: HookEntry = {
+      matcher: '*',
+      hooks: [{ type: 'http', url: 'http://127.0.0.1:55123/hook/tool-start' }],
+    };
+    const existing = { PreToolUse: [orphan] };
+    const dash = { PreToolUse: [dashHttp('tool-start')] };
+
+    const merged = mergeHookEntries(existing, dash);
+
+    expect(merged.PreToolUse).toHaveLength(1);
+  });
+
+  it('drops stale-port Dash entries from prior sessions (ECONNREFUSED migration)', () => {
+    // The bug this guards against: pre-`__dash`-brand Dash versions wrote
+    // hooks without the brand. After upgrading, every new Dash session got
+    // a different ephemeral port, but the merge couldn't recognize the old
+    // ones because URL matching was tied to the *current* port. The file
+    // accumulated ~one set per launch; tools fired hooks against dead ports
+    // and emitted ECONNREFUSED on every Bash call.
+    const stalePort1: HookEntry = {
+      hooks: [{ type: 'http', url: 'http://127.0.0.1:53317/hook/tool-start?ptyId=old-1' }],
+    } as HookEntry;
+    const stalePort2: HookEntry = {
+      matcher: '*',
+      hooks: [{ type: 'http', url: 'http://127.0.0.1:64617/hook/tool-start?ptyId=old-2' }],
+    };
+    const existing = { PreToolUse: [stalePort1, stalePort2] };
+    const dash = { PreToolUse: [dashHttp('tool-start')] };
+
+    const merged = mergeHookEntries(existing, dash);
+
+    expect(merged.PreToolUse).toHaveLength(1);
+    expect(merged.PreToolUse[0].hooks[0]).toMatchObject({ __dash: true });
+  });
+
+  it('drops stale curl-command Dash entries on legacy event names and removes the empty key', () => {
+    // Older Dash versions wrote `command: curl ...` hooks under
+    // PostToolUseFailure / SubagentStart / SubagentStop. The current code
+    // doesn't write those events, but DASH_HOOK_EVENTS still lists them so
+    // the merge cleans them out — and drops the key entirely so we don't
+    // leave `"SubagentStart": []` skeletons in settings.local.json.
+    const legacy: HookEntry = {
+      hooks: [
+        {
+          type: 'command',
+          command:
+            'curl -s --connect-timeout 2 -X POST -H "Content-Type: application/json" ' +
+            '-d @- http://127.0.0.1:58903/hook/subagent-start?ptyId=zzz || exit 0',
+        },
+      ],
+    } as HookEntry;
+    const existing = { SubagentStart: [legacy] };
+
+    const merged = mergeHookEntries(existing, {});
+
+    expect(merged.SubagentStart).toBeUndefined();
+    expect(Object.keys(merged)).not.toContain('SubagentStart');
+  });
+
+  it('drops the key when an active managed event ends up with no entries', () => {
+    // If the only thing in the existing file for a Dash-managed event is a
+    // stale Dash entry and we don't write a fresh one this round (e.g. the
+    // event was disabled), the merged file should not retain an empty
+    // array under that key.
+    const stale: HookEntry = {
+      matcher: '*',
+      hooks: [{ type: 'http', url: 'http://127.0.0.1:55123/hook/tool-start', __dash: true }],
+    };
+    const merged = mergeHookEntries({ PreToolUse: [stale] }, {});
+    expect(merged.PreToolUse).toBeUndefined();
+  });
+
+  it('preserves a user-authored hook even on a legacy Dash-managed event', () => {
+    // If a user happens to have written their own SubagentStart hook, we
+    // must keep it across the cleanup. Only Dash-owned entries get dropped.
+    const userHook: HookEntry = {
+      matcher: '*',
+      hooks: [{ type: 'command', command: 'echo my-subagent-hook' }],
+    };
+    const existing = { SubagentStart: [userHook] };
+
+    const merged = mergeHookEntries(existing, {});
+
+    expect(merged.SubagentStart).toEqual([userHook]);
+  });
+
+  it('passes user hooks on non-Dash events through unchanged', () => {
+    // PreCompact is a Dash-managed event; CustomEvent is not.
+    const customEvent: HookEntry = {
+      matcher: '*',
+      hooks: [{ type: 'command', command: 'user-script' }],
+    };
+    const existing = { CustomEvent: [customEvent] };
+    const dash = { PreCompact: [dashHttp('compact-start')] };
+
+    const merged = mergeHookEntries(existing, dash);
+
+    // Non-Dash event must NOT be filtered (Dash doesn't claim ownership of
+    // events it doesn't write to).
+    expect(merged.CustomEvent).toEqual([customEvent]);
+    expect(merged.PreCompact).toHaveLength(1);
+  });
+
+  it('preserves a user hook on a Dash-managed event when no Dash entry replaces it', () => {
+    // A user might author a Notification hook even though Dash also manages
+    // Notification. The merge produces the user's entry kept, plus whatever
+    // Dash adds — never an empty array that loses the user's hook.
+    const userHook: HookEntry = {
+      matcher: 'idle_prompt',
+      hooks: [{ type: 'command', command: 'osascript -e display dialog "hi"' }],
+    };
+    const existing = { Notification: [userHook] };
+    const dash = {}; // pretend we didn't write Notification this round
+
+    const merged = mergeHookEntries(existing, dash);
+
+    expect(merged.Notification).toEqual([userHook]);
+  });
+
+  it('skips entries whose value is not an array (defensive against hand-edited json)', () => {
+    // The raw json read can be `"hooks": { "PreToolUse": "garbage" }`. The
+    // merge must not throw or coerce — it should just skip and continue.
+    const existing = { PreToolUse: 'not-an-array' as unknown as HookEntry[] };
+    const dash = { PreToolUse: [dashHttp('tool-start')] };
+
+    const merged = mergeHookEntries(existing, dash);
+
+    expect(merged.PreToolUse).toHaveLength(1);
+    expect(merged.PreToolUse[0].hooks[0]).toMatchObject({ __dash: true });
+  });
+
+  it('handles a fully empty existing object', () => {
+    const merged = mergeHookEntries({}, { PreToolUse: [dashHttp('tool-start')] });
+    expect(Object.keys(merged)).toEqual(['PreToolUse']);
+  });
+
+  it('preserves multiple sibling user hooks across managed events', () => {
+    const userBash: HookEntry = {
+      matcher: 'Bash',
+      hooks: [{ type: 'command', command: 'log-bash' }],
+    };
+    const userPost: HookEntry = {
+      matcher: 'Read',
+      hooks: [{ type: 'command', command: 'log-read' }],
+    };
+    const existing = {
+      PreToolUse: [userBash],
+      PostToolUse: [userPost],
+    };
+    const dash = {
+      PreToolUse: [dashHttp('tool-start')],
+      PostToolUse: [dashHttp('tool-end')],
+    };
+
+    const merged = mergeHookEntries(existing, dash);
+
+    expect(merged.PreToolUse).toContainEqual(userBash);
+    expect(merged.PostToolUse).toContainEqual(userPost);
+    expect(merged.PreToolUse).toHaveLength(2);
+    expect(merged.PostToolUse).toHaveLength(2);
+  });
+});

--- a/src/main/services/__tests__/hookSettingsMerge.test.ts
+++ b/src/main/services/__tests__/hookSettingsMerge.test.ts
@@ -94,6 +94,35 @@ describe('isDashOwnedHook', () => {
     );
   });
 
+  it('does not match when the Dash URL appears as a substring inside a longer url field', () => {
+    // The url-field check is anchored to the full string. A user hook
+    // whose url field is a sentence that happens to contain a Dash URL
+    // must not be classified as Dash-owned (otherwise their hook gets
+    // silently deleted on the next merge).
+    const url = 'http://other-server.example.com http://127.0.0.1:9999/hook/stop';
+    expect(isDashOwnedHook({ type: 'http', url })).toBe(false);
+  });
+
+  it('matches a Dash URL with the typical ?ptyId= query string', () => {
+    // The URL Dash actually writes — anchor allowing the query suffix.
+    const url = 'http://127.0.0.1:55123/hook/tool-start?ptyId=abc-def';
+    expect(isDashOwnedHook({ type: 'http', url })).toBe(true);
+  });
+
+  it('matches a mixed-case Dash URL (case-insensitive)', () => {
+    // Regex carries the /i flag — pin the behavior so a future "tighten
+    // the regex" cleanup can't silently change classification.
+    const url = 'HTTP://127.0.0.1:55123/Hook/Tool-Start';
+    expect(isDashOwnedHook({ type: 'http', url })).toBe(true);
+  });
+
+  it('matches a non-curl command that contains a Dash URL substring', () => {
+    // Command strings legitimately wrap Dash URLs in larger invocations
+    // (curl, but also node -e, wget, etc.) — substring match is required.
+    const command = `node -e "fetch('http://127.0.0.1:9/hook/tool-start?ptyId=x')"`;
+    expect(isDashOwnedHook({ type: 'command', command })).toBe(true);
+  });
+
   it('treats command hooks without a Dash URL as user-owned', () => {
     expect(isDashOwnedHook({ type: 'command', command: 'echo hi' })).toBe(false);
   });
@@ -150,6 +179,43 @@ describe('mergeHookEntries — user content preservation', () => {
     expect(merged.PreToolUse[0]).toEqual(userHook);
     // Dash entry appended after.
     expect(merged.PreToolUse[1].hooks[0]).toMatchObject({ __dash: true });
+  });
+
+  it('drops a mixed entry (user hook + Dash hook spliced together) wholesale', () => {
+    // entryIsDashOwned is conservative: if any hook in the entry is Dash-
+    // owned, the whole entry is dropped. This is the only path where merge
+    // legitimately deletes user content; pin the consequence end-to-end so
+    // a future "be less aggressive" change doesn't silently change it.
+    const mixed: HookEntry = {
+      matcher: '*',
+      hooks: [
+        { type: 'command', command: 'echo my-thing' },
+        { type: 'http', url: 'http://127.0.0.1:9/hook/tool-start', __dash: true },
+      ],
+    };
+    const existing = { PreToolUse: [mixed] };
+    const dash = { PreToolUse: [dashHttp('tool-start')] };
+
+    const merged = mergeHookEntries(existing, dash);
+
+    // Mixed entry gone; only the fresh Dash entry remains.
+    expect(merged.PreToolUse).toHaveLength(1);
+    expect(merged.PreToolUse[0].hooks[0]).toMatchObject({ __dash: true });
+  });
+
+  it('passes a brand-tagged hook through unchanged on a non-Dash event', () => {
+    // Dash only filters events listed in DASH_HOOK_EVENTS. A __dash-tagged
+    // hook accidentally landing on a non-managed event (e.g. CustomEvent)
+    // must not be filtered — we don't claim ownership of unrelated events.
+    const tagged: HookEntry = {
+      matcher: '*',
+      hooks: [{ type: 'http', url: 'http://127.0.0.1:9/hook/tool-start', __dash: true }],
+    };
+    const existing = { CustomEvent: [tagged] };
+
+    const merged = mergeHookEntries(existing, {});
+
+    expect(merged.CustomEvent).toEqual([tagged]);
   });
 
   it('drops Dash-owned entries from existing so refreshes don’t accumulate duplicates', () => {

--- a/src/main/services/hookSettingsMerge.ts
+++ b/src/main/services/hookSettingsMerge.ts
@@ -78,7 +78,18 @@ export type DashHookEndpoint = (typeof DASH_HOOK_ENDPOINTS)[number];
 
 const DASH_ENDPOINT_SET: ReadonlySet<string> = new Set(DASH_HOOK_ENDPOINTS);
 
-const DASH_URL_RE = /https?:\/\/127\.0\.0\.1:\d+\/hook\/([a-z-]+)/i;
+/**
+ * Anchored match: the entire string is a Dash hook URL. Use this for HTTP
+ * hook `url` fields, where the value is meant to be exactly the URL.
+ *
+ * The unanchored variant below is for `command` strings, where a Dash URL
+ * legitimately appears as a substring inside curl invocations. Splitting
+ * the two prevents a user-authored `url: "http://127.0.0.1:9999/hook/stop"`
+ * (their own dev server happening to expose `/hook/stop`) from being
+ * silently classified as Dash-owned and deleted on the next merge.
+ */
+const DASH_URL_FULL_RE = /^https?:\/\/127\.0\.0\.1:\d+\/hook\/([a-z-]+)(\?|$)/i;
+const DASH_URL_SUBSTR_RE = /https?:\/\/127\.0\.0\.1:\d+\/hook\/([a-z-]+)/i;
 
 /**
  * Pre-brand Dash versions wrote SessionStart context-injection hooks as a
@@ -88,22 +99,25 @@ const DASH_URL_RE = /https?:\/\/127\.0\.0\.1:\d+\/hook\/([a-z-]+)/i;
  * fallback, the old untagged commands would be preserved as "user content"
  * on the first merge and persist alongside the new tagged versions).
  *
- * The patterns are anchored / specific enough to make false-positive
- * collisions with user-authored hooks vanishingly unlikely:
+ * Both branches are anchored both ends. False-positive collisions with
+ * user-authored hooks are vanishingly unlikely:
  *  - macOS / Linux: `echo '<base64>' | base64 -D` (or `-d`)
- *  - Windows: `powershell.exe -NoProfile -Command "[Console]::Out.Write...
- *             ::FromBase64String(...`
+ *  - Windows: `powershell.exe -NoProfile -Command "[Console]::Out.Write
+ *             ([System.Text.Encoding]::UTF8.GetString(
+ *             [Convert]::FromBase64String('<base64>')))"`
  */
 const DASH_BASE64_DECODE_RE =
-  /^echo '[A-Za-z0-9+/=]*' \| base64 -[Dd]$|^powershell\.exe -NoProfile -Command "\[Console\]::Out\.Write/;
+  /^echo '[A-Za-z0-9+/=]*' \| base64 -[Dd]$|^powershell\.exe -NoProfile -Command "\[Console\]::Out\.Write\(\[System\.Text\.Encoding\]::UTF8\.GetString\(\[Convert\]::FromBase64String\('[A-Za-z0-9+/=]*'\)\)\)"$/;
 
-function urlMatchesDashEndpoint(s: string): boolean {
-  const m = s.match(DASH_URL_RE);
+function urlFieldIsDashEndpoint(url: string): boolean {
+  const m = url.match(DASH_URL_FULL_RE);
   return m !== null && DASH_ENDPOINT_SET.has(m[1].toLowerCase());
 }
 
 function commandLooksLikeDash(s: string): boolean {
-  return urlMatchesDashEndpoint(s) || DASH_BASE64_DECODE_RE.test(s);
+  const m = s.match(DASH_URL_SUBSTR_RE);
+  if (m !== null && DASH_ENDPOINT_SET.has(m[1].toLowerCase())) return true;
+  return DASH_BASE64_DECODE_RE.test(s);
 }
 
 /**
@@ -112,16 +126,17 @@ function commandLooksLikeDash(s: string): boolean {
  * case where a round-trip through another tool stripped the unknown field
  * AND for entries written by Dash versions predating the brand.
  *
- * The fallback matches the structural shape `http://127.0.0.1:<port>/hook/<ep>`
- * (any port, any known endpoint) plus the SessionStart base64-decode shape
- * so prior-session URLs and context hooks still get cleaned up.
+ * The URL fallback is anchored on the `url` field (a user's local dev
+ * server hosting a same-named path must NOT be reclassified as Dash) and
+ * unanchored inside command strings (a curl-to-Dash-endpoint legitimately
+ * appears as a substring of a longer command).
  */
 export function isDashOwnedHook(h: unknown): boolean {
   if (!h || typeof h !== 'object') return false;
   if ((h as { __dash?: unknown }).__dash === true) return true;
 
   const url = (h as { url?: unknown }).url;
-  if (typeof url === 'string' && urlMatchesDashEndpoint(url)) return true;
+  if (typeof url === 'string' && urlFieldIsDashEndpoint(url)) return true;
 
   const command = (h as { command?: unknown }).command;
   if (typeof command === 'string' && commandLooksLikeDash(command)) return true;
@@ -149,17 +164,29 @@ export function entryIsDashOwned(entry: unknown): boolean {
  */
 export function mergeHookEntries(
   existing: Record<string, HookEntry[] | undefined>,
-  dash: Record<string, HookEntry[]>,
+  dash: Record<string, HookEntry[] | undefined>,
 ): Record<string, HookEntry[]> {
   const merged: Record<string, HookEntry[]> = {};
   const dashEventSet = new Set<string>(DASH_HOOK_EVENTS);
   for (const [event, userEntries] of Object.entries(existing)) {
-    if (!Array.isArray(userEntries)) continue;
+    if (userEntries === undefined) continue;
+    if (!Array.isArray(userEntries)) {
+      // Hand-edited settings.local.json with a malformed event value (e.g.
+      // an object or string instead of an array). Claude Code rejects this
+      // shape too, so the value is already non-functional — but the user's
+      // edit gets overwritten on the next write, which is data loss they
+      // should at least see in logs.
+      console.warn(
+        `[hookSettingsMerge] Skipping non-array value for event "${event}" — overwriting on next write.`,
+      );
+      continue;
+    }
     merged[event] = dashEventSet.has(event)
       ? userEntries.filter((e) => !entryIsDashOwned(e))
       : userEntries;
   }
   for (const [event, entries] of Object.entries(dash)) {
+    if (!entries) continue;
     const preserved = merged[event] ?? [];
     merged[event] = [...preserved, ...entries];
   }

--- a/src/main/services/hookSettingsMerge.ts
+++ b/src/main/services/hookSettingsMerge.ts
@@ -1,0 +1,170 @@
+/**
+ * Pure helpers for the settings.local.json merge — extracted so tests can
+ * exercise the user-content-preservation invariant without dragging in the
+ * full ptyManager dependency graph (DB, hookServer, native modules).
+ *
+ * Single source of truth: the two `as const` arrays below define every event
+ * Dash writes hooks for and every loopback endpoint those hooks call. The
+ * `DashHookEvent` / `DashHookEndpoint` types derive from them, and ptyManager
+ * is constrained to those types when constructing hook URLs — so adding a
+ * new endpoint without updating this list fails the TypeScript build, which
+ * is the drift-prevention this module is responsible for.
+ */
+
+export type HttpHook = { type: 'http'; url: string; async?: boolean };
+export type CommandHook = { type: 'command'; command: string };
+export type Hook = (HttpHook | CommandHook) & { __dash?: true };
+export type HookEntry = { matcher: string; hooks: Hook[] };
+
+/**
+ * All hook event names Dash has ever written. Used to decide which existing
+ * entries are candidates for replacement vs. preservation.
+ *
+ * Includes legacy event names (`PostToolUseFailure`, `SubagentStart`,
+ * `SubagentStop`) that older Dash versions wrote but the current code does
+ * not — kept here so the merge/cleanup paths drop stale entries forward
+ * for users updating from those versions.
+ */
+export const DASH_HOOK_EVENTS = [
+  'Stop',
+  'UserPromptSubmit',
+  'Notification',
+  'PreToolUse',
+  'PostToolUse',
+  'StopFailure',
+  'PreCompact',
+  'PostCompact',
+  'SessionStart',
+  'PostToolUseFailure',
+  'SubagentStart',
+  'SubagentStop',
+] as const;
+
+export type DashHookEvent = (typeof DASH_HOOK_EVENTS)[number];
+
+/**
+ * Hook endpoints Dash has ever served on its loopback HookServer. The merge
+ * detector matches any URL of the shape `http://127.0.0.1:<port>/hook/<ep>`
+ * against this set, regardless of which port the entry was written with.
+ *
+ * Why port-agnostic: HookServer binds to an ephemeral port at every Dash
+ * launch, so prior-session hook URLs always reference a dead port. An
+ * earlier version of this module matched URLs against the *current* port
+ * prefix only — which made it incapable of recognizing entries from prior
+ * sessions, and they accumulated across restarts as ECONNREFUSED-on-every-
+ * tool-call landmines. Matching the structural shape (loopback + /hook/ +
+ * known endpoint) recognizes them regardless of port.
+ *
+ * Includes legacy endpoints that older Dash versions wrote so the cleanup
+ * migrates them forward.
+ */
+export const DASH_HOOK_ENDPOINTS = [
+  'stop',
+  'busy',
+  'session-start',
+  'notification',
+  'context',
+  'tool-start',
+  'tool-end',
+  'stop-failure',
+  'compact-start',
+  'compact-end',
+  'post-tool-use-failure',
+  'subagent-start',
+  'subagent-stop',
+] as const;
+
+export type DashHookEndpoint = (typeof DASH_HOOK_ENDPOINTS)[number];
+
+const DASH_ENDPOINT_SET: ReadonlySet<string> = new Set(DASH_HOOK_ENDPOINTS);
+
+const DASH_URL_RE = /https?:\/\/127\.0\.0\.1:\d+\/hook\/([a-z-]+)/i;
+
+/**
+ * Pre-brand Dash versions wrote SessionStart context-injection hooks as a
+ * base64-decode command without the `__dash` marker. Recognize the
+ * structural shape so users upgrading from those versions don't accumulate
+ * duplicate context hooks (the new code tags fresh writes; without this
+ * fallback, the old untagged commands would be preserved as "user content"
+ * on the first merge and persist alongside the new tagged versions).
+ *
+ * The patterns are anchored / specific enough to make false-positive
+ * collisions with user-authored hooks vanishingly unlikely:
+ *  - macOS / Linux: `echo '<base64>' | base64 -D` (or `-d`)
+ *  - Windows: `powershell.exe -NoProfile -Command "[Console]::Out.Write...
+ *             ::FromBase64String(...`
+ */
+const DASH_BASE64_DECODE_RE =
+  /^echo '[A-Za-z0-9+/=]*' \| base64 -[Dd]$|^powershell\.exe -NoProfile -Command "\[Console\]::Out\.Write/;
+
+function urlMatchesDashEndpoint(s: string): boolean {
+  const m = s.match(DASH_URL_RE);
+  return m !== null && DASH_ENDPOINT_SET.has(m[1].toLowerCase());
+}
+
+function commandLooksLikeDash(s: string): boolean {
+  return urlMatchesDashEndpoint(s) || DASH_BASE64_DECODE_RE.test(s);
+}
+
+/**
+ * Recognise a Dash-authored hook entry. Primary signal is the explicit
+ * `__dash: true` brand. URL/command matching is a fallback for the rare
+ * case where a round-trip through another tool stripped the unknown field
+ * AND for entries written by Dash versions predating the brand.
+ *
+ * The fallback matches the structural shape `http://127.0.0.1:<port>/hook/<ep>`
+ * (any port, any known endpoint) plus the SessionStart base64-decode shape
+ * so prior-session URLs and context hooks still get cleaned up.
+ */
+export function isDashOwnedHook(h: unknown): boolean {
+  if (!h || typeof h !== 'object') return false;
+  if ((h as { __dash?: unknown }).__dash === true) return true;
+
+  const url = (h as { url?: unknown }).url;
+  if (typeof url === 'string' && urlMatchesDashEndpoint(url)) return true;
+
+  const command = (h as { command?: unknown }).command;
+  if (typeof command === 'string' && commandLooksLikeDash(command)) return true;
+
+  return false;
+}
+
+export function entryIsDashOwned(entry: unknown): boolean {
+  if (!entry || typeof entry !== 'object') return false;
+  const hooks = (entry as { hooks?: unknown }).hooks;
+  if (!Array.isArray(hooks)) return false;
+  return hooks.some((h) => isDashOwnedHook(h));
+}
+
+/**
+ * Merge existing hook entries with Dash-owned entries, preserving user-
+ * authored content verbatim:
+ * - For events Dash manages: drop Dash-owned entries (they get rewritten),
+ *   keep user-authored ones.
+ * - For events Dash doesn't touch: pass through unchanged.
+ * - Then append the fresh Dash entries.
+ * - Drop any event whose final value is an empty array, so legacy events
+ *   with only Dash-owned entries don't leave behind `"SubagentStart": []`
+ *   skeletons in settings.local.json.
+ */
+export function mergeHookEntries(
+  existing: Record<string, HookEntry[] | undefined>,
+  dash: Record<string, HookEntry[]>,
+): Record<string, HookEntry[]> {
+  const merged: Record<string, HookEntry[]> = {};
+  const dashEventSet = new Set<string>(DASH_HOOK_EVENTS);
+  for (const [event, userEntries] of Object.entries(existing)) {
+    if (!Array.isArray(userEntries)) continue;
+    merged[event] = dashEventSet.has(event)
+      ? userEntries.filter((e) => !entryIsDashOwned(e))
+      : userEntries;
+  }
+  for (const [event, entries] of Object.entries(dash)) {
+    const preserved = merged[event] ?? [];
+    merged[event] = [...preserved, ...entries];
+  }
+  for (const event of Object.keys(merged)) {
+    if (merged[event].length === 0) delete merged[event];
+  }
+  return merged;
+}

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -14,6 +14,7 @@ import {
   type HttpHook,
   type CommandHook,
   type DashHookEndpoint,
+  type DashHookEvent,
   DASH_HOOK_EVENTS,
   entryIsDashOwned,
   mergeHookEntries,
@@ -343,11 +344,26 @@ function tagDash<T extends HttpHook | CommandHook>(hook: T): T & { __dash: true 
  * rewritten frequently (every PTY spawn, every commit-attribution change)
  * and the corrupt-recovery path on the read side would otherwise have to
  * handle a wider class of partial-write failures than just user edits.
+ *
+ * On failure (write error mid-data, or rename error after a successful
+ * write), unlink the tmp file best-effort before rethrowing so failed
+ * writes don't accumulate orphan `*.tmp-<pid>-<ts>` files alongside the
+ * user's settings.
  */
 function atomicWriteFileSync(target: string, data: string): void {
   const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
-  fs.writeFileSync(tmp, data);
-  fs.renameSync(tmp, target);
+  try {
+    fs.writeFileSync(tmp, data);
+    fs.renameSync(tmp, target);
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      // best-effort: tmp may not exist if writeFileSync failed before
+      // creating the file, or unlink may race with another process.
+    }
+    throw err;
+  }
 }
 
 function broadcastToast(message: string): void {
@@ -357,8 +373,6 @@ function broadcastToast(message: string): void {
     }
   }
 }
-
-type HookWriteResult = { ok: true } | { ok: false; settingsPath: string; error: string };
 
 /**
  * Write .claude/settings.local.json with hooks for activity monitoring,
@@ -371,8 +385,11 @@ type HookWriteResult = { ok: true } | { ok: false; settingsPath: string; error: 
  * Merging preserves user-authored entries via the merge module's brand-or-
  * URL-shape detector, so users can have their own hooks under managed
  * events without losing them on every rewrite.
+ *
+ * Failure surfacing happens inside via console.error + broadcastToast.
+ * Callers don't need to act on the result.
  */
-function writeHookSettings(cwd: string, ptyId: string): HookWriteResult {
+function writeHookSettings(cwd: string, ptyId: string): void {
   const port = hookServer.port;
   const claudeDir = path.join(cwd, '.claude');
   const settingsPath = path.join(claudeDir, 'settings.local.json');
@@ -389,11 +406,7 @@ function writeHookSettings(cwd: string, ptyId: string): HookWriteResult {
     broadcastToast(
       `Hook server not ready — task hooks couldn't be written for ${path.basename(cwd)}. Restart Dash to recover.`,
     );
-    return {
-      ok: false,
-      settingsPath,
-      error: 'HookServer port not bound',
-    };
+    return;
   }
 
   const base = `http://127.0.0.1:${port}`;
@@ -408,7 +421,10 @@ function writeHookSettings(cwd: string, ptyId: string): HookWriteResult {
   const dashHttp = (endpoint: DashHookEndpoint, async?: boolean) =>
     tagDash(httpHook(endpoint, async));
 
-  const dashEntries: Record<string, HookEntry[]> = {
+  // Typed against DashHookEvent so a typo'd event key (e.g. 'PreToolUze')
+  // fails the build, matching the drift-prevention DashHookEndpoint gives
+  // us for endpoints.
+  const dashEntries: Partial<Record<DashHookEvent, HookEntry[]>> = {
     Stop: [{ matcher: '', hooks: [dashHttp('stop')] }],
     UserPromptSubmit: [{ matcher: '', hooks: [dashHttp('busy')] }],
     Notification: [
@@ -496,11 +512,7 @@ function writeHookSettings(cwd: string, ptyId: string): HookWriteResult {
           broadcastToast(
             `settings.local.json is corrupt and could not be backed up — hooks are off for this task. Fix or remove ${path.basename(settingsPath)} manually.`,
           );
-          return {
-            ok: false,
-            settingsPath,
-            error: `corrupt settings.local.json; backup rename failed: ${renameErr instanceof Error ? renameErr.message : String(renameErr)}`,
-          };
+          return;
         }
       }
     }
@@ -529,15 +541,9 @@ function writeHookSettings(cwd: string, ptyId: string): HookWriteResult {
 
     atomicWriteFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
     writtenSettingsPaths.add(settingsPath);
-    return { ok: true };
   } catch (err) {
     console.error('[writeHookSettings] Failed:', err);
     broadcastToast(`Could not write ${path.basename(settingsPath)} — hooks are off for this task.`);
-    return {
-      ok: false,
-      settingsPath,
-      error: err instanceof Error ? err.message : String(err),
-    };
   }
 }
 

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -3,11 +3,21 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { type WebContents, app } from 'electron';
+import { type WebContents, app, BrowserWindow } from 'electron';
 import { activityMonitor } from './ActivityMonitor';
 import { hookServer } from './HookServer';
 import { contextUsageService } from './ContextUsageService';
 import { DatabaseService } from './DatabaseService';
+import {
+  type Hook,
+  type HookEntry,
+  type HttpHook,
+  type CommandHook,
+  type DashHookEndpoint,
+  DASH_HOOK_EVENTS,
+  entryIsDashOwned,
+  mergeHookEntries,
+} from './hookSettingsMerge';
 
 const execFileAsync = promisify(execFile);
 
@@ -289,22 +299,6 @@ function getTaskContextPrompt(taskId: string): string | null {
 }
 
 /**
- * All hook event names that Dash writes to settings.local.json.
- * Used by both writeHookSettings and cleanupHookSettings.
- */
-const DASH_HOOK_EVENTS = [
-  'Stop',
-  'UserPromptSubmit',
-  'Notification',
-  'PreToolUse',
-  'PostToolUse',
-  'StopFailure',
-  'PreCompact',
-  'PostCompact',
-  'SessionStart',
-] as const;
-
-/**
  * Claude Code rejects an entire settings.local.json if any top-level hook key
  * is unknown to the running CLI version. Newer hook events must be gated so
  * older Claude Code installs don't lose ALL Dash hooks (see GH #127).
@@ -334,56 +328,107 @@ function isClaudeVersionAtLeast(major: number, minor: number, patch: number): bo
 }
 
 /**
+ * Mark a hook as Dash-authored. The brand lets the merge module recognize
+ * it on the next rewrite without falling back to URL/command-shape pattern
+ * matching.
+ */
+function tagDash<T extends HttpHook | CommandHook>(hook: T): T & { __dash: true } {
+  return { ...hook, __dash: true };
+}
+
+/**
+ * Atomic write: stage to a sibling tmp file then rename over the target.
+ * POSIX rename is atomic, so a crash mid-write can never leave a half-
+ * written file at `target`. Important here because settings.local.json is
+ * rewritten frequently (every PTY spawn, every commit-attribution change)
+ * and the corrupt-recovery path on the read side would otherwise have to
+ * handle a wider class of partial-write failures than just user edits.
+ */
+function atomicWriteFileSync(target: string, data: string): void {
+  const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmp, data);
+  fs.renameSync(tmp, target);
+}
+
+function broadcastToast(message: string): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send('app:toast', { message });
+    }
+  }
+}
+
+type HookWriteResult = { ok: true } | { ok: false; settingsPath: string; error: string };
+
+/**
  * Write .claude/settings.local.json with hooks for activity monitoring,
  * tool tracking, error detection, and context usage.
  *
  * Hooks use type: "http" — Claude Code POSTs the hook JSON body directly
  * to our local HookServer. The statusLine uses type: "command" with curl
  * (http type is not supported for statusLine).
+ *
+ * Merging preserves user-authored entries via the merge module's brand-or-
+ * URL-shape detector, so users can have their own hooks under managed
+ * events without losing them on every rewrite.
  */
-function writeHookSettings(cwd: string, ptyId: string): void {
+function writeHookSettings(cwd: string, ptyId: string): HookWriteResult {
   const port = hookServer.port;
-  if (port === 0) return;
-
   const claudeDir = path.join(cwd, '.claude');
   const settingsPath = path.join(claudeDir, 'settings.local.json');
-  const base = `http://127.0.0.1:${port}`;
 
-  /** Shorthand: build an HTTP hook entry. */
-  const httpHook = (endpoint: string, async?: boolean) => ({
+  // The await order in main.ts (`await hookServer.start()` before IPC
+  // registration) makes this branch unreachable in normal startup; if we hit
+  // it, something has invoked writeHookSettings outside the IPC entry path.
+  // Surface it loudly rather than leaving stale on-disk hooks unchanged.
+  if (port === 0) {
+    console.error(
+      '[writeHookSettings] HookServer port not bound — settings.local.json not updated. ' +
+        `Likely a startup-ordering bug (caller invoked before hookServer.start() resolved). cwd=${cwd}`,
+    );
+    broadcastToast(
+      `Hook server not ready — task hooks couldn't be written for ${path.basename(cwd)}. Restart Dash to recover.`,
+    );
+    return {
+      ok: false,
+      settingsPath,
+      error: 'HookServer port not bound',
+    };
+  }
+
+  const base = `http://127.0.0.1:${port}`;
+  const buildHookUrl = (endpoint: DashHookEndpoint) => `${base}/hook/${endpoint}?ptyId=${ptyId}`;
+
+  const httpHook = (endpoint: DashHookEndpoint, async?: boolean): HttpHook => ({
     type: 'http' as const,
-    url: `${base}${endpoint}?ptyId=${ptyId}`,
+    url: buildHookUrl(endpoint),
     ...(async ? { async: true } : {}),
   });
 
-  const hookSettings: Record<string, unknown[]> = {
-    // ── Activity state signals ──────────────────────────────
-    Stop: [{ hooks: [httpHook('/hook/stop')] }],
-    UserPromptSubmit: [{ hooks: [httpHook('/hook/busy')] }],
+  const dashHttp = (endpoint: DashHookEndpoint, async?: boolean) =>
+    tagDash(httpHook(endpoint, async));
 
-    // ── Notification (permission prompt, idle) ──────────────
+  const dashEntries: Record<string, HookEntry[]> = {
+    Stop: [{ matcher: '', hooks: [dashHttp('stop')] }],
+    UserPromptSubmit: [{ matcher: '', hooks: [dashHttp('busy')] }],
     Notification: [
-      { matcher: 'permission_prompt', hooks: [httpHook('/hook/notification')] },
-      { matcher: 'idle_prompt', hooks: [httpHook('/hook/notification')] },
+      { matcher: 'permission_prompt', hooks: [dashHttp('notification')] },
+      { matcher: 'idle_prompt', hooks: [dashHttp('notification')] },
     ],
-
-    // ── Tool activity tracking ──────────────────────────────
-    PreToolUse: [{ matcher: '*', hooks: [httpHook('/hook/tool-start', true)] }],
-    PostToolUse: [{ matcher: '*', hooks: [httpHook('/hook/tool-end', true)] }],
-
-    // ── Context compaction ──────────────────────────────────
-    PreCompact: [{ matcher: '*', hooks: [httpHook('/hook/compact-start', true)] }],
+    PreToolUse: [{ matcher: '*', hooks: [dashHttp('tool-start', true)] }],
+    PostToolUse: [{ matcher: '*', hooks: [dashHttp('tool-end', true)] }],
+    PreCompact: [{ matcher: '*', hooks: [dashHttp('compact-start', true)] }],
   };
 
   // PostCompact added in Claude Code 2.1.76; older CLIs reject the key and
   // skip the entire settings file (GH #127), losing all Dash hooks.
   if (isClaudeVersionAtLeast(2, 1, 76)) {
-    hookSettings.PostCompact = [{ matcher: '*', hooks: [httpHook('/hook/compact-end', true)] }];
+    dashEntries.PostCompact = [{ matcher: '*', hooks: [dashHttp('compact-end', true)] }];
   }
 
   // StopFailure added in Claude Code 2.1.78.
   if (isClaudeVersionAtLeast(2, 1, 78)) {
-    hookSettings.StopFailure = [{ matcher: '*', hooks: [httpHook('/hook/stop-failure')] }];
+    dashEntries.StopFailure = [{ matcher: '*', hooks: [dashHttp('stop-failure')] }];
   }
 
   // SessionStart hook re-injects task context (linked issue/work-item prompt)
@@ -406,10 +451,10 @@ function writeHookSettings(cwd: string, ptyId: string): void {
       process.platform === 'win32'
         ? `powershell.exe -NoProfile -Command "[Console]::Out.Write([System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${b64}')))"`
         : `echo '${b64}' | base64 ${process.platform === 'darwin' ? '-D' : '-d'}`;
-    const contextHook = { type: 'command', command: decodeCmd };
-    hookSettings.SessionStart = ['startup', 'compact', 'clear'].map((matcher) => ({
+    const contextHook: CommandHook = { type: 'command', command: decodeCmd };
+    dashEntries.SessionStart = ['startup', 'compact', 'clear'].map((matcher) => ({
       matcher,
-      hooks: [contextHook],
+      hooks: [tagDash(contextHook)],
     }));
   }
 
@@ -418,66 +463,89 @@ function writeHookSettings(cwd: string, ptyId: string): void {
       fs.mkdirSync(claudeDir, { recursive: true });
     }
 
-    // Merge with existing settings to preserve non-hook config
     let existing: Record<string, unknown> = {};
     if (fs.existsSync(settingsPath)) {
       try {
-        existing = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+        const parsed = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) as unknown;
+        // JSON.parse succeeds on "null", "42", "[]", etc. Only plain objects
+        // can be spread and merged safely; anything else is treated as corrupt.
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          existing = parsed as Record<string, unknown>;
+        } else {
+          throw new Error(`settings.local.json is not a JSON object (got ${typeof parsed})`);
+        }
       } catch (err) {
-        console.error(
-          '[writeHookSettings] Corrupted settings.local.json at',
-          settingsPath,
-          '— overwriting:',
-          err,
-        );
+        // Back up the corrupt file before overwriting so the user can recover.
+        // If the backup rename fails, we MUST NOT proceed to overwrite — that
+        // would destroy the user's on-disk file with no copy left.
+        const backupPath = `${settingsPath}.corrupt-${Date.now()}.bak`;
+        try {
+          fs.renameSync(settingsPath, backupPath);
+          console.error(
+            `[writeHookSettings] settings.local.json corrupt at ${settingsPath}; backed up to ${backupPath}`,
+            err,
+          );
+          broadcastToast(
+            `settings.local.json was unreadable — backed up to ${path.basename(backupPath)} and rewritten.`,
+          );
+        } catch (renameErr) {
+          console.error(
+            '[writeHookSettings] Failed to back up corrupt file; leaving on-disk file intact:',
+            renameErr,
+          );
+          broadcastToast(
+            `settings.local.json is corrupt and could not be backed up — hooks are off for this task. Fix or remove ${path.basename(settingsPath)} manually.`,
+          );
+          return {
+            ok: false,
+            settingsPath,
+            error: `corrupt settings.local.json; backup rename failed: ${renameErr instanceof Error ? renameErr.message : String(renameErr)}`,
+          };
+        }
       }
     }
 
-    // Drop any prior Dash-written hook keys before merging. A previous Dash
-    // version may have written events the current Claude Code CLI doesn't
-    // recognize (e.g. PostCompact pre-2.1.76), which would cause Claude to
-    // reject the entire settings file.
-    const existingHooks: Record<string, unknown> =
+    const existingHooks =
       existing.hooks && typeof existing.hooks === 'object'
-        ? { ...(existing.hooks as Record<string, unknown>) }
+        ? (existing.hooks as Record<string, HookEntry[] | undefined>)
         : {};
-    for (const key of DASH_HOOK_EVENTS) {
-      delete existingHooks[key];
-    }
+
+    const mergedHooks = mergeHookEntries(existingHooks, dashEntries);
 
     const merged: Record<string, unknown> = {
       ...existing,
-      hooks: {
-        ...existingHooks,
-        ...hookSettings,
-      },
+      hooks: mergedHooks,
     };
 
-    // statusLine: command that pipes Claude Code's JSON context data to our hook server
-    const contextUrl = `${base}/hook/context?ptyId=${ptyId}`;
+    const contextUrl = buildHookUrl('context');
     merged.statusLine = {
       type: 'command',
       command: `curl -s --connect-timeout 2 -X POST -H "Content-Type: application/json" -d @- "${contextUrl}" >/dev/null 2>&1`,
     };
 
-    // Commit attribution: undefined = Dash default, '' = suppress, other = custom.
     const effectiveAttribution =
       commitAttributionSetting === undefined ? DASH_DEFAULT_ATTRIBUTION : commitAttributionSetting;
     merged.attribution = { commit: effectiveAttribution };
 
-    fs.writeFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
+    atomicWriteFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
     writtenSettingsPaths.add(settingsPath);
-    console.error(
-      `[writeHookSettings] Wrote ${settingsPath} (attribution: ${commitAttributionSetting === undefined ? 'default' : commitAttributionSetting || 'none'})`,
-    );
+    return { ok: true };
   } catch (err) {
     console.error('[writeHookSettings] Failed:', err);
+    broadcastToast(`Could not write ${path.basename(settingsPath)} — hooks are off for this task.`);
+    return {
+      ok: false,
+      settingsPath,
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
 }
 
 /**
  * Remove Dash-written hooks and attribution from all settings.local.json files
- * that were written during this session. Called on app quit to prevent stale hooks.
+ * that were written during this session. Preserves user-authored entries
+ * by filtering against the merge module's Dash-owned detector instead of
+ * deleting the entire managed-event keys.
  */
 export function cleanupHookSettings(): void {
   for (const settingsPath of writtenSettingsPaths) {
@@ -489,25 +557,24 @@ export function cleanupHookSettings(): void {
 
       if (hooks && typeof hooks === 'object') {
         for (const key of DASH_HOOK_EVENTS) {
-          delete hooks[key];
+          const entries = hooks[key];
+          if (!Array.isArray(entries)) continue;
+          const userOnly = entries.filter((e) => !entryIsDashOwned(e));
+          if (userOnly.length === 0) delete hooks[key];
+          else hooks[key] = userOnly;
         }
-        // Remove hooks object entirely if empty
         if (Object.keys(hooks).length === 0) {
           delete raw.hooks;
         }
       }
 
-      // Remove Dash statusLine and attribution
       delete raw.statusLine;
       delete raw.attribution;
 
-      // If nothing meaningful remains, delete the file
       if (Object.keys(raw).length === 0) {
         fs.unlinkSync(settingsPath);
-        console.error(`[cleanupHookSettings] Removed empty ${settingsPath}`);
       } else {
-        fs.writeFileSync(settingsPath, JSON.stringify(raw, null, 2) + '\n');
-        console.error(`[cleanupHookSettings] Cleaned hooks from ${settingsPath}`);
+        atomicWriteFileSync(settingsPath, JSON.stringify(raw, null, 2) + '\n');
       }
     } catch (err) {
       console.error(`[cleanupHookSettings] Failed for ${settingsPath}:`, err);


### PR DESCRIPTION
## Summary
- Replace destructive `delete existingHooks[key]` in `writeHookSettings` with a brand-aware merge from a new pure module (`hookSettingsMerge.ts`). Dash-owned entries are now identified by `__dash: true` brand, by loopback URL shape (any port, against a canonical `/hook/<endpoint>` set), or by the SessionStart base64-decode command shape — so stale entries from prior sessions and from versions before the brand existed get cleaned forward instead of accumulating into ECONNREFUSED-on-every-tool-call landmines.
- Drift prevention via typed canonical lists: `DashHookEndpoint` is a literal union derived from the endpoint array, and `writeHookSettings`'s URL builder is constrained to it — adding a new endpoint without updating the canonical list now fails the build.
- Adjacent improvements bundled in the same code path: `atomicWriteFileSync` (tmp + rename) so a crash mid-write can't strand a half-written file; backup-before-overwrite when `settings.local.json` is unparseable; visible failure (log + toast) when the hook server's port isn't bound instead of a silent no-op; `cleanupHookSettings` filters Dash-owned entries instead of nuking entire managed-event keys, so user-authored hooks survive.
- Keeps #128's `isClaudeVersionAtLeast` gating for `PostCompact` / `StopFailure` and doesn't touch #124's session-resume path.

## Test plan
- [x] `pnpm exec vitest run` — 69 tests pass (26 in the new `hookSettingsMerge.test.ts` covering brand match, URL-shape fallback, stale-port migration, curl-command Dash entries, SessionStart base64 shapes on macOS / Linux / Windows, false-positive guards on user commands and unknown endpoints, empty-key cleanup, and user-content survival across the merge).
- [x] `pnpm type-check` — clean (verifies the `DashHookEndpoint` constraint catches typo'd endpoints at compile time).
- [x] Manual verification: with a `settings.local.json` containing stale hooks from prior sessions (any of: HTTP entries with dead ports, curl-command entries under legacy event names like `PostToolUseFailure`/`SubagentStart`/`SubagentStop`, SessionStart base64-decode commands), spawn a task in Dash; the file should be migrated to a single set of fresh tagged entries on the current port.
- [x] Manual verification: a user-authored hook entry under a managed event (e.g. `PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'echo from-user' }] }]`) survives a Dash spawn unchanged.

Claude goes brrr - via Dash