### PR TITLE
Salvage three independent bug fixes from PR #126

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, app, shell, BrowserWindow, Notification } from 'electron';
+import { ipcMain, dialog, app, shell, BrowserWindow, Notification, clipboard } from 'electron';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { existsSync, readFileSync } from 'fs';
@@ -159,6 +159,16 @@ export function registerAppIpc(): void {
 
   ipcMain.handle('app:openExternal', async (_event, url: string) => {
     await shell.openExternal(url);
+  });
+
+  // Electron's clipboard module bypasses the web clipboard API, which is
+  // unreliable on Linux (Wayland permission prompts, silent failures when
+  // the page loses focus between keydown and the async write).
+  ipcMain.on('app:clipboardWriteText', (_event, text: string) => {
+    clipboard.writeText(text);
+  });
+  ipcMain.handle('app:clipboardReadText', () => {
+    return clipboard.readText();
   });
 
   ipcMain.handle('app:showOpenDialog', async () => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -8,6 +8,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Dialogs
   showOpenDialog: () => ipcRenderer.invoke('app:showOpenDialog'),
   openExternal: (url: string) => ipcRenderer.invoke('app:openExternal', url),
+  clipboardWriteText: (text: string) => ipcRenderer.send('app:clipboardWriteText', text),
+  clipboardReadText: () => ipcRenderer.invoke('app:clipboardReadText'),
   openInEditor: (args: { cwd: string; filePath: string; line?: number; col?: number }) =>
     ipcRenderer.invoke('app:openInEditor', args),
   openInIDE: (args: {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -514,7 +514,7 @@ export function App() {
   }, [tasksByProject]);
 
   // Threshold alerts — fires toast notifications when usage exceeds thresholds
-  useThresholdAlerts(statusLineData, usageThresholds, taskNames);
+  useThresholdAlerts(statusLineData, latestRateLimits, usageThresholds, taskNames);
 
   // Persist usage thresholds
   useEffect(() => {

--- a/src/renderer/hooks/useThresholdAlerts.ts
+++ b/src/renderer/hooks/useThresholdAlerts.ts
@@ -1,60 +1,67 @@
 import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
-import type { StatusLineData, UsageThresholds } from '../../shared/types';
+import type { RateLimits, StatusLineData, UsageThresholds } from '../../shared/types';
 
 export function useThresholdAlerts(
   statusLineData: Record<string, StatusLineData>,
+  latestRateLimits: RateLimits | undefined,
   usageThresholds: UsageThresholds,
   taskNames: Record<string, string>,
 ) {
   const firedRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    // Prune fired keys for PTYs that no longer exist
+    // Prune fired context keys for PTYs that no longer exist. Global
+    // rate-limit keys ('global:*') are kept across PTY churn.
     for (const key of firedRef.current) {
+      if (key.startsWith('global:')) continue;
       const ptyId = key.split(':')[0];
       if (!statusLineData[ptyId]) {
         firedRef.current.delete(key);
       }
     }
 
-    for (const [ptyId, sl] of Object.entries(statusLineData)) {
-      const checks: [string, number, number | null][] = [
-        ['context', sl.contextUsage.percentage, usageThresholds.contextPercentage],
-        [
-          'fiveHour',
-          sl.rateLimits?.fiveHour?.usedPercentage ?? 0,
-          usageThresholds.fiveHourPercentage,
-        ],
-        [
-          'sevenDay',
-          sl.rateLimits?.sevenDay?.usedPercentage ?? 0,
-          usageThresholds.sevenDayPercentage,
-        ],
-      ];
-      const taskName = taskNames[ptyId];
-      for (const [kind, value, threshold] of checks) {
-        if (threshold === null || threshold <= 0) continue;
-        const key = `${ptyId}:${kind}`;
-
-        // Hysteresis: clear fired state when value drops below 90% of threshold
-        if (value < threshold * 0.9) {
-          firedRef.current.delete(key);
-          continue;
-        }
-
-        if (value >= threshold && !firedRef.current.has(key)) {
-          firedRef.current.add(key);
-          const pct = Math.round(value);
-          const labels: Record<string, string> = {
-            context: `Context window at ${pct}%`,
-            fiveHour: `5-hour rate limit at ${pct}%`,
-            sevenDay: `7-day rate limit at ${pct}%`,
-          };
-          const base = labels[kind] || `Usage threshold reached: ${kind}`;
-          toast.warning(taskName ? `${taskName}: ${base}` : base);
-        }
+    const fire = (key: string, value: number, threshold: number | null, label: string) => {
+      if (threshold === null || threshold <= 0) return;
+      if (value < threshold * 0.9) {
+        firedRef.current.delete(key);
+        return;
       }
+      if (value >= threshold && !firedRef.current.has(key)) {
+        firedRef.current.add(key);
+        toast.warning(label);
+      }
+    };
+
+    // Context window is per-session, so check each PTY independently.
+    for (const [ptyId, sl] of Object.entries(statusLineData)) {
+      const taskName = taskNames[ptyId];
+      const pct = Math.round(sl.contextUsage.percentage);
+      const base = `Context window at ${pct}%`;
+      fire(
+        `${ptyId}:context`,
+        sl.contextUsage.percentage,
+        usageThresholds.contextPercentage,
+        taskName ? `${taskName}: ${base}` : base,
+      );
     }
-  }, [statusLineData, usageThresholds, taskNames]);
+
+    // Rate limits are account-wide. Per-PTY status-line snapshots can be
+    // stale (e.g. a resumed old chat reports a stale rate_limits value),
+    // so check against the most-recent snapshot only.
+    const fh = latestRateLimits?.fiveHour?.usedPercentage ?? 0;
+    fire(
+      'global:fiveHour',
+      fh,
+      usageThresholds.fiveHourPercentage,
+      `5-hour rate limit at ${Math.round(fh)}%`,
+    );
+    const sd = latestRateLimits?.sevenDay?.usedPercentage ?? 0;
+    fire(
+      'global:sevenDay',
+      sd,
+      usageThresholds.sevenDayPercentage,
+      `7-day rate limit at ${Math.round(sd)}%`,
+    );
+  }, [statusLineData, latestRateLimits, usageThresholds, taskNames]);
 }

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -42,6 +42,11 @@ export class TerminalSessionManager {
   private savedViewportY: number | null = null;
   readonly shellOnly: boolean;
   private themeId: string;
+  // Claude Code's TUI rewrites cells continuously, which causes xterm to drop
+  // the visible selection before the user can press the copy shortcut. Cache
+  // the last non-empty selection on every change so Ctrl+Shift+C / Cmd+C can
+  // still copy it even after xterm has cleared the highlight.
+  private lastSelection = '';
   constructor(opts: {
     id: string;
     cwd: string;
@@ -108,6 +113,13 @@ export class TerminalSessionManager {
       ),
     );
 
+    // Cache selection on every change — Claude Code's TUI rewrites cells as the
+    // user drags, which clears xterm's selection before the copy shortcut fires.
+    this.terminal.onSelectionChange(() => {
+      const sel = this.terminal.getSelection();
+      if (sel) this.lastSelection = sel;
+    });
+
     // Track cwd via OSC 7 (emitted by zsh on macOS by default)
     this.terminal.parser.registerOscHandler(7, (data) => {
       try {
@@ -130,29 +142,36 @@ export class TerminalSessionManager {
 
       const isMac = navigator.userAgent.includes('Mac');
 
-      // Copy: Cmd+C (macOS) or Ctrl+Shift+C (Linux) — copy terminal selection
+      // Match by physical key (e.code) so alternate keyboard layouts where
+      // Ctrl+Shift+C reports e.key as something other than 'C' still work.
+      const isKeyC = e.code === 'KeyC';
+      const isKeyV = e.code === 'KeyV';
+
+      // Copy: Cmd+C (macOS) or Ctrl+Shift+C (Linux) — copy terminal selection.
       // Also Ctrl+C on any platform when there's an active selection (matches
-      // native terminal behaviour: Ctrl+C copies when selected, sends SIGINT otherwise)
-      if (
-        (isMac && e.metaKey && e.key === 'c') ||
-        (!isMac && e.ctrlKey && e.shiftKey && e.key === 'C') ||
-        (e.ctrlKey && !e.shiftKey && e.key === 'c' && this.terminal.hasSelection())
-      ) {
-        const sel = this.terminal.getSelection();
+      // native terminal behaviour: Ctrl+C copies when selected, sends SIGINT
+      // otherwise). Explicit shortcuts fall back to lastSelection so users can
+      // still copy after the TUI has cleared xterm's highlight.
+      const isExplicitCopy =
+        (isMac && e.metaKey && isKeyC && !e.ctrlKey) ||
+        (!isMac && e.ctrlKey && e.shiftKey && isKeyC);
+      const isPlainCtrlC = e.ctrlKey && !e.shiftKey && isKeyC && this.terminal.hasSelection();
+      if (isExplicitCopy || isPlainCtrlC) {
+        const sel = this.terminal.getSelection() || (isExplicitCopy ? this.lastSelection : '');
         if (sel) {
           e.preventDefault();
-          navigator.clipboard.writeText(sel);
+          window.electronAPI.clipboardWriteText(sel);
           return false;
         }
       }
 
       // Paste: Cmd+V (macOS) or Ctrl+Shift+V (Linux)
       if (
-        (isMac && e.metaKey && e.key === 'v') ||
-        (!isMac && e.ctrlKey && e.shiftKey && e.key === 'V')
+        (isMac && e.metaKey && isKeyV && !e.ctrlKey) ||
+        (!isMac && e.ctrlKey && e.shiftKey && isKeyV)
       ) {
         e.preventDefault();
-        navigator.clipboard.readText().then((text) => {
+        window.electronAPI.clipboardReadText().then((text) => {
           if (text) window.electronAPI.ptyInput({ id: this.id, data: text });
         });
         return false;

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -319,8 +319,11 @@ export class TerminalSessionManager {
           if (snapshotResp.success && snapshotResp.data) {
             existingSnapshot = snapshotResp.data;
           }
-        } catch {
-          // Best effort
+        } catch (err) {
+          // Snapshot fetch via IPC: legitimate "no snapshot" arrives as a
+          // success with empty data, so reaching the catch means IPC itself
+          // misbehaved — log so a permanently broken bridge is debuggable.
+          console.warn('[terminal] ptyGetSnapshot failed:', err);
         }
         if (gen !== this.attachGeneration) return;
 
@@ -338,8 +341,11 @@ export class TerminalSessionManager {
         if (existingSnapshot && !reattached) {
           try {
             this.terminal.write(existingSnapshot.data);
-          } catch {
-            // Best effort
+          } catch (err) {
+            // xterm rejected the buffered bytes — usually a corrupt or
+            // malformed control sequence in the snapshot. Without logging,
+            // the user just sees a half-rendered terminal with no clue why.
+            console.warn('[terminal] writing snapshot to xterm failed:', err);
           }
         }
       } else {
@@ -352,8 +358,11 @@ export class TerminalSessionManager {
           if (snapshotResp.success && snapshotResp.data) {
             existingSnapshot = snapshotResp.data;
           }
-        } catch {
-          // Best effort
+        } catch (err) {
+          // Snapshot fetch via IPC: legitimate "no snapshot" arrives as a
+          // success with empty data, so reaching the catch means IPC itself
+          // misbehaved — log so a permanently broken bridge is debuggable.
+          console.warn('[terminal] ptyGetSnapshot failed:', err);
         }
         if (gen !== this.attachGeneration) return;
 
@@ -387,8 +396,11 @@ export class TerminalSessionManager {
         if (existingSnapshot && !result.reattached) {
           try {
             this.terminal.write(existingSnapshot.data);
-          } catch {
-            // Best effort
+          } catch (err) {
+            // xterm rejected the buffered bytes — usually a corrupt or
+            // malformed control sequence in the snapshot. Without logging,
+            // the user just sees a half-rendered terminal with no clue why.
+            console.warn('[terminal] writing snapshot to xterm failed:', err);
           }
         }
       }
@@ -789,8 +801,10 @@ export class TerminalSessionManager {
       };
       window.electronAPI.ptySaveSnapshot(this.id, snapshot);
       this.snapshotDirty = false;
-    } catch {
-      // Best effort
+    } catch (err) {
+      // Serialize / IPC failure. If snapshots are silently broken, the user
+      // sees a blank terminal on next reload with no way to attribute it.
+      console.warn('[terminal] saveSnapshot failed:', err);
     }
   }
 
@@ -801,8 +815,8 @@ export class TerminalSessionManager {
         this.terminal.write(resp.data.data);
         return true;
       }
-    } catch {
-      // Best effort
+    } catch (err) {
+      console.warn('[terminal] restoreSnapshot failed:', err);
     }
     return false;
   }

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -29,6 +29,8 @@ export interface ElectronAPI {
   // Dialogs
   showOpenDialog: () => Promise<IpcResponse<string[]>>;
   openExternal: (url: string) => Promise<void>;
+  clipboardWriteText: (text: string) => void;
+  clipboardReadText: () => Promise<string>;
   openInEditor: (args: {
     cwd: string;
     filePath: string;


### PR DESCRIPTION
## Summary
Three orthogonal bug fixes that were sitting on the RTK branch (#126) but are unrelated to RTK. Lifting them onto main as their own focused PR so they don't get lost when #126 is rebased to RTK-only. Each commit preserves its original author.

- **`8939608` Check rate-limit thresholds against latest snapshot, not per PTY** — `useThresholdAlerts` was iterating every PTY's stored status-line snapshot, but the 5-hour and 7-day rate limits are account-wide. Resumed chats report stale `rate_limits`, so an idle session at 71% would fire a toast even when the live (top-right) value was 6%. Check rate limits once against `latestRateLimits` with global keys; keep the per-PTY loop for context window only.
- **`d6faff5` Fix terminal copy/paste on Linux** — `navigator.clipboard` silently fails on Wayland (no permission prompt, just a rejected promise we never awaited). Route clipboard writes/reads through Electron's main-process `clipboard` module instead. Also caches the last non-empty xterm selection so Ctrl+Shift+C / Cmd+C still works after Claude Code's TUI has redrawn cells, and matches copy/paste shortcuts by `e.code` (physical key) so non-QWERTY layouts aren't silently excluded.
- **`6bdd718` Log snapshot save/restore IPC failures instead of swallowing them** — six catch blocks around per-PTY snapshot save / restore / re-write paths swallowed errors with `// Best effort`. A permanently broken IPC bridge or a corrupt snapshot would silently produce a blank terminal with no way to attribute it. Switched to `console.warn` with short path-specific notes. Slice salvaged from `a5835f3`; the rest of that commit is now on main via #130.

## Test plan
- [x] `pnpm exec vitest run` — 75 tests pass.
- [x] `pnpm type-check` — clean.
- [x] Manual (Wayland Linux): Ctrl+Shift+C / Ctrl+Shift+V in a Dash terminal works; selection survives Claude Code TUI redraws; non-QWERTY keyboard layouts still copy/paste.
- [x] Manual: resume a Dash task whose stored status-line snapshot has a high `fiveHour.usedPercentage` while the live account value is low — toast no longer fires falsely.

Claude goes brrr - via Dash