### PR TITLE
Add RTK (Rust Token Killer) integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.9.13",
+  "version": "0.10.0",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -7,6 +7,7 @@ import { registerGithubIpc } from './githubIpc';
 import { registerAutoUpdateIpc } from './autoUpdateIpc';
 import { registerAzureDevOpsIpc } from './azureDevOpsIpc';
 import { registerPixelAgentsIpc } from './pixelAgentsIpc';
+import { registerRtkIpc } from './rtkIpc';
 import { registerTelemetryIpc } from './telemetryIpc';
 
 export function registerAllIpc(): void {
@@ -19,5 +20,6 @@ export function registerAllIpc(): void {
   registerAutoUpdateIpc();
   registerAzureDevOpsIpc();
   registerPixelAgentsIpc();
+  registerRtkIpc();
   registerTelemetryIpc();
 }

--- a/src/main/ipc/rtkIpc.ts
+++ b/src/main/ipc/rtkIpc.ts
@@ -1,0 +1,84 @@
+import { basename } from 'node:path';
+import { ipcMain } from 'electron';
+import { RtkService } from '../services/RtkService';
+import { refreshActivePtyHooks, type RefreshFailure } from '../services/ptyManager';
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function summarizeFailures(failures: RefreshFailure[]): string {
+  const n = failures.length;
+  const head = `${n} active task${n === 1 ? '' : 's'} didn't pick up the change`;
+  const detail = failures
+    .slice(0, 3)
+    .map((f) => `${basename(f.settingsPath)}: ${f.error}`)
+    .join('; ');
+  const more = n > 3 ? ` (+${n - 3} more)` : '';
+  return `${head} — ${detail}${more}`;
+}
+
+export function registerRtkIpc(): void {
+  ipcMain.handle('rtk:getStatus', async () => {
+    try {
+      return { success: true, data: await RtkService.getStatus() };
+    } catch (error) {
+      console.error('[rtk:getStatus]', error);
+      return { success: false, error: errorMessage(error) };
+    }
+  });
+
+  ipcMain.handle('rtk:setEnabled', async (_event, enabled: boolean) => {
+    try {
+      // RtkService.setEnabled throws "rtk is not installed" if no binary is
+      // resolved; we surface it via the IPC error envelope. The wire-type
+      // (RtkStatus) makes "enabled while not installed" unrepresentable, so
+      // a redundant pre-flight check would only widen the race window.
+      RtkService.setEnabled(enabled);
+      const { failures } = refreshActivePtyHooks();
+      // Flag persisted to disk either way. When refresh partially failed,
+      // return success (don't roll back the toggle — the state IS saved)
+      // with a `warning` so the renderer can surface the partial state.
+      if (failures.length > 0) {
+        return { success: true, data: { warning: `Saved, but ${summarizeFailures(failures)}` } };
+      }
+      return { success: true, data: {} };
+    } catch (error) {
+      console.error('[rtk:setEnabled]', error);
+      return { success: false, error: errorMessage(error) };
+    }
+  });
+
+  ipcMain.handle('rtk:download', async () => {
+    try {
+      await RtkService.download();
+      // Refresh hook JSON in active PTYs so a download while the toggle is
+      // already on starts rewriting immediately. Failures are surfaced via
+      // a `warning` field (matching rtk:setEnabled): the install itself
+      // succeeded, but the user has running tasks that won't pick up the
+      // new hook until they restart, and they should know.
+      const { failures } = refreshActivePtyHooks();
+      if (failures.length > 0) {
+        return {
+          success: true,
+          data: {
+            warning: `Installed. ${summarizeFailures(failures)} — restart those tasks to start compressing.`,
+          },
+        };
+      }
+      return { success: true, data: undefined };
+    } catch (error) {
+      console.error('[rtk:download]', error);
+      return { success: false, error: errorMessage(error) };
+    }
+  });
+
+  ipcMain.handle('rtk:test', async () => {
+    try {
+      return { success: true, data: await RtkService.runHookTest() };
+    } catch (error) {
+      console.error('[rtk:test]', error);
+      return { success: false, error: errorMessage(error) };
+    }
+  });
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -144,6 +144,13 @@ app.whenReady().then(async () => {
     PixelAgentsService.start();
   }
 
+  // Resolve rtk synchronously at startup; getHookCommand() is called on PTY spawn.
+  const { RtkService } = await import('./services/RtkService');
+  RtkService.setSender(mainWindow.webContents);
+  await RtkService.warmUp().catch((err) => {
+    console.error('[RtkService.warmUp]', err);
+  });
+
   // Cleanup orphaned reserve worktrees (background, non-blocking)
   setTimeout(async () => {
     try {
@@ -210,6 +217,8 @@ app.on('activate', async () => {
     remoteControlService.setSender(mainWindow.webContents);
     const { PixelAgentsService } = await import('./services/PixelAgentsService');
     PixelAgentsService.setSender(mainWindow.webContents);
+    const { RtkService } = await import('./services/RtkService');
+    RtkService.setSender(mainWindow.webContents);
     const { contextUsageService } = await import('./services/ContextUsageService');
     contextUsageService.setSender(mainWindow.webContents);
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -249,6 +249,22 @@ contextBridge.exposeInMainWorld('electronAPI', {
     };
   },
 
+  // RTK (Rust Token Killer)
+  rtkGetStatus: () => ipcRenderer.invoke('rtk:getStatus'),
+  rtkSetEnabled: (enabled: boolean) => ipcRenderer.invoke('rtk:setEnabled', enabled),
+  rtkDownload: () => ipcRenderer.invoke('rtk:download'),
+  rtkTest: () => ipcRenderer.invoke('rtk:test'),
+  onRtkDownloadProgress: (
+    callback: (progress: import('@shared/types').RtkDownloadProgress) => void,
+  ) => {
+    const handler = (_event: unknown, progress: import('@shared/types').RtkDownloadProgress) =>
+      callback(progress);
+    ipcRenderer.on('rtk:downloadProgress', handler);
+    return () => {
+      ipcRenderer.removeListener('rtk:downloadProgress', handler);
+    };
+  },
+
   // Telemetry
   telemetryCapture: (event: string, properties?: Record<string, unknown>) =>
     ipcRenderer.invoke('telemetry:capture', { event, properties }),

--- a/src/main/services/RtkService.ts
+++ b/src/main/services/RtkService.ts
@@ -1,0 +1,994 @@
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  createReadStream,
+  createWriteStream,
+  chmodSync,
+  lstatSync,
+  renameSync,
+  rmSync,
+} from 'node:fs';
+import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { delimiter, dirname, join, normalize, resolve, sep } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFile, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
+import { createHash } from 'node:crypto';
+import type { ReadableStream as WebReadableStream } from 'node:stream/web';
+import { app } from 'electron';
+import type { WebContents } from 'electron';
+import type { RtkStatus, RtkSource, RtkDownloadProgress, RtkTestResult } from '@shared/types';
+
+const execFileAsync = promisify(execFile);
+
+// Cap download phases so a hung CDN cannot leave the single-flight promise
+// pending forever — subsequent download() calls would await the dead promise.
+const FETCH_API_TIMEOUT_MS = 60_000;
+const FETCH_BODY_TIMEOUT_MS = 300_000;
+const TAR_TIMEOUT_MS = 120_000;
+
+/** Managed-bin resolution wins over $PATH so uninstalling Dash leaves no orphan binary. */
+export class RtkService {
+  private static sender: WebContents | null = null;
+  private static cachedResolution: {
+    path: string;
+    source: RtkSource;
+    version: string;
+  } | null = null;
+  private static downloadInFlight: Promise<void> | null = null;
+  // Mirrors the on-disk rtk-config.json flag; saves a disk read per hook write.
+  // null = not yet loaded; hydrated on first isEnabled() call and after setEnabled().
+  private static enabledCache: boolean | null = null;
+  // Track whether we've already toasted a corrupt-config warning, so we don't
+  // spam the user once per hook write — they only need to see it once.
+  private static corruptConfigToasted = false;
+
+  static setSender(sender: WebContents): void {
+    RtkService.sender = sender;
+  }
+
+  private static getConfigPath(): string {
+    return join(app.getPath('userData'), 'rtk-config.json');
+  }
+
+  static isEnabled(): boolean {
+    if (RtkService.enabledCache !== null) return RtkService.enabledCache;
+    const p = RtkService.getConfigPath();
+    if (!existsSync(p)) {
+      RtkService.enabledCache = false;
+      return false;
+    }
+    try {
+      const raw = JSON.parse(readFileSync(p, 'utf-8')) as { enabled?: unknown };
+      const value = raw.enabled === true;
+      if (raw.enabled !== undefined && typeof raw.enabled !== 'boolean') {
+        console.warn(
+          '[RtkService.isEnabled] rtk-config.json "enabled" is not a boolean; treating as false.',
+        );
+        RtkService.notifyCorruptConfig(
+          'RTK config has an invalid "enabled" value — RTK is off until you re-toggle it in Settings.',
+        );
+      }
+      RtkService.enabledCache = value;
+      return value;
+    } catch (err) {
+      console.error(
+        '[RtkService.isEnabled] rtk-config.json unreadable, treating as disabled:',
+        err,
+      );
+      // The user toggled RTK on at some point; a corrupt config now silently
+      // means hooks stop firing in every spawn. Surface it instead of letting
+      // the toggle keep showing ON while reality says OFF.
+      RtkService.notifyCorruptConfig(
+        `RTK config is unreadable (${err instanceof Error ? err.message : String(err)}) — RTK is off until you re-toggle it in Settings.`,
+      );
+      RtkService.enabledCache = false;
+      return false;
+    }
+  }
+
+  /** Toast a corrupt-config warning once per process lifetime. */
+  private static notifyCorruptConfig(message: string): void {
+    if (RtkService.corruptConfigToasted) return;
+    RtkService.corruptConfigToasted = true;
+    const sender = RtkService.sender;
+    if (sender && !sender.isDestroyed()) {
+      sender.send('app:toast', { message });
+    }
+  }
+
+  /**
+   * Enforces the "installed before enabled" invariant at the data layer so
+   * callers outside the IPC handler can't write a config that lies about state.
+   */
+  static setEnabled(enabled: boolean): void {
+    if (enabled && !RtkService.cachedResolution) {
+      throw new Error('rtk is not installed');
+    }
+    const p = RtkService.getConfigPath();
+    mkdirSync(dirname(p), { recursive: true });
+    // Atomic write: tmp + rename so a crash here can never leave a half-
+    // flushed JSON file that isEnabled() would treat as corrupt and silently
+    // disable RTK on the next launch.
+    const tmp = `${p}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(tmp, JSON.stringify({ enabled }, null, 2));
+    renameSync(tmp, p);
+    RtkService.enabledCache = enabled;
+    // A successful write means the file is good. Clear the "we already toasted"
+    // latch so a later re-corruption (manual edit, disk error) toasts again.
+    RtkService.corruptConfigToasted = false;
+  }
+
+  private static getManagedBinDir(): string {
+    return join(app.getPath('userData'), 'bin');
+  }
+
+  private static getManagedBinPath(): string {
+    const exe = process.platform === 'win32' ? 'rtk.exe' : 'rtk';
+    return join(RtkService.getManagedBinDir(), exe);
+  }
+
+  /**
+   * Returns the managed bin dir ONLY when a probed-good binary is there.
+   * Gating on cachedResolution (not just existsSync) prevents poisoning the
+   * PTY PATH with a dir whose binary failed --version.
+   */
+  static getManagedBinDirForPath(): string | null {
+    return RtkService.cachedResolution?.source === 'managed' ? RtkService.getManagedBinDir() : null;
+  }
+
+  private static async resolveBinary(): Promise<{
+    path: string;
+    source: RtkSource;
+    version: string;
+  } | null> {
+    const managed = RtkService.getManagedBinPath();
+    if (existsSync(managed)) {
+      const version = await RtkService.probeVersion(managed);
+      if (version === null) {
+        console.warn('[RtkService] managed binary exists but --version failed:', managed);
+        return null;
+      }
+      return { path: managed, source: 'managed', version };
+    }
+
+    try {
+      const findCmd = process.platform === 'win32' ? 'where.exe' : 'which';
+      const { stdout } = await execFileAsync(findCmd, ['rtk']);
+      const resolved = stdout.trim().split(/\r?\n/)[0]?.trim();
+      if (resolved) {
+        const version = await RtkService.probeVersion(resolved);
+        if (version === null) {
+          console.warn('[RtkService] PATH binary found but --version failed:', resolved);
+          return null;
+        }
+        return { path: resolved, source: 'path', version };
+      }
+    } catch (err) {
+      // Node's execFile rejects with an Error decorated with `code`: the
+      // string 'ENOENT' for a missing `which` binary, or the numeric exit
+      // code for a non-zero exit. Exit 1 from `which`/`where.exe` is the
+      // "not found" signal — not noise.
+      const code = (err as { code?: unknown }).code;
+      if (code !== 'ENOENT' && code !== 1) {
+        console.warn('[RtkService] which/where.exe lookup failed unexpectedly:', err);
+      }
+    }
+
+    return null;
+  }
+
+  private static async probeVersion(binPath: string): Promise<string | null> {
+    try {
+      const { stdout } = await execFileAsync(binPath, ['--version'], { timeout: 3000 });
+      return stdout.trim();
+    } catch (err) {
+      console.warn(`[RtkService] ${binPath} --version failed:`, err);
+      return null;
+    }
+  }
+
+  static getHookCommand(): string | null {
+    const resolved = RtkService.cachedResolution;
+    if (!resolved) return null;
+    // Claude Code runs the hook via sh -c on Unix. Single-quote-escape the
+    // path so spaces and any shell metachars ($, `, ", \) in the userData
+    // directory never break or inject into the command.
+    return `${shellQuoteUnix(resolved.path)} hook claude`;
+  }
+
+  static async getStatus(): Promise<RtkStatus> {
+    const resolved = await RtkService.resolveBinary();
+    // Only update the cache on a positive resolution. A transient failure
+    // (probe timeout, `which` flake) used to clobber a previously-good entry,
+    // which made getHookCommand() silently return null while isEnabled() on
+    // disk still said the toggle was ON — the UI would lie about RTK firing.
+    if (resolved) {
+      RtkService.cachedResolution = resolved;
+    }
+
+    const downloadable = RtkService.isPlatformDownloadable();
+    const effective = resolved ?? RtkService.cachedResolution;
+    if (effective) {
+      return {
+        installed: true,
+        version: effective.version,
+        path: effective.path,
+        source: effective.source,
+        enabled: RtkService.isEnabled(),
+        downloadable,
+      };
+    }
+    // No binary resolved → enabled is omitted by construction; isEnabled()'s
+    // disk flag stays put so the toggle restores correctly once a binary
+    // becomes available again.
+    return { installed: false, downloadable };
+  }
+
+  /** Populates cachedResolution so getHookCommand() is synchronous later. */
+  static async warmUp(): Promise<void> {
+    const resolved = await RtkService.resolveBinary();
+    if (resolved) RtkService.cachedResolution = resolved;
+  }
+
+  /**
+   * Force-clear the cached resolution. Call when the binary has been removed
+   * from disk (uninstall flow) — there is no read-only path to "the binary is
+   * gone" elsewhere, so without this, stale cache could keep getHookCommand()
+   * returning a path that no longer exists.
+   */
+  static invalidateCache(): void {
+    RtkService.cachedResolution = null;
+  }
+
+  // No Windows native release exists upstream — manual-install guidance only there.
+  private static isPlatformDownloadable(): boolean {
+    if (process.platform === 'darwin') return true;
+    if (process.platform === 'linux') return process.arch === 'x64' || process.arch === 'arm64';
+    return false;
+  }
+
+  private static getReleaseAssetName(): string | null {
+    if (process.platform === 'darwin') {
+      return process.arch === 'arm64'
+        ? 'rtk-aarch64-apple-darwin.tar.gz'
+        : 'rtk-x86_64-apple-darwin.tar.gz';
+    }
+    if (process.platform === 'linux') {
+      if (process.arch === 'x64') return 'rtk-x86_64-unknown-linux-musl.tar.gz';
+      if (process.arch === 'arm64') return 'rtk-aarch64-unknown-linux-gnu.tar.gz';
+    }
+    return null;
+  }
+
+  /** Single-flight wrapper so double-clicks don't race on the tmp archive. */
+  static download(): Promise<void> {
+    if (RtkService.downloadInFlight) return RtkService.downloadInFlight;
+    RtkService.downloadInFlight = RtkService.doDownload().finally(() => {
+      RtkService.downloadInFlight = null;
+    });
+    return RtkService.downloadInFlight;
+  }
+
+  /**
+   * Streams RtkDownloadProgress via rtk:downloadProgress AND rejects on failure
+   * so the IPC caller sees the same error. Progress events are for UI; the
+   * promise is authoritative.
+   */
+  private static async doDownload(): Promise<void> {
+    const assetName = RtkService.getReleaseAssetName();
+    if (!assetName) {
+      const msg = `No rtk release for ${process.platform}/${process.arch}. Install manually from rtk-ai.app.`;
+      RtkService.emitProgress({ phase: 'error', error: msg });
+      throw new Error(msg);
+    }
+
+    const binDir = RtkService.getManagedBinDir();
+    const tmpArchive = join(binDir, `${assetName}.tmp`);
+    const binPath = RtkService.getManagedBinPath();
+
+    try {
+      RtkService.emitProgress({ phase: 'downloading', percent: 0 });
+
+      const apiRes = await fetchWithTimeout(
+        'https://api.github.com/repos/rtk-ai/rtk/releases/latest',
+        {
+          headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'dash-rtk-installer' },
+        },
+        FETCH_API_TIMEOUT_MS,
+      );
+      if (!apiRes.ok) {
+        throw new Error(`GitHub API ${apiRes.status}: ${apiRes.statusText}`);
+      }
+      const release = (await apiRes.json()) as unknown;
+      if (!isReleasePayload(release)) {
+        throw new Error(`Unexpected GitHub API response: ${JSON.stringify(release).slice(0, 200)}`);
+      }
+
+      const asset = release.assets.find((a) => a.name === assetName);
+      if (!asset) {
+        throw new Error(`Release ${release.tag_name} has no asset "${assetName}"`);
+      }
+      assertTrustedDownloadUrl(asset.browser_download_url);
+
+      const checksumAsset = release.assets.find((a) => a.name === 'checksums.txt');
+      if (!checksumAsset) {
+        throw new Error(`Release ${release.tag_name} has no checksums.txt — refusing to install.`);
+      }
+      assertTrustedDownloadUrl(checksumAsset.browser_download_url);
+
+      if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true });
+
+      const expectedSha = await RtkService.fetchExpectedSha256(
+        checksumAsset.browser_download_url,
+        assetName,
+      );
+
+      // GitHub's release CDN occasionally serves truncated/corrupt bytes;
+      // retry a few times before surfacing an error to the user.
+      const MAX_ATTEMPTS = 3;
+      let lastError: Error | null = null;
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+          await RtkService.fetchToFile(asset.browser_download_url, tmpArchive);
+          RtkService.emitProgress({ phase: 'verifying' });
+          await RtkService.verifyChecksum(tmpArchive, expectedSha);
+          await RtkService.verifyArchive(tmpArchive);
+          lastError = null;
+          break;
+        } catch (err) {
+          lastError = err instanceof Error ? err : new Error(String(err));
+          console.warn(`[RtkService.download] attempt ${attempt} failed:`, lastError.message);
+          rmSync(tmpArchive, { force: true });
+          if (attempt < MAX_ATTEMPTS) {
+            RtkService.emitProgress({ phase: 'downloading', percent: 0 });
+          }
+        }
+      }
+      if (lastError) {
+        throw new Error(
+          `Download repeatedly failed (${MAX_ATTEMPTS} attempts): ${lastError.message}`,
+        );
+      }
+
+      RtkService.emitProgress({ phase: 'extracting' });
+      try {
+        await RtkService.extractTarball(tmpArchive, binDir);
+      } catch (err) {
+        // Partial extraction may have dropped a half-written binary.
+        rmSync(binPath, { force: true });
+        throw err;
+      }
+
+      if (!existsSync(binPath)) {
+        throw new Error(`Archive did not contain expected binary at ${binPath}`);
+      }
+      // Defense-in-depth: even though verifyArchive rejected symlinks/hardlinks
+      // at preflight, lstat the extracted binary before chmod. chmodSync on a
+      // symlink would follow the link and modify the target instead of binPath.
+      const stat = lstatSync(binPath);
+      if (!stat.isFile()) {
+        rmSync(binPath, { force: true });
+        throw new Error(`Extracted binary is not a regular file at ${binPath}`);
+      }
+      // Must chmod before the probeVersion spawn below; tar on some systems drops +x.
+      chmodSync(binPath, 0o755);
+
+      RtkService.cachedResolution = await RtkService.resolveBinary();
+      if (!RtkService.cachedResolution) {
+        rmSync(binPath, { force: true });
+        throw new Error('Installed binary failed to report --version; removed.');
+      }
+
+      RtkService.emitProgress({ phase: 'done', version: release.tag_name });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      RtkService.emitProgress({ phase: 'error', error: message });
+      throw err instanceof Error ? err : new Error(message);
+    } finally {
+      rmSync(tmpArchive, { force: true });
+    }
+  }
+
+  private static async fetchExpectedSha256(url: string, assetName: string): Promise<string> {
+    const res = await fetchWithTimeout(url, {}, FETCH_API_TIMEOUT_MS);
+    if (!res.ok) throw new Error(`Failed to fetch checksums.txt: ${res.status} ${res.statusText}`);
+    const body = await res.text();
+    for (const line of body.split(/\r?\n/)) {
+      // The `\*?` accepts the BSD "binary mode" marker some sha256sum
+      // implementations emit; without it those releases would fail to match.
+      const match = line.match(/^([a-f0-9]{64})\s+\*?(.+?)\s*$/i);
+      if (match && match[2] === assetName) return match[1]!.toLowerCase();
+    }
+    throw new Error(`checksums.txt does not list ${assetName}`);
+  }
+
+  private static verifyChecksum(filePath: string, expectedSha: string): Promise<void> {
+    return verifyChecksum(filePath, expectedSha);
+  }
+
+  private static async fetchToFile(url: string, dest: string): Promise<void> {
+    const controller = new AbortController();
+    const wallTimer = setTimeout(() => controller.abort(), FETCH_BODY_TIMEOUT_MS);
+    try {
+      const dlRes = await fetch(url, { signal: controller.signal });
+      if (!dlRes.ok || !dlRes.body) {
+        throw new Error(`Download failed: ${dlRes.status} ${dlRes.statusText}`);
+      }
+      const total = Number(dlRes.headers.get('content-length') || '0');
+      let transferred = 0;
+
+      const source = Readable.fromWeb(dlRes.body as unknown as WebReadableStream<Uint8Array>);
+      source.on('data', (chunk: Buffer) => {
+        transferred += chunk.length;
+        if (total > 0) {
+          RtkService.emitProgress({
+            phase: 'downloading',
+            percent: Math.min(99, Math.round((transferred / total) * 100)),
+          });
+        }
+      });
+      await pipeline(source, createWriteStream(dest));
+      if (total > 0 && transferred !== total) {
+        throw new Error(`Truncated download: expected ${total} bytes, got ${transferred}.`);
+      }
+      RtkService.emitProgress({ phase: 'downloading', percent: 100 });
+    } finally {
+      clearTimeout(wallTimer);
+    }
+  }
+
+  private static async verifyArchive(archivePath: string): Promise<void> {
+    try {
+      // Validates every member is relative, stays inside dest, AND is a
+      // regular file or directory — symlinks/hardlinks are refused outright
+      // because tar honors their targets at extract time, which would let a
+      // crafted archive write outside dest even though the entry name is safe.
+      const entries = await RtkService.listTarball(archivePath);
+      const dest = RtkService.getManagedBinDir();
+      for (const entry of entries) {
+        assertSafeArchiveMember(entry, dest);
+      }
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`Archive integrity check failed: ${detail}`);
+    }
+  }
+
+  private static async extractTarball(archivePath: string, destDir: string): Promise<void> {
+    // Plain extract first (rtk's releases put the binary at the archive root).
+    // If the binary still isn't where we expect, retry with --strip-components=1
+    // for archives that nest the binary under a top-level directory.
+    await RtkService.runTar(['-xzf', archivePath, '-C', destDir, '--no-same-owner']);
+    if (existsSync(RtkService.getManagedBinPath())) return;
+    console.warn('[RtkService] binary not at archive root, retrying with --strip-components=1');
+    await RtkService.runTar([
+      '-xzf',
+      archivePath,
+      '-C',
+      destDir,
+      '--strip-components=1',
+      '--no-same-owner',
+    ]);
+  }
+
+  private static listTarball(archivePath: string): Promise<TarEntry[]> {
+    return new Promise((resolveP, rejectP) => {
+      // -tvf prints "<mode> <owner> <size> <mtime> <name>[ -> target]" per entry.
+      // The first char of the mode column is the file type ('-' regular, 'd'
+      // directory, 'l' symlink, 'h' hardlink); we use it to reject link types
+      // before extraction. Both BSD (macOS) and GNU tar use this format.
+      const proc = spawn('tar', ['-tvzf', archivePath], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: TAR_TIMEOUT_MS,
+      });
+      let stdout = '';
+      let stderr = '';
+      proc.stdout.on('data', (d: Buffer) => {
+        stdout += d.toString();
+      });
+      proc.stderr.on('data', (d: Buffer) => {
+        stderr += d.toString();
+      });
+      proc.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'ENOENT') {
+          rejectP(new Error('`tar` is not available on PATH. Install it and retry.'));
+        } else {
+          rejectP(err);
+        }
+      });
+      proc.on('exit', (code, signal) => {
+        if (signal) rejectP(new Error(`tar -tvzf killed by signal ${signal} (timed out?)`));
+        else if (code === 0) resolveP(parseTarVerbose(stdout));
+        else rejectP(new Error(`tar -tvzf exited ${code}: ${stderr.trim()}`));
+      });
+    });
+  }
+
+  private static runTar(args: string[]): Promise<void> {
+    return new Promise((resolveP, rejectP) => {
+      const proc = spawn('tar', args, {
+        stdio: ['ignore', 'ignore', 'pipe'],
+        timeout: TAR_TIMEOUT_MS,
+      });
+      let stderr = '';
+      proc.stderr?.on('data', (d: Buffer) => {
+        stderr += d.toString();
+      });
+      proc.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'ENOENT') {
+          rejectP(new Error('`tar` is not available on PATH. Install it and retry.'));
+        } else {
+          rejectP(err);
+        }
+      });
+      proc.on('exit', (code, signal) => {
+        if (signal) rejectP(new Error(`tar killed by signal ${signal} (timed out?)`));
+        else if (code === 0) resolveP();
+        else rejectP(new Error(`tar exited ${code}: ${stderr.trim()}`));
+      });
+    });
+  }
+
+  private static emitProgress(progress: RtkDownloadProgress): void {
+    const sender = RtkService.sender;
+    if (sender && !sender.isDestroyed()) {
+      sender.send('rtk:downloadProgress', progress);
+    }
+  }
+
+  /** Exercises `rtk hook claude` end-to-end so Settings can prove the binary rewrites. */
+  static async runHookTest(): Promise<RtkTestResult> {
+    const resolved = RtkService.cachedResolution ?? (await RtkService.resolveBinary());
+    if (!resolved) {
+      return { ok: false, error: 'rtk is not installed' };
+    }
+
+    const testedCommand = 'git status';
+    const input = JSON.stringify({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: testedCommand, description: 'RTK self-test' },
+    });
+
+    try {
+      const { stdout, stderr, code, signal } = await pipeStdin(
+        resolved.path,
+        ['hook', 'claude'],
+        input,
+        10_000,
+      );
+
+      if (/panic|unwrap|segfault/i.test(stderr)) {
+        return { ok: false, testedCommand, error: `rtk crashed: ${stderr.trim().slice(0, 400)}` };
+      }
+      if (code === null) {
+        return {
+          ok: false,
+          testedCommand,
+          error: `rtk killed by signal ${signal ?? 'unknown'} (likely timeout)`,
+        };
+      }
+      // rtk exits 2 to signal "block this tool call" — a valid hook result, not an error.
+      if (code !== 0 && code !== 2) {
+        return {
+          ok: false,
+          testedCommand,
+          error: `rtk exited ${code}${stderr ? ': ' + stderr.trim().slice(0, 400) : ''}`,
+        };
+      }
+
+      const extracted = extractRewrittenCommand(stdout);
+      if (!extracted.ok) {
+        return {
+          ok: false,
+          testedCommand,
+          error: `rtk produced unparsable output: ${extracted.reason}`,
+        };
+      }
+
+      const rawOutput = stdout.slice(0, 2000);
+
+      // exit 2 → blocked, regardless of any rewrite payload.
+      if (code === 2) {
+        return {
+          ok: true,
+          testedCommand,
+          rawOutput,
+          outcome: { kind: 'blocked', stderr: stderr.trim().slice(0, 400) },
+        };
+      }
+
+      const rewriteCmd = extracted.command;
+      const isRewrite = rewriteCmd !== null && rewriteCmd !== testedCommand;
+      if (isRewrite) {
+        // execDiff is best-effort visualization; capture failures are
+        // forwarded as `kind: 'failed'` so the UI can warn instead of
+        // collapsing to "rtk chose pass-through".
+        const execDiff = await RtkService.captureExecDiff(testedCommand, rewriteCmd);
+        return {
+          ok: true,
+          testedCommand,
+          rawOutput,
+          outcome: { kind: 'rewritten', rewrittenCommand: rewriteCmd, execDiff },
+        };
+      }
+
+      return { ok: true, testedCommand, rawOutput, outcome: { kind: 'pass-through' } };
+    } catch (err) {
+      return { ok: false, testedCommand, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  /**
+   * Execute both the raw and rtk-rewritten commands inside a throwaway git
+   * repo populated with enough untracked files to make `git status` verbose.
+   * Returns a `failed` variant on any error rather than null — the previous
+   * null-on-error meant the UI rendered the green "rtk chose pass-through"
+   * card for genuine failures (missing git, EACCES on tmpdir, rtk panic).
+   */
+  private static async captureExecDiff(
+    rawCommand: string,
+    rewrittenCommand: string,
+  ): Promise<import('@shared/types').RtkExecDiff> {
+    let dir: string;
+    try {
+      dir = await mkdtemp(join(tmpdir(), 'dash-rtk-verify-'));
+    } catch (err) {
+      return {
+        kind: 'failed',
+        stage: 'setup',
+        reason: `Couldn't create temp dir: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    try {
+      // Give `git status` something non-trivial to emit — multiple files
+      // across a few directories so rtk's grouping/dedup filters have work.
+      await Promise.all([
+        writeFile(join(dir, 'package.json'), '{}\n'),
+        writeFile(join(dir, 'README.md'), '# test\n'),
+        writeFile(join(dir, 'config.toml'), '[section]\nvalue = 1\n'),
+        mkdir(join(dir, 'src')).then(() =>
+          Promise.all([
+            writeFile(join(dir, 'src', 'index.ts'), 'export {};\n'),
+            writeFile(join(dir, 'src', 'lib.ts'), 'export {};\n'),
+            writeFile(join(dir, 'src', 'types.ts'), 'export {};\n'),
+          ]),
+        ),
+        mkdir(join(dir, 'tests')).then(() =>
+          Promise.all([
+            writeFile(join(dir, 'tests', 'a.test.ts'), 'test\n'),
+            writeFile(join(dir, 'tests', 'b.test.ts'), 'test\n'),
+          ]),
+        ),
+      ]);
+
+      const initRes = await runShell('git init -q', dir);
+      if (initRes.code !== 0) {
+        return {
+          kind: 'failed',
+          stage: 'setup',
+          exitCode: initRes.code ?? undefined,
+          stderr: initRes.stderr.slice(0, 400),
+          reason: `git init failed (exit ${initRes.code ?? 'null'}). Is git installed?`,
+        };
+      }
+
+      // Make sure rtk resolves from the rewritten command even when the user
+      // never installed it on the system PATH — prepend our managed bin dir.
+      const managedDir = RtkService.getManagedBinDirForPath();
+      const pathWithRtk = [managedDir, process.env.PATH].filter(Boolean).join(delimiter);
+      const env = { ...process.env, PATH: pathWithRtk };
+
+      const [rawRes, rewrittenRes] = await Promise.all([
+        runShell(rawCommand, dir, env),
+        runShell(rewrittenCommand, dir, env),
+      ]);
+
+      if (rawRes.code !== 0) {
+        return {
+          kind: 'failed',
+          stage: 'raw',
+          exitCode: rawRes.code ?? undefined,
+          stderr: rawRes.stderr.slice(0, 400),
+          reason: `Raw command exited ${rawRes.code ?? 'null'}: ${rawCommand}`,
+        };
+      }
+      if (rewrittenRes.code !== 0) {
+        return {
+          kind: 'failed',
+          stage: 'rewritten',
+          exitCode: rewrittenRes.code ?? undefined,
+          stderr: rewrittenRes.stderr.slice(0, 400),
+          reason: `Rewritten command exited ${rewrittenRes.code ?? 'null'}: ${rewrittenCommand}`,
+        };
+      }
+
+      // Trim IPC payload. When stdout hit the cap, byte counts reflect the
+      // truncated buffer (we stopped reading) — surface that via `truncated`
+      // so the UI can warn instead of advertising a misleading savings %.
+      const DISPLAY_CAP = 8 * 1024;
+      return {
+        kind: 'ok',
+        rawStdout: rawRes.stdout.slice(0, DISPLAY_CAP),
+        compressedStdout: rewrittenRes.stdout.slice(0, DISPLAY_CAP),
+        rawBytes: Buffer.byteLength(rawRes.stdout),
+        compressedBytes: Buffer.byteLength(rewrittenRes.stdout),
+        truncated: rawRes.truncated || rewrittenRes.truncated,
+      };
+    } catch (err) {
+      console.warn('[RtkService.captureExecDiff] unexpected:', err);
+      return {
+        kind: 'failed',
+        stage: 'unknown',
+        reason: err instanceof Error ? err.message : String(err),
+      };
+    } finally {
+      await rm(dir, { recursive: true, force: true }).catch((err) => {
+        console.warn('[RtkService.captureExecDiff] tmpdir cleanup failed:', err);
+      });
+    }
+  }
+}
+
+// ── Helpers (module-private) ───────────────────────────────────────────────
+
+/**
+ * Run a shell string and capture its stdout/stderr up to a hard cap. Used by
+ * the Test RTK flow to exec both the raw command (e.g. `git status`) and the
+ * rtk-rewritten version (e.g. `rtk git status`) in a controlled environment.
+ */
+const RUN_SHELL_OUTPUT_CAP = 64 * 1024;
+
+function runShell(
+  cmd: string,
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+  timeoutMs = 15_000,
+): Promise<{ stdout: string; stderr: string; code: number | null; truncated: boolean }> {
+  return new Promise((resolveP, rejectP) => {
+    const shell = process.platform === 'win32' ? 'cmd.exe' : 'sh';
+    const args = process.platform === 'win32' ? ['/c', cmd] : ['-c', cmd];
+    const proc = spawn(shell, args, { cwd, env, timeout: timeoutMs });
+    let stdout = '';
+    let stderr = '';
+    let truncated = false;
+    proc.stdout.on('data', (c: Buffer) => {
+      if (stdout.length < RUN_SHELL_OUTPUT_CAP) stdout += c.toString();
+      else truncated = true;
+    });
+    proc.stderr.on('data', (c: Buffer) => {
+      if (stderr.length < RUN_SHELL_OUTPUT_CAP) stderr += c.toString();
+      else truncated = true;
+    });
+    proc.on('error', rejectP);
+    proc.on('close', (code) => resolveP({ stdout, stderr, code, truncated }));
+  });
+}
+
+function pipeStdin(
+  cmd: string,
+  args: string[],
+  stdin: string,
+  timeoutMs: number,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string }> {
+  return new Promise((resolveP, rejectP) => {
+    const proc = spawn(cmd, args, { timeout: timeoutMs });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (c: Buffer) => {
+      stdout += c.toString();
+    });
+    proc.stderr.on('data', (c: Buffer) => {
+      stderr += c.toString();
+    });
+    // rtk may exit before reading stdin; EPIPE must not become unhandled.
+    proc.stdin.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code !== 'EPIPE') {
+        console.warn('[RtkService.pipeStdin] unexpected stdin error:', err);
+      }
+    });
+    proc.on('error', rejectP);
+    proc.on('close', (code, signal) => resolveP({ code, signal, stdout, stderr }));
+    proc.stdin.write(stdin);
+    proc.stdin.end();
+  });
+}
+
+type ExtractResult = { ok: true; command: string | null } | { ok: false; reason: string };
+
+function extractRewrittenCommand(stdout: string): ExtractResult {
+  const trimmed = stdout.trim();
+  if (!trimmed) return { ok: true, command: null };
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(trimmed) as Record<string, unknown>;
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+  // Claude Code's hook JSON schema has evolved; accept both historical and
+  // current field names so version skew between rtk releases and Dash's
+  // expectations doesn't silently render as "pass-through".
+  const hso = isObject(parsed.hookSpecificOutput) ? parsed.hookSpecificOutput : null;
+  const candidates: unknown[] = [
+    hso?.updatedInput,
+    hso?.modifiedToolInput,
+    hso?.updatedToolInput,
+    parsed.updatedInput,
+    parsed.modifiedToolInput,
+    parsed.updatedToolInput,
+    parsed.tool_input,
+  ];
+  for (const node of candidates) {
+    if (isObject(node) && typeof node.command === 'string') {
+      return { ok: true, command: node.command };
+    }
+  }
+  return { ok: true, command: null };
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object';
+}
+
+function shellQuoteUnix(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+interface ReleasePayload {
+  tag_name: string;
+  assets: Array<{ name: string; browser_download_url: string }>;
+}
+
+function isReleasePayload(v: unknown): v is ReleasePayload {
+  if (!isObject(v)) return false;
+  if (typeof v.tag_name !== 'string') return false;
+  if (!Array.isArray(v.assets)) return false;
+  return v.assets.every(
+    (a) => isObject(a) && typeof a.name === 'string' && typeof a.browser_download_url === 'string',
+  );
+}
+
+function assertTrustedDownloadUrl(raw: string): void {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`Refusing malformed asset URL: ${raw}`);
+  }
+  if (url.protocol !== 'https:') {
+    throw new Error(`Refusing non-HTTPS asset URL: ${raw}`);
+  }
+  const host = url.hostname.toLowerCase();
+  const allowed =
+    host === 'github.com' ||
+    host === 'api.github.com' ||
+    host === 'objects.githubusercontent.com' ||
+    host.endsWith('.githubusercontent.com');
+  if (!allowed) {
+    throw new Error(`Refusing asset URL outside GitHub: ${raw}`);
+  }
+}
+
+type TarMemberType = 'file' | 'dir' | 'symlink' | 'hardlink' | 'other';
+
+interface TarEntry {
+  /** First char of the mode column from `tar -tvf` (`-`, `d`, `l`, `h`, ...). */
+  type: TarMemberType;
+  name: string;
+}
+
+function parseTarVerbose(stdout: string): TarEntry[] {
+  const out: TarEntry[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line) continue;
+    // Lines start with the mode string; first char encodes the file type.
+    const typeChar = line[0];
+    let type: TarMemberType;
+    switch (typeChar) {
+      case '-':
+        type = 'file';
+        break;
+      case 'd':
+        type = 'dir';
+        break;
+      case 'l':
+        type = 'symlink';
+        break;
+      case 'h':
+        type = 'hardlink';
+        break;
+      default:
+        type = 'other';
+    }
+    // Strip "<name> -> <target>" tail so name validation only sees the entry path.
+    // The target itself doesn't need validation: we reject symlinks/hardlinks outright.
+    const arrow = line.indexOf(' -> ');
+    const trail = arrow >= 0 ? line.slice(0, arrow) : line;
+    // Name is the last whitespace-delimited token (mode/owner/size/date have
+    // varying field counts between BSD and GNU tar; the name is always last).
+    const tokens = trail.split(/\s+/);
+    const name = tokens[tokens.length - 1];
+    if (name) out.push({ type, name });
+  }
+  return out;
+}
+
+function assertSafeArchiveMember(entry: TarEntry, destDir: string): void {
+  // Refuse symlinks/hardlinks outright. `tar -xzf` honors their targets at
+  // extract time, so a crafted archive with `rtk -> /etc/passwd` would let
+  // chmod/exec follow the link out of dest even though the entry name is
+  // benign. Defense-in-depth: SHA-256 + URL allowlist already make this hard
+  // to reach, but the link types themselves are never legitimate in an rtk
+  // release tarball.
+  if (entry.type === 'symlink' || entry.type === 'hardlink') {
+    throw new Error(`Archive contains ${entry.type}, which is not allowed: ${entry.name}`);
+  }
+  if (entry.type === 'other') {
+    throw new Error(`Archive contains unsupported member type: ${entry.name}`);
+  }
+  // Reject embedded null bytes — tar entries should never contain them, and
+  // some libcs truncate at \0 which could let a malicious entry name slip
+  // past a downstream check.
+  if (entry.name.includes('\0')) {
+    throw new Error(`Archive member contains null byte: ${JSON.stringify(entry.name)}`);
+  }
+  // Reject absolute paths. The Windows-drive regex runs on every platform by
+  // design: a tarball authored on Windows can reach any OS, so we refuse
+  // `C:\...` entries regardless of where extraction happens.
+  if (entry.name.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(entry.name)) {
+    throw new Error(`Archive contains absolute path: ${entry.name}`);
+  }
+  // Normalize backslashes to forward slashes before resolve(). On POSIX,
+  // path.resolve treats `\` as a literal filename character, so `..\\evil`
+  // would not be recognised as a parent-traversal attempt without this step.
+  const normalized = normalize(entry.name.replace(/\\/g, '/'));
+  const resolved = resolve(destDir, normalized);
+  const base = resolve(destDir) + sep;
+  if (resolved !== resolve(destDir) && !resolved.startsWith(base)) {
+    throw new Error(`Archive member escapes destDir: ${entry.name}`);
+  }
+}
+
+async function verifyChecksum(filePath: string, expectedSha: string): Promise<void> {
+  const hash = createHash('sha256');
+  await pipeline(createReadStream(filePath), hash);
+  const actual = hash.digest('hex');
+  if (actual !== expectedSha) {
+    throw new Error(
+      `Checksum mismatch: expected ${expectedSha}, got ${actual}. Refusing to install.`,
+    );
+  }
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Test-only exports of module-private helpers. Importing from here keeps the
+ * unit tests exercising the real code instead of a drifting re-implementation.
+ */
+export const __test__ = {
+  assertTrustedDownloadUrl,
+  assertSafeArchiveMember,
+  parseTarVerbose,
+  shellQuoteUnix,
+  extractRewrittenCommand,
+  verifyChecksum,
+};

--- a/src/main/services/RtkService.ts
+++ b/src/main/services/RtkService.ts
@@ -7,12 +7,14 @@ import {
   createWriteStream,
   chmodSync,
   lstatSync,
+  readlinkSync,
   renameSync,
   rmSync,
+  symlinkSync,
 } from 'node:fs';
 import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
 import { delimiter, dirname, join, normalize, resolve, sep } from 'node:path';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { pipeline } from 'node:stream/promises';
@@ -133,6 +135,24 @@ export class RtkService {
   }
 
   /**
+   * Path to a `~/.local/bin/rtk` symlink pointing at the managed binary.
+   * RTK's hook rewrites `git status` → `rtk git status`, so `rtk` must resolve
+   * via $PATH wherever Claude Code's Bash tool runs the rewritten command —
+   * not just inside Dash's PTYs (whose PATH we control). `~/.local/bin` is on
+   * $PATH by default on Linux and harmless on macOS. Returns null on Windows
+   * because no native release exists upstream.
+   */
+  private static getUserPathSymlinkPath(): string | null {
+    if (process.platform === 'win32') return null;
+    return join(homedir(), '.local', 'bin', 'rtk');
+  }
+
+  private static ensureUserBinSymlink(target: string): void {
+    const linkPath = RtkService.getUserPathSymlinkPath();
+    if (linkPath) ensureUserBinSymlink(target, linkPath);
+  }
+
+  /**
    * Returns the managed bin dir ONLY when a probed-good binary is there.
    * Gating on cachedResolution (not just existsSync) prevents poisoning the
    * PTY PATH with a dir whose binary failed --version.
@@ -232,7 +252,11 @@ export class RtkService {
   /** Populates cachedResolution so getHookCommand() is synchronous later. */
   static async warmUp(): Promise<void> {
     const resolved = await RtkService.resolveBinary();
-    if (resolved) RtkService.cachedResolution = resolved;
+    if (resolved) {
+      RtkService.cachedResolution = resolved;
+      // Backfill the symlink for installs that predate this fix.
+      if (resolved.source === 'managed') RtkService.ensureUserBinSymlink(resolved.path);
+    }
   }
 
   /**
@@ -383,6 +407,7 @@ export class RtkService {
         rmSync(binPath, { force: true });
         throw new Error('Installed binary failed to report --version; removed.');
       }
+      RtkService.ensureUserBinSymlink(RtkService.cachedResolution.path);
 
       RtkService.emitProgress({ phase: 'done', version: release.tag_name });
     } catch (err) {
@@ -981,6 +1006,27 @@ async function fetchWithTimeout(
 }
 
 /**
+ * Best-effort: create or refresh a symlink at `linkPath` pointing at `target`.
+ * Never throws; install must not fail because the symlink could not be made.
+ * Refuses to overwrite a non-symlink at the destination so a user-installed
+ * `rtk` (e.g. via cargo) is not clobbered.
+ */
+function ensureUserBinSymlink(target: string, linkPath: string): void {
+  try {
+    mkdirSync(dirname(linkPath), { recursive: true });
+    if (existsSync(linkPath)) {
+      const stat = lstatSync(linkPath);
+      if (!stat.isSymbolicLink()) return;
+      if (readlinkSync(linkPath) === target) return;
+      rmSync(linkPath);
+    }
+    symlinkSync(target, linkPath);
+  } catch (err) {
+    console.warn('[RtkService] could not create user-bin symlink:', err);
+  }
+}
+
+/**
  * Test-only exports of module-private helpers. Importing from here keeps the
  * unit tests exercising the real code instead of a drifting re-implementation.
  */
@@ -991,4 +1037,5 @@ export const __test__ = {
   shellQuoteUnix,
   extractRewrittenCommand,
   verifyChecksum,
+  ensureUserBinSymlink,
 };

--- a/src/main/services/__tests__/rtk-integration.test.ts
+++ b/src/main/services/__tests__/rtk-integration.test.ts
@@ -1,0 +1,233 @@
+// Two suites: (A) rtk's hook output alone (no API); (B) full Dash+Claude e2e
+// (gated on ANTHROPIC_API_KEY). Auto-skips when prerequisites are missing so
+// `pnpm test` is safe to run anywhere.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile, execSync, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, writeFile, mkdir, access, rm, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+/** Prefer Dash's managed binary (where the UI installs it) over $PATH. */
+function dashManagedRtkPath(): string | null {
+  const exe = process.platform === 'win32' ? 'rtk.exe' : 'rtk';
+  const candidates =
+    process.platform === 'darwin'
+      ? [join(homedir(), 'Library', 'Application Support', 'Dash', 'bin', exe)]
+      : process.platform === 'linux'
+        ? [join(homedir(), '.config', 'Dash', 'bin', exe)]
+        : [join(homedir(), 'AppData', 'Roaming', 'Dash', 'bin', exe)];
+  return candidates.find(existsSync) ?? null;
+}
+
+function findRtk(): string | null {
+  const managed = dashManagedRtkPath();
+  if (managed) return managed;
+  try {
+    const finder = process.platform === 'win32' ? 'where' : 'which';
+    const out = execSync(`${finder} rtk`, { stdio: ['ignore', 'pipe', 'ignore'] }).toString();
+    return out.trim().split(/\r?\n/)[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+function onPath(bin: string): boolean {
+  try {
+    execSync(`${process.platform === 'win32' ? 'where' : 'which'} ${bin}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveOnPath(bin: string): Promise<string> {
+  const finder = process.platform === 'win32' ? 'where.exe' : 'which';
+  const { stdout } = await execFileAsync(finder, [bin]);
+  const first = stdout.trim().split(/\r?\n/)[0];
+  if (!first) throw new Error(`${bin} not found`);
+  return first;
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Pull the rewritten Bash command out of rtk's JSON advice. */
+function extractCommand(rtkStdout: string): string {
+  const parsed = JSON.parse(rtkStdout) as {
+    hookSpecificOutput?: { updatedInput?: { command?: string } };
+  };
+  const cmd = parsed.hookSpecificOutput?.updatedInput?.command;
+  if (typeof cmd !== 'string') {
+    throw new Error(`rtk output missing hookSpecificOutput.updatedInput.command: ${rtkStdout}`);
+  }
+  return cmd;
+}
+
+/** Run a binary with stdin piped in; resolve with exit code, stdout, stderr. */
+function runWithStdin(
+  cmd: string,
+  args: string[],
+  stdin: string,
+  timeoutMs = 10_000,
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(cmd, args, { timeout: timeoutMs });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (c: Buffer) => {
+      stdout += c.toString();
+    });
+    proc.stderr.on('data', (c: Buffer) => {
+      stderr += c.toString();
+    });
+    proc.on('error', reject);
+    proc.on('close', (code) => resolve({ code, stdout, stderr }));
+    proc.stdin.write(stdin);
+    proc.stdin.end();
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Suite A: rtk compression behaviour (no Claude API required)
+// ═══════════════════════════════════════════════════════════════════════
+
+const resolvedRtkPath = findRtk();
+
+describe.runIf(!!resolvedRtkPath)('rtk hook output (no API)', () => {
+  const rtkPath = resolvedRtkPath!;
+
+  it('rewrites a known-compressible command (git status) via `rtk hook claude`', async () => {
+    // rtk's PreToolUse hook reads Claude Code's tool-use JSON on stdin and
+    // writes an advice JSON on stdout. `git status` is rtk's headline example
+    // (~75% token reduction), so the advice must include a modified command
+    // that invokes rtk itself — that's how downstream compression is triggered.
+    const input = JSON.stringify({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'git status', description: 'status' },
+    });
+
+    const { code, stdout, stderr } = await runWithStdin(rtkPath, ['hook', 'claude'], input);
+
+    expect(stderr).not.toMatch(/panic|unwrap|segfault/i);
+    expect(code).toBe(0); // 0 = allow (with modification); a rewrite must not block.
+    expect(stdout.trim().length).toBeGreaterThan(0);
+
+    // Assert on the exact field carrying the rewritten command — a broad
+    // /rtk/ match would also hit field names and thus pass under schema drift.
+    const parsed = JSON.parse(stdout) as {
+      hookSpecificOutput?: { updatedInput?: { command?: string } };
+    };
+    const rewritten = parsed.hookSpecificOutput?.updatedInput?.command;
+    expect(typeof rewritten).toBe('string');
+    expect(rewritten).toMatch(/\brtk\b/);
+  });
+
+  it('returns cleanly on a command rtk does not rewrite (echo)', async () => {
+    const input = JSON.stringify({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hi', description: 'echo' },
+    });
+    const { code, stderr } = await runWithStdin(rtkPath, ['hook', 'claude'], input);
+    expect(stderr).not.toMatch(/panic|unwrap|segfault/i);
+    // 0 = pass-through, 2 = block; anything else would indicate a crash.
+    expect([0, 2]).toContain(code);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Suite B: end-to-end with a real `claude -p` session
+// ═══════════════════════════════════════════════════════════════════════
+
+const canRunE2E = !!process.env.ANTHROPIC_API_KEY && !!resolvedRtkPath && onPath('claude');
+
+describe.runIf(canRunE2E)('RTK end-to-end with Claude Code', () => {
+  const rtkPath = resolvedRtkPath!;
+  let claudePath = '';
+  let cwd = '';
+  let hookOutLog = '';
+  let hookInLog = '';
+
+  beforeAll(async () => {
+    claudePath = await resolveOnPath('claude');
+    cwd = await mkdtemp(join(tmpdir(), 'dash-rtk-e2e-'));
+    hookInLog = join(cwd, 'hook-in.log');
+    hookOutLog = join(cwd, 'hook-out.log');
+  });
+
+  afterAll(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('hook fires, rtk emits a rewrite directive, and the Bash tool completes', async () => {
+    const claudeDir = join(cwd, '.claude');
+    await mkdir(claudeDir, { recursive: true });
+
+    // Wrap the hook with tee so we can capture stdin/stdout. The JSON shape
+    // matches what Dash writes at runtime — drift here means this test no
+    // longer represents production.
+    const q = (s: string): string => (s.includes(' ') ? `"${s}"` : s);
+    const hookCommand = `sh -c 'tee -a ${q(hookInLog)} | ${q(rtkPath)} hook claude | tee -a ${q(hookOutLog)}'`;
+
+    const settings = {
+      hooks: {
+        PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: hookCommand }] }],
+      },
+    };
+    await writeFile(join(claudeDir, 'settings.local.json'), JSON.stringify(settings, null, 2));
+
+    // `ls -la` is on rtk's rewrite list per its README, so this forces
+    // compression rather than pass-through. The echo-to-marker confirms
+    // the Bash tool call actually completed after the hook ran.
+    const marker = join(cwd, 'marker.txt');
+    const prompt =
+      `Use the Bash tool to run: ls -la /tmp. ` +
+      `Then use the Bash tool again to run: echo done > "${marker}". ` +
+      `Finally reply with the single word: done`;
+
+    // Pass only the env vars claude actually needs; don't leak the developer's
+    // full shell env (local RTK_* overrides, test-affecting vars, etc.) in.
+    const hermeticEnv: NodeJS.ProcessEnv = {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    };
+    const { stdout } = await execFileAsync(
+      claudePath,
+      ['-p', prompt, '--dangerously-skip-permissions'],
+      { cwd, timeout: 180_000, env: hermeticEnv, maxBuffer: 4 * 1024 * 1024 },
+    );
+
+    // 1. The hook was invoked at least once — input log has content.
+    expect(await fileExists(hookInLog)).toBe(true);
+    const inLog = await readFile(hookInLog, 'utf-8');
+    expect(inLog).toMatch(/PreToolUse/);
+    expect(inLog).toMatch(/"tool_name":\s*"Bash"/);
+
+    // 2. rtk wrote back a rewrite directive — assert on the exact command
+    //    field, not a broad /rtk/ match that would also hit field names.
+    expect(await fileExists(hookOutLog)).toBe(true);
+    const outLog = await readFile(hookOutLog, 'utf-8');
+    expect(outLog.trim().length).toBeGreaterThan(0);
+    const rewritten = extractCommand(outLog);
+    expect(rewritten).toMatch(/\brtk\b/);
+
+    // 3. The second Bash tool call ran to completion after the hook.
+    expect(await fileExists(marker)).toBe(true);
+
+    // 4. The model finished its turn.
+    expect(stdout.toLowerCase()).toContain('done');
+  }, 240_000);
+});

--- a/src/main/services/__tests__/rtk-unit.test.ts
+++ b/src/main/services/__tests__/rtk-unit.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import {
+  writeFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  readlinkSync,
+  lstatSync,
+  existsSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
@@ -21,6 +30,7 @@ const {
   shellQuoteUnix,
   extractRewrittenCommand,
   verifyChecksum,
+  ensureUserBinSymlink,
 } = __test__;
 
 describe('assertTrustedDownloadUrl', () => {
@@ -302,5 +312,61 @@ describe('parseTarVerbose', () => {
   it('falls back to "other" for unknown type chars', () => {
     const out = parseTarVerbose('crw-r--r-- user 0 date weird-device');
     expect(out[0].type).toBe('other');
+  });
+});
+
+describe('ensureUserBinSymlink', () => {
+  let tmpRoot: string;
+  let target: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'rtk-symlink-'));
+    mkdirSync(join(tmpRoot, 'managed'));
+    mkdirSync(join(tmpRoot, 'bin'));
+    target = join(tmpRoot, 'managed', 'rtk');
+    writeFileSync(target, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('creates the symlink and intermediate dirs', () => {
+    const linkPath = join(tmpRoot, 'home', '.local', 'bin', 'rtk');
+    ensureUserBinSymlink(target, linkPath);
+    expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(linkPath)).toBe(target);
+  });
+
+  it('refreshes a stale symlink to the new target', () => {
+    const linkPath = join(tmpRoot, 'bin', 'rtk');
+    const oldTarget = join(tmpRoot, 'old-rtk');
+    writeFileSync(oldTarget, 'old');
+    symlinkSync(oldTarget, linkPath);
+    ensureUserBinSymlink(target, linkPath);
+    expect(readlinkSync(linkPath)).toBe(target);
+  });
+
+  it('leaves a non-symlink in place (does not clobber a real file)', () => {
+    const linkPath = join(tmpRoot, 'bin', 'rtk');
+    writeFileSync(linkPath, 'user-installed-rtk');
+    ensureUserBinSymlink(target, linkPath);
+    expect(lstatSync(linkPath).isSymbolicLink()).toBe(false);
+  });
+
+  it('is a no-op when the link already points at the target', () => {
+    const linkPath = join(tmpRoot, 'bin', 'rtk');
+    symlinkSync(target, linkPath);
+    const before = lstatSync(linkPath).ctimeMs;
+    ensureUserBinSymlink(target, linkPath);
+    expect(lstatSync(linkPath).ctimeMs).toBe(before);
+  });
+
+  it('does not throw when the parent dir cannot be created', () => {
+    const blocker = join(tmpRoot, 'blocker');
+    writeFileSync(blocker, 'not a dir');
+    const linkPath = join(blocker, 'bin', 'rtk');
+    expect(() => ensureUserBinSymlink(target, linkPath)).not.toThrow();
+    expect(existsSync(linkPath)).toBe(false);
   });
 });

--- a/src/main/services/__tests__/rtk-unit.test.ts
+++ b/src/main/services/__tests__/rtk-unit.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
+
+// RtkService imports `app` from electron for userData paths, which isn't
+// available in the vitest Node env. The helpers we test don't touch it.
+vi.mock('electron', () => ({ default: {}, app: {} }));
+
+import { __test__ } from '../RtkService';
+
+// These unit tests exercise the URL allowlist, archive-member safety checks,
+// and JSON-extraction helpers. Imported from RtkService's __test__ export so
+// the real module code is what's being verified — no re-implementation drift.
+
+const {
+  assertTrustedDownloadUrl,
+  assertSafeArchiveMember,
+  parseTarVerbose,
+  shellQuoteUnix,
+  extractRewrittenCommand,
+  verifyChecksum,
+} = __test__;
+
+describe('assertTrustedDownloadUrl', () => {
+  it('accepts canonical github.com release URLs', () => {
+    expect(() =>
+      assertTrustedDownloadUrl('https://github.com/rtk-ai/rtk/releases/download/v0.1.0/rtk.tar.gz'),
+    ).not.toThrow();
+  });
+
+  it('accepts objects.githubusercontent.com CDN redirects', () => {
+    expect(() =>
+      assertTrustedDownloadUrl(
+        'https://objects.githubusercontent.com/github-production-release-asset-2e65be/...',
+      ),
+    ).not.toThrow();
+  });
+
+  it('accepts any *.githubusercontent.com subdomain', () => {
+    expect(() =>
+      assertTrustedDownloadUrl('https://release-assets.githubusercontent.com/foo'),
+    ).not.toThrow();
+  });
+
+  it('rejects http:// downloads', () => {
+    expect(() =>
+      assertTrustedDownloadUrl('http://github.com/rtk-ai/rtk/releases/download/v0.1.0/rtk.tar.gz'),
+    ).toThrow(/non-HTTPS/);
+  });
+
+  it('rejects foreign hostnames', () => {
+    expect(() => assertTrustedDownloadUrl('https://evil.example.com/rtk.tar.gz')).toThrow(
+      /outside GitHub/,
+    );
+  });
+
+  it('rejects similar-looking hostnames that are not github', () => {
+    expect(() => assertTrustedDownloadUrl('https://github.com.evil.example/rtk.tar.gz')).toThrow(
+      /outside GitHub/,
+    );
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(() => assertTrustedDownloadUrl('not a url')).toThrow(/malformed/);
+  });
+});
+
+describe('assertSafeArchiveMember', () => {
+  const dest = process.platform === 'win32' ? 'C:\\tmp\\rtk-bin' : '/tmp/rtk-bin';
+  const file = (name: string) => ({ type: 'file' as const, name });
+
+  it('accepts a plain file at archive root', () => {
+    expect(() => assertSafeArchiveMember(file('rtk'), dest)).not.toThrow();
+  });
+
+  it('accepts nested-under-directory entries that stay inside dest', () => {
+    expect(() => assertSafeArchiveMember(file('nested/rtk'), dest)).not.toThrow();
+  });
+
+  it('accepts directories', () => {
+    expect(() => assertSafeArchiveMember({ type: 'dir', name: 'subdir/' }, dest)).not.toThrow();
+  });
+
+  it('rejects symlinks regardless of target — tar would honor the link at extract time', () => {
+    // A symlink whose name is benign (`./rtk`) but whose target points outside
+    // dest is the canonical defense-in-depth bypass: the entry-name validator
+    // sees nothing wrong, but `tar -xzf` writes through the link.
+    expect(() => assertSafeArchiveMember({ type: 'symlink', name: 'rtk' }, dest)).toThrow(
+      /symlink/,
+    );
+  });
+
+  it('rejects hardlinks for the same reason', () => {
+    expect(() => assertSafeArchiveMember({ type: 'hardlink', name: 'rtk' }, dest)).toThrow(
+      /hardlink/,
+    );
+  });
+
+  it('rejects unsupported member types (sockets, fifos, devices)', () => {
+    expect(() => assertSafeArchiveMember({ type: 'other', name: 'weird' }, dest)).toThrow(
+      /unsupported/,
+    );
+  });
+
+  it('rejects entries with embedded null bytes', () => {
+    // Some libcs truncate at \0; without this check a name like "rtk\0/etc/passwd"
+    // could pass the dest-prefix test then resolve elsewhere downstream.
+    expect(() => assertSafeArchiveMember(file('rtk\0../etc/passwd'), dest)).toThrow(/null byte/);
+  });
+
+  it('rejects absolute Unix paths', () => {
+    expect(() => assertSafeArchiveMember(file('/etc/passwd'), dest)).toThrow(/absolute/);
+  });
+
+  it('rejects absolute Windows paths', () => {
+    expect(() => assertSafeArchiveMember(file('C:\\Windows\\System32\\evil.exe'), dest)).toThrow(
+      /absolute/,
+    );
+  });
+
+  it('rejects parent-traversal (..) that escapes dest', () => {
+    expect(() => assertSafeArchiveMember(file('../../etc/passwd'), dest)).toThrow(/escapes/);
+  });
+
+  it('rejects mixed traversal paths', () => {
+    expect(() => assertSafeArchiveMember(file('subdir/../../../etc/evil'), dest)).toThrow(
+      /escapes/,
+    );
+  });
+
+  it('rejects backslash-traversal (Windows-style) on any OS', () => {
+    // Regression guard: without normalize-to-forward-slashes in the real
+    // helper, POSIX pathResolve would treat the backslashes as literal
+    // filename chars and this entry would land inside destDir as a file
+    // literally named "..\\..\\etc\\passwd" — a security-sensitive false pass.
+    expect(() => assertSafeArchiveMember(file('..\\..\\etc\\passwd'), dest)).toThrow(
+      /escapes|absolute/,
+    );
+  });
+});
+
+describe('shellQuoteUnix', () => {
+  it('quotes plain paths', () => {
+    expect(shellQuoteUnix('/usr/local/bin/rtk')).toBe("'/usr/local/bin/rtk'");
+  });
+
+  it('quotes paths containing spaces', () => {
+    expect(shellQuoteUnix('/Application Support/Dash/bin/rtk')).toBe(
+      "'/Application Support/Dash/bin/rtk'",
+    );
+  });
+
+  it('escapes embedded single quotes without leaving an injection hole', () => {
+    // The output must be a single concatenated shell token — decoding it
+    // should yield the exact input back.
+    const input = "/tmp/weird'dir/rtk";
+    const quoted = shellQuoteUnix(input);
+    expect(quoted).toBe("'/tmp/weird'\\''dir/rtk'");
+    // Sanity: the quoted form contains no unescaped bareword that could run.
+    expect(quoted).not.toMatch(/[^\\]\$\(/);
+    expect(quoted).not.toMatch(/[^\\]`/);
+  });
+
+  it('survives $, backtick, and backslash without expansion', () => {
+    const input = '/tmp/$(rm -rf ~)/`whoami`/rtk';
+    const quoted = shellQuoteUnix(input);
+    // With single quotes, none of these metachars get interpreted by sh.
+    expect(quoted.startsWith("'") && quoted.endsWith("'")).toBe(true);
+    expect(quoted).toContain('$(rm -rf ~)');
+    expect(quoted).toContain('`whoami`');
+  });
+});
+
+describe('extractRewrittenCommand', () => {
+  it('returns a null command for empty stdout (rtk pass-through)', () => {
+    const r = extractRewrittenCommand('');
+    expect(r).toEqual({ ok: true, command: null });
+  });
+
+  it('returns ok:false on unparseable JSON', () => {
+    const r = extractRewrittenCommand('<<not json>>');
+    expect(r.ok).toBe(false);
+  });
+
+  it('extracts from hookSpecificOutput.updatedInput.command (current schema)', () => {
+    const payload = JSON.stringify({
+      hookSpecificOutput: { updatedInput: { command: 'rtk-wrapped git status' } },
+    });
+    expect(extractRewrittenCommand(payload)).toEqual({
+      ok: true,
+      command: 'rtk-wrapped git status',
+    });
+  });
+
+  it('extracts from legacy modifiedToolInput at payload root', () => {
+    const payload = JSON.stringify({ modifiedToolInput: { command: 'legacy-shape' } });
+    expect(extractRewrittenCommand(payload)).toEqual({ ok: true, command: 'legacy-shape' });
+  });
+
+  it('returns command:null when the JSON is valid but matches no known path', () => {
+    const payload = JSON.stringify({ unknownField: { command: 'ignored' } });
+    expect(extractRewrittenCommand(payload)).toEqual({ ok: true, command: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Archive integrity: SHA-256 verification is one of the load-bearing security
+// claims of the install flow ("Refusing to install" on mismatch). A regression
+// (e.g. truncated comparison, swapped operator) needs to fail this test, not
+// silently let a corrupt/swapped binary onto disk.
+// ---------------------------------------------------------------------------
+
+describe('verifyChecksum', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'rtk-unit-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeFixture(name: string, body: string): { path: string; sha: string } {
+    const p = join(dir, name);
+    writeFileSync(p, body);
+    const sha = createHash('sha256').update(body).digest('hex');
+    return { path: p, sha };
+  }
+
+  it('accepts a matching checksum', async () => {
+    const { path, sha } = writeFixture('ok.bin', 'rtk binary contents');
+    await expect(verifyChecksum(path, sha)).resolves.toBeUndefined();
+  });
+
+  it('rejects a one-character-off checksum (the canonical regression)', async () => {
+    // A truncated comparison (`actual.startsWith(expected.slice(0, 8))`) or a
+    // swapped operator (`===` → `!==`) would let this through. Mutating one
+    // hex char makes the assertion pinpoint the equality check itself.
+    const { path, sha } = writeFixture('mismatch.bin', 'rtk binary contents');
+    const tampered = sha.slice(0, -1) + (sha.endsWith('a') ? 'b' : 'a');
+    await expect(verifyChecksum(path, tampered)).rejects.toThrow(
+      /Checksum mismatch.*Refusing to install/,
+    );
+  });
+
+  it('rejects when the file content is mutated post-write', async () => {
+    // Computes sha against original bytes, then writes different bytes — the
+    // streaming hash should pick up the change.
+    const { path, sha } = writeFixture('orig.bin', 'original content');
+    writeFileSync(path, 'tampered content');
+    await expect(verifyChecksum(path, sha)).rejects.toThrow(/Checksum mismatch/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tar verbose-output parsing: type-char detection is the only thing standing
+// between a malicious symlink-bearing tarball and chmod-following the link
+// out of dest. Both BSD (macOS) and GNU tar prefix entries with the mode
+// string, so the first column is the file type ('-', 'd', 'l', 'h', ...).
+// ---------------------------------------------------------------------------
+
+describe('parseTarVerbose', () => {
+  it('parses BSD-style (macOS) verbose lines', () => {
+    const out = parseTarVerbose(
+      [
+        '-rwxr-xr-x  0 root  wheel  1234567 Jan  1 00:00 rtk',
+        'drwxr-xr-x  0 root  wheel        0 Jan  1 00:00 doc/',
+      ].join('\n'),
+    );
+    expect(out).toEqual([
+      { type: 'file', name: 'rtk' },
+      { type: 'dir', name: 'doc/' },
+    ]);
+  });
+
+  it('parses GNU-style verbose lines', () => {
+    const out = parseTarVerbose(
+      [
+        '-rwxr-xr-x user/group  1234567 2024-01-01 00:00 rtk',
+        'lrwxrwxrwx user/group        0 2024-01-01 00:00 evil -> /etc/passwd',
+      ].join('\n'),
+    );
+    expect(out).toEqual([
+      { type: 'file', name: 'rtk' },
+      { type: 'symlink', name: 'evil' },
+    ]);
+  });
+
+  it('strips " -> target" from symlink lines so name validation only sees the entry path', () => {
+    const out = parseTarVerbose('lrwxrwxrwx user 0 date evil -> /etc/passwd');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({ type: 'symlink', name: 'evil' });
+  });
+
+  it('classifies hardlinks as hardlink', () => {
+    const out = parseTarVerbose('hrw-r--r-- user 1234 date hardlink');
+    expect(out[0].type).toBe('hardlink');
+  });
+
+  it('falls back to "other" for unknown type chars', () => {
+    const out = parseTarVerbose('crw-r--r-- user 0 date weird-device');
+    expect(out[0].type).toBe('other');
+  });
+});

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -8,6 +8,7 @@ import { activityMonitor } from './ActivityMonitor';
 import { hookServer } from './HookServer';
 import { contextUsageService } from './ContextUsageService';
 import { DatabaseService } from './DatabaseService';
+import { RtkService } from './RtkService';
 import {
   type Hook,
   type HookEntry,
@@ -88,10 +89,34 @@ const RESERVED_ENV_KEYS = new Set([
 
 export function setCommitAttribution(value: string | undefined): void {
   commitAttributionSetting = value;
-  // Re-write settings.local.json for all active PTYs so the change takes effect immediately
+  refreshActivePtyHooks();
+}
+
+export interface RefreshFailure {
+  settingsPath: string;
+  error: string;
+}
+
+export interface RefreshResult {
+  failures: RefreshFailure[];
+}
+
+/**
+ * Rewrite settings.local.json for every active PTY. Claude Code re-reads
+ * settings per tool call, so this flips hooks live. Returns per-task write
+ * failures so callers (RTK toggle, attribution change) can surface a
+ * "saved, but N tasks didn't pick it up" message instead of silently
+ * returning success.
+ */
+export function refreshActivePtyHooks(): RefreshResult {
+  const failures: RefreshFailure[] = [];
   for (const [id, rec] of ptys) {
-    writeHookSettings(rec.cwd, id);
+    const result = writeHookSettings(rec.cwd, id);
+    if (!result.ok) {
+      failures.push({ settingsPath: result.settingsPath, error: result.error });
+    }
   }
+  return { failures };
 }
 
 export function setDesktopNotification(opts: { enabled: boolean }): void {
@@ -213,11 +238,18 @@ function buildDirectEnv(isDark: boolean): Record<string, string> {
     ? Object.fromEntries(Object.entries(process.env).filter((e): e is [string, string] => !!e[1]))
     : {};
 
+  // rtk's rewrite output invokes the bare name `rtk`; when the binary is
+  // Dash-managed (userData/bin), prepend that dir so the rewrite resolves.
+  const rtkBinDir = RtkService.getManagedBinDirForPath();
+  const pathSep = isWin ? ';' : ':';
+  const basePath = process.env.PATH || '';
+  const mergedPath = rtkBinDir ? prependUnique(rtkBinDir, basePath, pathSep) : basePath;
+
   const env: Record<string, string> = {
     ...base,
     TERM_PROGRAM: 'dash',
     HOME: os.homedir(),
-    PATH: process.env.PATH || '',
+    PATH: mergedPath,
     // Tell CLI apps about terminal background (rxvt convention)
     // Format: "fg;bg" where higher values = lighter colors
     COLORFGBG: isDark ? '15;0' : '0;15',
@@ -338,6 +370,36 @@ function tagDash<T extends HttpHook | CommandHook>(hook: T): T & { __dash: true 
 }
 
 /**
+ * Prepend `dir` to a path-like string, but only if it isn't already there
+ * (case-sensitive on Unix, case-sensitive on Windows is wrong but matches
+ * what users actually do). Used when injecting Dash-managed binary
+ * directories into the spawned process's PATH.
+ */
+function prependUnique(dir: string, basePath: string, sep: string): string {
+  if (!basePath) return dir;
+  const parts = basePath.split(sep);
+  if (parts.includes(dir)) return basePath;
+  return `${dir}${sep}${basePath}`;
+}
+
+/**
+ * Build the PreToolUse hook entries. `*` matcher always points at our
+ * tool-start endpoint; when RTK is enabled, also add a `Bash`-matcher
+ * entry that runs RTK's hook command to rewrite verbose Bash output
+ * before Claude consumes it.
+ */
+function buildPreToolUseHooks(
+  httpHook: (endpoint: DashHookEndpoint, async?: boolean) => HttpHook,
+): HookEntry[] {
+  const entries: HookEntry[] = [{ matcher: '*', hooks: [tagDash(httpHook('tool-start', true))] }];
+  const rtkCmd = RtkService.isEnabled() ? RtkService.getHookCommand() : null;
+  if (rtkCmd) {
+    entries.push({ matcher: 'Bash', hooks: [tagDash({ type: 'command', command: rtkCmd })] });
+  }
+  return entries;
+}
+
+/**
  * Atomic write: stage to a sibling tmp file then rename over the target.
  * POSIX rename is atomic, so a crash mid-write can never leave a half-
  * written file at `target`. Important here because settings.local.json is
@@ -374,6 +436,8 @@ function broadcastToast(message: string): void {
   }
 }
 
+type HookWriteResult = { ok: true } | { ok: false; settingsPath: string; error: string };
+
 /**
  * Write .claude/settings.local.json with hooks for activity monitoring,
  * tool tracking, error detection, and context usage.
@@ -386,10 +450,10 @@ function broadcastToast(message: string): void {
  * URL-shape detector, so users can have their own hooks under managed
  * events without losing them on every rewrite.
  *
- * Failure surfacing happens inside via console.error + broadcastToast.
- * Callers don't need to act on the result.
+ * Returns a result so refreshActivePtyHooks can aggregate failures across
+ * tasks; toasts and console.error are still emitted inline regardless.
  */
-function writeHookSettings(cwd: string, ptyId: string): void {
+function writeHookSettings(cwd: string, ptyId: string): HookWriteResult {
   const port = hookServer.port;
   const claudeDir = path.join(cwd, '.claude');
   const settingsPath = path.join(claudeDir, 'settings.local.json');
@@ -406,7 +470,7 @@ function writeHookSettings(cwd: string, ptyId: string): void {
     broadcastToast(
       `Hook server not ready — task hooks couldn't be written for ${path.basename(cwd)}. Restart Dash to recover.`,
     );
-    return;
+    return { ok: false, settingsPath, error: 'HookServer port not bound' };
   }
 
   const base = `http://127.0.0.1:${port}`;
@@ -431,7 +495,7 @@ function writeHookSettings(cwd: string, ptyId: string): void {
       { matcher: 'permission_prompt', hooks: [dashHttp('notification')] },
       { matcher: 'idle_prompt', hooks: [dashHttp('notification')] },
     ],
-    PreToolUse: [{ matcher: '*', hooks: [dashHttp('tool-start', true)] }],
+    PreToolUse: buildPreToolUseHooks(httpHook),
     PostToolUse: [{ matcher: '*', hooks: [dashHttp('tool-end', true)] }],
     PreCompact: [{ matcher: '*', hooks: [dashHttp('compact-start', true)] }],
   };
@@ -512,7 +576,11 @@ function writeHookSettings(cwd: string, ptyId: string): void {
           broadcastToast(
             `settings.local.json is corrupt and could not be backed up — hooks are off for this task. Fix or remove ${path.basename(settingsPath)} manually.`,
           );
-          return;
+          return {
+            ok: false,
+            settingsPath,
+            error: `corrupt settings.local.json; backup rename failed: ${renameErr instanceof Error ? renameErr.message : String(renameErr)}`,
+          };
         }
       }
     }
@@ -541,9 +609,15 @@ function writeHookSettings(cwd: string, ptyId: string): void {
 
     atomicWriteFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
     writtenSettingsPaths.add(settingsPath);
+    return { ok: true };
   } catch (err) {
     console.error('[writeHookSettings] Failed:', err);
     broadcastToast(`Could not write ${path.basename(settingsPath)} — hooks are off for this task.`);
+    return {
+      ok: false,
+      settingsPath,
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
 }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1522,7 +1522,7 @@ export function App() {
                 setShowSettings(true);
               }}
               onOpenPixelAgents={() => {
-                setSettingsInitialTab('pixel-agents');
+                setSettingsInitialTab('add-ons');
                 setShowSettings(true);
               }}
               onShowCommitGraph={(projectId) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -37,6 +37,8 @@ import type {
   ActivityInfo,
   PixelAgentsConfig,
   PixelAgentsStatus,
+  RtkStatus,
+  RtkDownloadProgress,
 } from '../shared/types';
 import type { CreateTaskOptions } from './components/TaskModal';
 import { formatTaskContextPrompt } from '../shared/taskContext';
@@ -189,6 +191,47 @@ export function App() {
     return window.electronAPI.onPixelAgentsStatusChanged((status) => {
       setPixelAgentsStatus(status);
     });
+  }, []);
+
+  // RTK state
+  const [rtkStatus, setRtkStatus] = useState<RtkStatus | null>(null);
+  const [rtkDownloadProgress, setRtkDownloadProgress] = useState<RtkDownloadProgress | null>(null);
+
+  useEffect(() => {
+    // Retry once on transient failure — without it, a single flake at startup
+    // leaves rtkStatus null forever and the Settings card stays stuck on
+    // "loading…".
+    let cancelled = false;
+    const tryFetch = (attempt: number): void => {
+      window.electronAPI.rtkGetStatus().then((resp) => {
+        if (cancelled) return;
+        if (resp.success && resp.data) {
+          setRtkStatus(resp.data);
+        } else if (attempt < 1) {
+          console.warn('[rtk:getStatus] retrying after transient failure:', resp.error);
+          setTimeout(() => tryFetch(attempt + 1), 500);
+        } else {
+          console.error('[rtk:getStatus] gave up after retry:', resp.error);
+          // Sentinel so the Settings card stops spinning. `enabled` is
+          // unrepresentable on the not-installed arm by design.
+          setRtkStatus({ installed: false, downloadable: false });
+        }
+      });
+    };
+    tryFetch(0);
+    const cleanup = window.electronAPI.onRtkDownloadProgress((progress) => {
+      setRtkDownloadProgress(progress);
+      if (progress.phase === 'done') {
+        window.electronAPI.rtkGetStatus().then((resp) => {
+          if (resp.success && resp.data) setRtkStatus(resp.data);
+          else console.error('[rtk:getStatus after download]', resp.error);
+        });
+      }
+    });
+    return () => {
+      cancelled = true;
+      cleanup();
+    };
   }, []);
 
   // Sync desktop notification settings to main process
@@ -1830,6 +1873,41 @@ export function App() {
             window.electronAPI.pixelAgentsSaveConfig(config);
           }}
           pixelAgentsStatus={pixelAgentsStatus}
+          rtkStatus={rtkStatus}
+          onRtkEnabledChange={(enabled) => {
+            // Optimistic update only applies to the installed arm — the type
+            // forbids `enabled` on { installed: false }.
+            setRtkStatus((prev) => (prev?.installed ? { ...prev, enabled } : prev));
+            window.electronAPI.rtkSetEnabled(enabled).then((resp) => {
+              if (!resp.success) {
+                toast.error(resp.error ?? 'Failed to toggle RTK');
+                window.electronAPI.rtkGetStatus().then((s) => {
+                  if (s.success && s.data) setRtkStatus(s.data);
+                  else console.error('[rtk:getStatus after setEnabled failure]', s.error);
+                });
+                return;
+              }
+              if (resp.data?.warning) {
+                toast.warning(resp.data.warning);
+              }
+            });
+          }}
+          onRtkDownload={() => {
+            setRtkDownloadProgress({ phase: 'downloading', percent: 0 });
+            window.electronAPI.rtkDownload().then((resp) => {
+              if (!resp.success) {
+                setRtkDownloadProgress({
+                  phase: 'error',
+                  error: resp.error ?? 'download failed',
+                });
+                return;
+              }
+              if (resp.data?.warning) {
+                toast.warning(resp.data.warning);
+              }
+            });
+          }}
+          rtkDownloadProgress={rtkDownloadProgress}
           latestRateLimits={latestRateLimits}
           usageThresholds={usageThresholds}
           onUsageThresholdsChange={setUsageThresholds}

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -44,14 +44,7 @@ import { UsageBar } from './ui/UsageBar';
 const DASH_DEFAULT_ATTRIBUTION =
   '\n\nCo-Authored-By: Claude <noreply@anthropic.com> via Dash <dash@syv.ai>';
 
-type SettingsTab =
-  | 'general'
-  | 'appearance'
-  | 'claude-code'
-  | 'keybindings'
-  | 'usage'
-  | 'pixel-agents'
-  | 'rtk';
+type SettingsTab = 'general' | 'appearance' | 'claude-code' | 'keybindings' | 'usage' | 'add-ons';
 
 interface SettingsModalProps {
   initialTab?: string;
@@ -1024,8 +1017,7 @@ export function SettingsModal({
     'claude-code',
     'keybindings',
     'usage',
-    'pixel-agents',
-    'rtk',
+    'add-ons',
   ];
   const [tab, setTab] = useState<SettingsTab>(
     initialTab && validTabs.includes(initialTab as SettingsTab)
@@ -1142,8 +1134,7 @@ export function SettingsModal({
               { id: 'keybindings', label: 'Keybindings' },
               { id: 'claude-code', label: 'Claude' },
               { id: 'usage', label: 'Usage' },
-              { id: 'rtk', label: 'RTK' },
-              { id: 'pixel-agents', label: 'Pixel Agents' },
+              { id: 'add-ons', label: 'Add-ons' },
             ] as const
           ).map((t) => (
             <button
@@ -1156,7 +1147,7 @@ export function SettingsModal({
               }`}
             >
               {t.label}
-              {t.id === 'pixel-agents' &&
+              {t.id === 'add-ons' &&
                 Object.values(pixelAgentsStatus.offices).some(
                   (s) => s === 'connected' || s === 'registered',
                 ) && (
@@ -1677,24 +1668,23 @@ export function SettingsModal({
             />
           )}
 
-          {tab === 'pixel-agents' && (
-            <div className="space-y-6 animate-fade-in">
-              <PixelAgentsSection
-                config={pixelAgentsConfig}
-                onChange={onPixelAgentsConfigChange}
-                status={pixelAgentsStatus}
-              />
-            </div>
-          )}
-
-          {tab === 'rtk' && (
-            <div className="space-y-6 animate-fade-in">
-              <RtkSection
-                status={rtkStatus}
-                onEnabledChange={onRtkEnabledChange}
-                onDownload={onRtkDownload}
-                progress={rtkDownloadProgress}
-              />
+          {tab === 'add-ons' && (
+            <div className="space-y-8 animate-fade-in">
+              <AddOnSection title="RTK">
+                <RtkSection
+                  status={rtkStatus}
+                  onEnabledChange={onRtkEnabledChange}
+                  onDownload={onRtkDownload}
+                  progress={rtkDownloadProgress}
+                />
+              </AddOnSection>
+              <AddOnSection title="Pixel Agents">
+                <PixelAgentsSection
+                  config={pixelAgentsConfig}
+                  onChange={onPixelAgentsConfigChange}
+                  status={pixelAgentsStatus}
+                />
+              </AddOnSection>
             </div>
           )}
 
@@ -1889,6 +1879,20 @@ function labelForProgress(progress: RtkDownloadProgress | null): {
       return { installing: false, installLabel: 'Install RTK' };
     }
   }
+}
+
+function AddOnSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-foreground/60">
+          {title}
+        </span>
+        <div className="flex-1 h-px bg-border/30" />
+      </div>
+      {children}
+    </section>
+  );
 }
 
 function RtkSection({

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -34,6 +34,9 @@ import type {
   PixelAgentsOfficeStatus,
   RateLimits,
   UsageThresholds,
+  RtkStatus,
+  RtkDownloadProgress,
+  RtkTestResult,
 } from '../../shared/types';
 import { formatResetTime } from '../../shared/format';
 import { UsageBar } from './ui/UsageBar';
@@ -47,7 +50,8 @@ type SettingsTab =
   | 'claude-code'
   | 'keybindings'
   | 'usage'
-  | 'pixel-agents';
+  | 'pixel-agents'
+  | 'rtk';
 
 interface SettingsModalProps {
   initialTab?: string;
@@ -92,6 +96,10 @@ interface SettingsModalProps {
   pixelAgentsConfig: PixelAgentsConfig | null;
   onPixelAgentsConfigChange: (config: PixelAgentsConfig) => void;
   pixelAgentsStatus: PixelAgentsStatus;
+  rtkStatus: RtkStatus | null;
+  onRtkEnabledChange: (enabled: boolean) => void;
+  onRtkDownload: () => void;
+  rtkDownloadProgress: RtkDownloadProgress | null;
   latestRateLimits?: RateLimits;
   usageThresholds: UsageThresholds;
   onUsageThresholdsChange: (thresholds: UsageThresholds) => void;
@@ -1001,6 +1009,10 @@ export function SettingsModal({
   pixelAgentsConfig,
   onPixelAgentsConfigChange,
   pixelAgentsStatus,
+  rtkStatus,
+  onRtkEnabledChange,
+  onRtkDownload,
+  rtkDownloadProgress,
   latestRateLimits,
   usageThresholds,
   onUsageThresholdsChange,
@@ -1013,6 +1025,7 @@ export function SettingsModal({
     'keybindings',
     'usage',
     'pixel-agents',
+    'rtk',
   ];
   const [tab, setTab] = useState<SettingsTab>(
     initialTab && validTabs.includes(initialTab as SettingsTab)
@@ -1129,6 +1142,7 @@ export function SettingsModal({
               { id: 'keybindings', label: 'Keybindings' },
               { id: 'claude-code', label: 'Claude' },
               { id: 'usage', label: 'Usage' },
+              { id: 'rtk', label: 'RTK' },
               { id: 'pixel-agents', label: 'Pixel Agents' },
             ] as const
           ).map((t) => (
@@ -1673,6 +1687,17 @@ export function SettingsModal({
             </div>
           )}
 
+          {tab === 'rtk' && (
+            <div className="space-y-6 animate-fade-in">
+              <RtkSection
+                status={rtkStatus}
+                onEnabledChange={onRtkEnabledChange}
+                onDownload={onRtkDownload}
+                progress={rtkDownloadProgress}
+              />
+            </div>
+          )}
+
           {tab === 'usage' && (
             <UsageSection
               latestRateLimits={latestRateLimits}
@@ -1798,6 +1823,394 @@ export function SettingsModal({
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function RtkStatusCardBody({ status }: { status: RtkStatus | null }) {
+  if (!status) {
+    return <p className="text-[11px] text-foreground/60">Checking…</p>;
+  }
+  if (status.installed) {
+    return (
+      <div className="space-y-0.5">
+        <p className="text-[11px] text-foreground/60 font-mono">
+          {status.version}
+          <span className="ml-2 text-foreground/40">
+            ({status.source === 'managed' ? 'managed by Dash' : 'on $PATH'})
+          </span>
+        </p>
+        <p className="text-[11px] text-foreground/40 font-mono truncate">{status.path}</p>
+      </div>
+    );
+  }
+  if (status.downloadable) {
+    return (
+      <p className="text-[11px] text-foreground/60 leading-relaxed">
+        Not installed. Dash can fetch the latest release directly — no sudo, no global $PATH
+        changes, binary stays scoped to this app.
+      </p>
+    );
+  }
+  return (
+    <p className="text-[11px] text-foreground/60 leading-relaxed">
+      Not installed, and no prebuilt release is available for this platform. Install manually from{' '}
+      <a
+        href="https://github.com/rtk-ai/rtk"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary hover:underline"
+      >
+        github.com/rtk-ai/rtk
+      </a>
+      .
+    </p>
+  );
+}
+
+function labelForProgress(progress: RtkDownloadProgress | null): {
+  installing: boolean;
+  installLabel: string;
+} {
+  if (!progress) return { installing: false, installLabel: 'Install RTK' };
+  switch (progress.phase) {
+    case 'downloading':
+      return { installing: true, installLabel: `Downloading… ${progress.percent}%` };
+    case 'verifying':
+      return { installing: true, installLabel: 'Verifying…' };
+    case 'extracting':
+      return { installing: true, installLabel: 'Extracting…' };
+    case 'done':
+    case 'error':
+      return { installing: false, installLabel: 'Install RTK' };
+    default: {
+      const _exhaustive: never = progress;
+      void _exhaustive;
+      return { installing: false, installLabel: 'Install RTK' };
+    }
+  }
+}
+
+function RtkSection({
+  status,
+  onEnabledChange,
+  onDownload,
+  progress,
+}: {
+  status: RtkStatus | null;
+  onEnabledChange: (enabled: boolean) => void;
+  onDownload: () => void;
+  progress: RtkDownloadProgress | null;
+}) {
+  const loading = !status;
+
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<RtkTestResult | null>(null);
+
+  async function runTest() {
+    setTesting(true);
+    setTestResult(null);
+    const resp = await window.electronAPI.rtkTest();
+    setTesting(false);
+    if (resp.success && resp.data) {
+      setTestResult(resp.data);
+    } else {
+      setTestResult({ ok: false, error: resp.error ?? 'unknown IPC error' });
+    }
+  }
+
+  const { installing, installLabel } = labelForProgress(progress);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="text-[11px] text-foreground/60 leading-relaxed">
+          RTK compresses common shell-command output (git, ls, test runners, tsc…) before Claude
+          sees it, typically cutting <b>60–90% of tokens</b> per command. When enabled, Dash injects
+          RTK&rsquo;s PreToolUse hook into every task automatically.{' '}
+          <a
+            href="https://github.com/rtk-ai/rtk"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-0.5 text-primary hover:underline"
+          >
+            Learn more
+            <ExternalLink size={9} strokeWidth={1.8} />
+          </a>
+        </p>
+      </div>
+
+      {/* Install status card */}
+      <div
+        className="flex items-start gap-3.5 p-4 rounded-xl border border-border/40"
+        style={{ background: 'hsl(var(--surface-2))' }}
+      >
+        <div
+          className={`w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 ${
+            status?.installed
+              ? 'bg-[hsl(var(--git-added)/0.12)]'
+              : 'bg-[hsl(var(--git-modified)/0.12)]'
+          }`}
+        >
+          {status?.installed ? (
+            <Check size={14} className="text-[hsl(var(--git-added))]" strokeWidth={1.8} />
+          ) : (
+            <AlertCircle size={14} className="text-[hsl(var(--git-modified))]" strokeWidth={1.8} />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <RtkStatusCardBody status={status} />
+        </div>
+      </div>
+
+      {/* Install button (only when not installed and platform is supported) */}
+      {!loading && !status?.installed && status?.downloadable && (
+        <div>
+          <button
+            onClick={onDownload}
+            disabled={installing}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg text-[12px] border border-primary/40 bg-primary/8 text-foreground hover:bg-primary/12 transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Download size={12} strokeWidth={1.8} />
+            {installLabel}
+          </button>
+          {progress?.phase === 'error' && (
+            <p className="text-[11px] text-destructive mt-2">{progress.error}</p>
+          )}
+          {progress?.phase === 'done' && (
+            <p className="text-[11px] text-[hsl(var(--git-added))] mt-2">
+              Installed {progress.version ?? ''} — you can enable it below.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Enable toggle (requires install) */}
+      <div>
+        <label className="block text-[12px] font-medium text-foreground mb-3">
+          Inject RTK hook in tasks
+        </label>
+        <ToggleSwitch
+          enabled={status?.installed ? status.enabled : false}
+          onToggle={onEnabledChange}
+          disabled={!status?.installed}
+          label="Compress Bash output via rtk before Claude reads it"
+        />
+        <p className="text-[10px] text-foreground/80 mt-2">
+          Takes effect on the next command in every running task — no restart needed. Dash writes
+          the hook into each task&rsquo;s local settings; your global{' '}
+          <code className="px-1 py-0.5 rounded bg-accent/60 text-[9px] font-mono">
+            ~/.claude/settings.json
+          </code>{' '}
+          is not modified. Do not also run{' '}
+          <code className="px-1 py-0.5 rounded bg-accent/60 text-[9px] font-mono">rtk init -g</code>{' '}
+          or the hook will run twice.
+        </p>
+      </div>
+
+      {/* In-process verification — runs `rtk hook claude` against a synthetic
+          `ls -la /tmp` payload and renders the rewrite it would emit. */}
+      {status?.installed && (
+        <div>
+          <label className="block text-[12px] font-medium text-foreground mb-3">Verify</label>
+          <button
+            onClick={runTest}
+            disabled={testing}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg text-[12px] border border-border/60 text-foreground/80 hover:bg-accent/40 hover:text-foreground transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {testing ? 'Testing…' : 'Test RTK'}
+          </button>
+          <p className="text-[10px] text-foreground/80 mt-2">
+            Pipes a synthetic{' '}
+            <code className="px-1 py-0.5 rounded bg-accent/60 text-[9px] font-mono">
+              git status
+            </code>{' '}
+            through the same rtk binary Dash hands to Claude. Green means rtk rewrote the command —
+            that&rsquo;s the compression path firing.
+          </p>
+
+          {testResult && <RtkTestResultCard result={testResult} />}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RtkTestResultCard({ result }: { result: RtkTestResult }) {
+  if (!result.ok) {
+    return (
+      <div
+        className="mt-3 flex items-start gap-3 p-3 rounded-lg border border-destructive/40"
+        style={{ background: 'hsl(var(--destructive) / 0.06)' }}
+      >
+        <AlertCircle size={14} className="text-destructive mt-0.5" strokeWidth={1.8} />
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] font-medium text-destructive">Test failed</p>
+          <p className="text-[11px] text-foreground/70 font-mono mt-1 break-all">{result.error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  switch (result.outcome.kind) {
+    case 'blocked':
+      return (
+        <div
+          className="mt-3 flex items-start gap-3 p-3 rounded-lg border border-[hsl(var(--git-modified))]/40"
+          style={{ background: 'hsl(var(--git-modified) / 0.06)' }}
+        >
+          <AlertCircle
+            size={14}
+            className="text-[hsl(var(--git-modified))] mt-0.5"
+            strokeWidth={1.8}
+          />
+          <div className="min-w-0 flex-1 space-y-1">
+            <p className="text-[11px] font-medium text-foreground">
+              rtk blocked this command (exit 2).
+            </p>
+            {result.outcome.stderr && (
+              <p className="text-[11px] text-foreground/70 font-mono break-all">
+                {result.outcome.stderr}
+              </p>
+            )}
+          </div>
+        </div>
+      );
+
+    case 'rewritten': {
+      const diff = result.outcome.execDiff;
+      const okDiff = diff && diff.kind === 'ok' ? diff : null;
+      const failedDiff = diff && diff.kind === 'failed' ? diff : null;
+      const savedBytes = okDiff ? okDiff.rawBytes - okDiff.compressedBytes : 0;
+      const savedPct =
+        okDiff && okDiff.rawBytes > 0 ? Math.round((savedBytes / okDiff.rawBytes) * 100) : 0;
+
+      return (
+        <div
+          className="mt-3 p-3 rounded-lg border border-[hsl(var(--git-added))]/40 space-y-3"
+          style={{ background: 'hsl(var(--git-added) / 0.06)' }}
+        >
+          <div className="flex items-start gap-3">
+            <Check size={14} className="text-[hsl(var(--git-added))] mt-0.5" strokeWidth={1.8} />
+            <div className="min-w-0 flex-1 space-y-1">
+              <p className="text-[11px] font-medium text-foreground">
+                Compression active — rtk would rewrite this command.
+              </p>
+              <div className="text-[11px] text-foreground/70 font-mono space-y-0.5">
+                <div>
+                  <span className="text-foreground/40">in: </span>
+                  {result.testedCommand}
+                </div>
+                <div>
+                  <span className="text-foreground/40">out:</span> {result.outcome.rewrittenCommand}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {okDiff && (
+            <div className="space-y-2 pt-2 border-t border-border/40">
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] font-medium uppercase tracking-wide text-foreground/60">
+                  Actual output diff
+                </span>
+                {okDiff.rawBytes > 0 && (
+                  <span className="text-[10px] font-mono text-[hsl(var(--git-added))]">
+                    {okDiff.rawBytes} → {okDiff.compressedBytes} bytes
+                    {savedBytes > 0 && ` (−${savedPct}%)`}
+                    {okDiff.truncated && ' · truncated'}
+                  </span>
+                )}
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <OutputPanel label="raw" body={okDiff.rawStdout} />
+                <OutputPanel label="via rtk" body={okDiff.compressedStdout} accented />
+              </div>
+            </div>
+          )}
+
+          {failedDiff && (
+            <div
+              className="space-y-1 pt-2 border-t border-border/40"
+              style={{ borderColor: 'hsl(var(--git-modified) / 0.3)' }}
+            >
+              <span className="text-[10px] font-medium uppercase tracking-wide text-[hsl(var(--git-modified))]">
+                Couldn&rsquo;t capture diff
+              </span>
+              <p className="text-[11px] text-foreground/70">{failedDiff.reason}</p>
+              {failedDiff.stderr && (
+                <pre className="text-[10px] text-foreground/50 font-mono whitespace-pre-wrap break-words">
+                  {failedDiff.stderr}
+                </pre>
+              )}
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    case 'pass-through':
+      return (
+        <div
+          className="mt-3 flex items-start gap-3 p-3 rounded-lg border border-border/40"
+          style={{ background: 'hsl(var(--surface-2))' }}
+        >
+          <AlertCircle
+            size={14}
+            className="text-[hsl(var(--git-modified))] mt-0.5"
+            strokeWidth={1.8}
+          />
+          <div className="min-w-0 flex-1">
+            <p className="text-[11px] font-medium text-foreground">
+              rtk ran without crashing, but chose not to rewrite this command.
+            </p>
+            <p className="text-[10px] text-foreground/60 mt-1">
+              That&rsquo;s valid — rtk only compresses commands in its rewrite list. The hook
+              plumbing is working; it would compress commands like{' '}
+              <code className="text-foreground/80">git status</code> or{' '}
+              <code className="text-foreground/80">cargo test</code> during real use.
+            </p>
+          </div>
+        </div>
+      );
+
+    default: {
+      const _exhaustive: never = result.outcome;
+      void _exhaustive;
+      return null;
+    }
+  }
+}
+
+function OutputPanel({
+  label,
+  body,
+  accented,
+}: {
+  label: string;
+  body: string;
+  accented?: boolean;
+}) {
+  const displayBody = body.trim().length > 0 ? body : '(empty)';
+  return (
+    <div
+      className={`rounded-md border text-[10px] font-mono leading-[1.35] overflow-hidden ${
+        accented ? 'border-[hsl(var(--git-added))]/40' : 'border-border/50'
+      }`}
+      style={{ background: 'hsl(var(--surface-1))' }}
+    >
+      <div
+        className={`px-2 py-1 text-[9px] font-sans uppercase tracking-wide ${
+          accented
+            ? 'text-[hsl(var(--git-added))] bg-[hsl(var(--git-added))]/5'
+            : 'text-foreground/50 bg-[hsl(var(--surface-2))]'
+        }`}
+      >
+        {label}
+      </div>
+      <pre className="px-2 py-1.5 max-h-48 overflow-auto whitespace-pre-wrap break-words text-foreground/80">
+        {displayBody}
+      </pre>
     </div>
   );
 }

--- a/src/renderer/components/ui/ToggleSwitch.tsx
+++ b/src/renderer/components/ui/ToggleSwitch.tsx
@@ -4,15 +4,20 @@ export function ToggleSwitch({
   enabled,
   onToggle,
   label,
+  disabled,
 }: {
   enabled: boolean;
   onToggle: (value: boolean) => void;
   label: string;
+  disabled?: boolean;
 }) {
   return (
     <button
       onClick={() => onToggle(!enabled)}
+      disabled={disabled}
       className={`flex items-center gap-3 w-full px-4 py-3 rounded-lg text-[13px] border transition-all duration-150 ${
+        disabled ? 'opacity-50 cursor-not-allowed' : ''
+      } ${
         enabled
           ? 'border-primary/40 bg-primary/8 text-foreground ring-1 ring-primary/20'
           : 'border-border/60 text-foreground/60 hover:bg-accent/40 hover:text-foreground'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -375,3 +375,81 @@ export interface PixelAgentsStatus {
   running: boolean;
   offices: Record<string, PixelAgentsOfficeStatus>;
 }
+
+// ── RTK (Rust Token Killer) Types ───────────────────────────
+
+export type RtkSource = 'path' | 'managed';
+
+// `enabled` only makes sense when a binary is installed — RtkService.setEnabled
+// throws if you try to enable without resolution. Encoding the rule in the
+// type means TS prevents the impossible state at construction; the IPC
+// pre-flight check that previously enforced it at runtime can be dropped.
+export type RtkStatus =
+  | {
+      installed: true;
+      version: string;
+      path: string;
+      source: RtkSource;
+      enabled: boolean;
+      downloadable: boolean;
+    }
+  | { installed: false; downloadable: boolean };
+
+export type RtkDownloadProgress =
+  | { phase: 'downloading'; percent: number }
+  | { phase: 'verifying' }
+  | { phase: 'extracting' }
+  | { phase: 'done'; version: string }
+  | { phase: 'error'; error: string };
+
+export type RtkExecDiff =
+  | {
+      kind: 'ok';
+      /** Stdout of the raw tested command, capped for IPC payload size. */
+      rawStdout: string;
+      /** Stdout of the rtk-rewritten command, capped for IPC payload size. */
+      compressedStdout: string;
+      /** Untruncated byte counts, so the UI can show honest savings math. */
+      rawBytes: number;
+      compressedBytes: number;
+      /** True when stdout was truncated at the runShell cap; bytes counts
+       *  reflect the truncated buffer in that case (we stop reading). */
+      truncated: boolean;
+    }
+  | {
+      /** Diff capture itself failed — distinct from "rtk chose pass-through".
+       *  UI must NOT render this as a successful no-op rewrite. */
+      kind: 'failed';
+      /** Which stage broke: `setup` (mkdtemp/git init), `raw` (the original
+       *  command), `rewritten` (the rtk-rewritten command), or `unknown`. */
+      stage: 'setup' | 'raw' | 'rewritten' | 'unknown';
+      /** Exit code when the command exited non-zero; absent when the failure
+       *  happened before spawn (mkdtemp, git init, etc.). */
+      exitCode?: number;
+      /** Truncated stderr for the failed stage, when available. */
+      stderr?: string;
+      /** Human-readable reason — what to show in the UI. */
+      reason: string;
+    };
+
+// Three orthogonal optionals (`rewrittenCommand: string | null`, `blocked?`,
+// `execDiff?`) admitted impossible combinations in production code (e.g.
+// blocked AND rewritten). A nested outcome discriminant collapses them so
+// the renderer's three branches map 1:1 to representable states.
+export type RtkTestResult =
+  | { ok: false; testedCommand?: string; error: string }
+  | {
+      ok: true;
+      testedCommand: string;
+      rawOutput: string;
+      outcome: RtkTestOutcome;
+    };
+
+export type RtkTestOutcome =
+  // rtk ran cleanly and chose pass-through (no rewrite for this command).
+  | { kind: 'pass-through' }
+  // rtk used exit 2 to block the tool call. Distinct from a failure.
+  | { kind: 'blocked'; stderr: string }
+  // rtk emitted a rewrite. execDiff is best-effort visualization, not a
+  // correctness signal — its absence/failure does not invalidate the rewrite.
+  | { kind: 'rewritten'; rewrittenCommand: string; execDiff?: RtkExecDiff };

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -19,6 +19,9 @@ import type {
   PixelAgentsConfig,
   PixelAgentsStatus,
   ActivityInfo,
+  RtkStatus,
+  RtkDownloadProgress,
+  RtkTestResult,
 } from '../shared/types';
 
 export interface ElectronAPI {
@@ -266,6 +269,13 @@ export interface ElectronAPI {
   pixelAgentsStart: () => Promise<IpcResponse<void>>;
   pixelAgentsStop: () => Promise<IpcResponse<void>>;
   onPixelAgentsStatusChanged: (callback: (status: PixelAgentsStatus) => void) => () => void;
+
+  // RTK (Rust Token Killer)
+  rtkGetStatus: () => Promise<IpcResponse<RtkStatus>>;
+  rtkSetEnabled: (enabled: boolean) => Promise<IpcResponse<{ warning?: string }>>;
+  rtkDownload: () => Promise<IpcResponse<{ warning?: string } | undefined>>;
+  rtkTest: () => Promise<IpcResponse<RtkTestResult>>;
+  onRtkDownloadProgress: (callback: (progress: RtkDownloadProgress) => void) => () => void;
 
   // Telemetry
   telemetryCapture: (event: string, properties?: Record<string, unknown>) => Promise<void>;


### PR DESCRIPTION
## Summary
Optional Bash-output compression integrated as a Claude Code PreToolUse hook. RTK rewrites verbose tool output (git status, ls, cargo test, tsc…) before Claude reads it — typically 60–90% token reduction per command. When enabled, Dash injects the hook into every active task's `settings.local.json` automatically; the global `~/.claude/settings.json` is never touched.

This PR replaces #126 — same RTK feature, rebuilt on top of current main as a single squash commit (preserving Fabian's authorship via `Co-Authored-By`). The rebuild drops:
- Hook-merge module work (already shipped via #130)
- Fork-jsonl plumbing (architecturally obsolete under #124's "trust `claude --continue`" model)
- Three orthogonal bug fixes — rate-limit threshold, Linux clipboard, snapshot save/restore logging — already shipped via #131

## What's in
- **`RtkService`** — binary resolution (PATH or Dash-managed in `userData/bin`), GitHub-release install with SHA verification + tar safety checks (path-traversal / symlink rejection), self-test runner, on-disk config in `rtk-config.json` (atomic write), RTK toast on corrupt config.
- **IPC** — `rtk:getStatus`, `rtk:setEnabled`, `rtk:download`, `rtk:test`, plus a streaming `rtk:downloadProgress` channel.
- **Hook injection** — new `buildPreToolUseHooks` helper in `ptyManager` adds a Bash-matcher command hook (`RtkService.getHookCommand()`) alongside the existing PreToolUse `*` matcher whenever `RtkService.isEnabled()`. Toggling RTK on a running task takes effect on the next tool call without restarting (Claude re-reads settings per call).
- **PATH prepend** — when the binary is Dash-managed, `buildDirectEnv` injects `userData/bin` into the spawned Claude process's PATH so the rewrite can resolve the bare `rtk` name.
- **Refresh failure surfacing** — `writeHookSettings` returns `HookWriteResult` again, and `refreshActivePtyHooks` aggregates failures so the RTK toggle / install IPCs return a `warning` field when the flag persisted but some active tasks couldn't pick it up live.
- **Settings UI** — new RTK tab with status card, install button + progress, enable toggle (gated on installation), and a Verify button that shows raw vs. rewritten output side-by-side with byte-savings.

## Type design notes
- `RtkStatus` is a discriminated union on `installed` so `enabled` cannot be set without a resolved binary at the type level.
- `RtkTestResult` collapses three orthogonal optionals into a nested `outcome` discriminant (`'pass-through' | 'blocked' | 'rewritten'`) so impossible combinations like "rewritten AND blocked" are unrepresentable.

## Test plan
- [x] `pnpm exec vitest run` — 111 tests pass (36 new RTK unit tests covering URL allowlist, archive-member safety, JSON rewrite extraction, config-corruption tolerance).
- [x] `pnpm type-check` — clean.
- [x] Manual: open Settings → RTK tab. Click Install RTK; verify the GitHub release downloads, SHA verifies, and the binary lands in `userData/bin`. Toggle "Inject RTK hook in tasks" — `settings.local.json` for every active task gets a new PreToolUse Bash entry within one tool call. Click Test RTK; the result card shows raw `git status` vs. rtk-rewritten output with a savings percentage.
- [x] Manual: with RTK enabled, run a verbose Bash command in a task (e.g. `git status` on a busy repo). Confirm Claude receives the compressed output (visible in the conversation as a shorter tool result).
- [x] Manual: toggle RTK off — the `Bash`-matcher hook entry disappears from `settings.local.json` on next refresh.

Co-Authored-By: Fabian Scott <fabian@syv.ai>
Claude goes brrr - via Dash