### PR TITLE
Fix Windows clipboard: Ctrl+V paste and chunked writes

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -140,21 +140,24 @@ export class TerminalSessionManager {
     this.terminal.attachCustomKeyEventHandler((e) => {
       if (e.type !== 'keydown') return true;
 
-      const isMac = navigator.userAgent.includes('Mac');
+      const platform = window.electronAPI.getPlatform();
+      const isMac = platform === 'darwin';
+      const isWin = platform === 'win32';
 
       // Match by physical key (e.code) so alternate keyboard layouts where
       // Ctrl+Shift+C reports e.key as something other than 'C' still work.
       const isKeyC = e.code === 'KeyC';
       const isKeyV = e.code === 'KeyV';
 
-      // Copy: Cmd+C (macOS) or Ctrl+Shift+C (Linux) — copy terminal selection.
+      // Copy: Cmd+C (macOS), Ctrl+Shift+C (Linux), Ctrl+C (Windows).
       // Also Ctrl+C on any platform when there's an active selection (matches
       // native terminal behaviour: Ctrl+C copies when selected, sends SIGINT
       // otherwise). Explicit shortcuts fall back to lastSelection so users can
       // still copy after the TUI has cleared xterm's highlight.
       const isExplicitCopy =
         (isMac && e.metaKey && isKeyC && !e.ctrlKey) ||
-        (!isMac && e.ctrlKey && e.shiftKey && isKeyC);
+        (isWin && e.ctrlKey && !e.shiftKey && isKeyC && this.terminal.hasSelection()) ||
+        (!isMac && !isWin && e.ctrlKey && e.shiftKey && isKeyC);
       const isPlainCtrlC = e.ctrlKey && !e.shiftKey && isKeyC && this.terminal.hasSelection();
       if (isExplicitCopy || isPlainCtrlC) {
         const sel = this.terminal.getSelection() || (isExplicitCopy ? this.lastSelection : '');
@@ -165,14 +168,15 @@ export class TerminalSessionManager {
         }
       }
 
-      // Paste: Cmd+V (macOS) or Ctrl+Shift+V (Linux)
+      // Paste: Cmd+V (macOS), Ctrl+V (Windows), Ctrl+Shift+V (Linux)
       if (
         (isMac && e.metaKey && isKeyV && !e.ctrlKey) ||
-        (!isMac && e.ctrlKey && e.shiftKey && isKeyV)
+        (isWin && e.ctrlKey && isKeyV) ||
+        (!isMac && !isWin && e.ctrlKey && e.shiftKey && isKeyV)
       ) {
         e.preventDefault();
         window.electronAPI.clipboardReadText().then((text) => {
-          if (text) window.electronAPI.ptyInput({ id: this.id, data: text });
+          if (text) this.writePasteData(text);
         });
         return false;
       }
@@ -523,6 +527,10 @@ export class TerminalSessionManager {
       clearTimeout(this.fitDebounceTimer);
       this.fitDebounceTimer = null;
     }
+    if (this.pasteTimer) {
+      clearTimeout(this.pasteTimer);
+      this.pasteTimer = null;
+    }
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
       this.resizeObserver = null;
@@ -549,6 +557,34 @@ export class TerminalSessionManager {
 
   writeInput(data: string) {
     window.electronAPI.ptyInput({ id: this.id, data });
+  }
+
+  private pasteTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Write pasted text in chunks to avoid overflowing the PTY input buffer
+  // (conpty on Windows drops data beyond ~4 KB written in a single call).
+  private writePasteData(text: string) {
+    if (this.pasteTimer) {
+      clearTimeout(this.pasteTimer);
+      this.pasteTimer = null;
+    }
+    const CHUNK = 4096;
+    if (text.length <= CHUNK) {
+      window.electronAPI.ptyInput({ id: this.id, data: text });
+      return;
+    }
+    let offset = 0;
+    const writeNext = () => {
+      if (offset >= text.length || this.disposed) {
+        this.pasteTimer = null;
+        return;
+      }
+      const end = Math.min(offset + CHUNK, text.length);
+      window.electronAPI.ptyInput({ id: this.id, data: text.slice(offset, end) });
+      offset = end;
+      this.pasteTimer = setTimeout(writeNext, 12);
+    };
+    writeNext();
   }
 
   focus() {

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -149,11 +149,13 @@ export class TerminalSessionManager {
       const isKeyC = e.code === 'KeyC';
       const isKeyV = e.code === 'KeyV';
 
-      // Copy: Cmd+C (macOS), Ctrl+Shift+C (Linux), Ctrl+C (Windows).
+      // Copy: Cmd+C (macOS), Ctrl+Shift+C (Linux), Ctrl+C (Windows, only when text is selected).
       // Also Ctrl+C on any platform when there's an active selection (matches
       // native terminal behaviour: Ctrl+C copies when selected, sends SIGINT
-      // otherwise). Explicit shortcuts fall back to lastSelection so users can
-      // still copy after the TUI has cleared xterm's highlight.
+      // otherwise). macOS and Linux explicit shortcuts fall back to lastSelection
+      // so users can still copy after the TUI has cleared xterm's highlight.
+      // Windows does not use lastSelection — Ctrl+C without a live selection
+      // should always send SIGINT.
       const isExplicitCopy =
         (isMac && e.metaKey && isKeyC && !e.ctrlKey) ||
         (isWin && e.ctrlKey && !e.shiftKey && isKeyC && this.terminal.hasSelection()) ||
@@ -175,9 +177,14 @@ export class TerminalSessionManager {
         (!isMac && !isWin && e.ctrlKey && e.shiftKey && isKeyV)
       ) {
         e.preventDefault();
-        window.electronAPI.clipboardReadText().then((text) => {
-          if (text) this.writePasteData(text);
-        });
+        window.electronAPI
+          .clipboardReadText()
+          .then((text) => {
+            if (text) this.writePasteData(text);
+          })
+          .catch((err) => {
+            console.warn('[terminal] clipboardReadText failed:', err);
+          });
         return false;
       }
 
@@ -564,6 +571,7 @@ export class TerminalSessionManager {
   // Write pasted text in chunks to avoid overflowing the PTY input buffer
   // (conpty on Windows drops data beyond ~4 KB written in a single call).
   private writePasteData(text: string) {
+    if (this.disposed) return;
     if (this.pasteTimer) {
       clearTimeout(this.pasteTimer);
       this.pasteTimer = null;


### PR DESCRIPTION
## Summary
- **Ctrl+V now works on Windows** — previously only Ctrl+Shift+V was handled (Linux convention), leaving Windows users without a working paste shortcut
- **Large pastes no longer truncated** — content is chunked into 4 KB pieces with 12ms delays to avoid overflowing conpty's input buffer (which caused only ~20 lines to appear)
- **Ctrl+C copies selection on Windows** — matches standard Windows terminal UX (copies when text is selected, sends SIGINT otherwise)
- Cancels in-flight chunked paste when a new paste arrives; cleans up timer on dispose

## Test plan
- [ ] On Windows: Ctrl+V pastes clipboard content into terminal
- [ ] On Windows: Ctrl+Shift+V also pastes (both shortcuts work)
- [ ] On Windows: paste content longer than ~20 lines arrives fully
- [ ] On Windows: Ctrl+C with selection copies text
- [ ] On Windows: Ctrl+C without selection sends SIGINT
- [ ] On macOS: Cmd+V / Cmd+C still work as before
- [ ] On Linux: Ctrl+Shift+V / Ctrl+Shift+C still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)