### PR TITLE
Add settings to disable auto-update and update notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/main/ipc/autoUpdateIpc.ts
+++ b/src/main/ipc/autoUpdateIpc.ts
@@ -5,4 +5,11 @@ export function registerAutoUpdateIpc(): void {
   ipcMain.handle('autoUpdate:check', () => AutoUpdateService.checkForUpdates());
   ipcMain.handle('autoUpdate:download', () => AutoUpdateService.downloadUpdate());
   ipcMain.handle('autoUpdate:quitAndInstall', () => AutoUpdateService.quitAndInstall());
+  ipcMain.handle('autoUpdate:getEnabled', () => ({
+    success: true,
+    data: AutoUpdateService.readPreference(),
+  }));
+  ipcMain.handle('autoUpdate:setEnabled', (_event, enabled: boolean) =>
+    AutoUpdateService.setEnabled(enabled),
+  );
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -300,6 +300,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   autoUpdateCheck: () => ipcRenderer.invoke('autoUpdate:check'),
   autoUpdateDownload: () => ipcRenderer.invoke('autoUpdate:download'),
   autoUpdateQuitAndInstall: () => ipcRenderer.invoke('autoUpdate:quitAndInstall'),
+  autoUpdateGetEnabled: () => ipcRenderer.invoke('autoUpdate:getEnabled'),
+  autoUpdateSetEnabled: (enabled: boolean) =>
+    ipcRenderer.invoke('autoUpdate:setEnabled', enabled),
   onAutoUpdateAvailable: (callback: (info: { version: string }) => void) => {
     const handler = (_event: unknown, info: { version: string }) => callback(info);
     ipcRenderer.on('autoUpdate:available', handler);

--- a/src/main/services/AutoUpdateService.ts
+++ b/src/main/services/AutoUpdateService.ts
@@ -1,5 +1,7 @@
 import { autoUpdater, type UpdateInfo, type ProgressInfo } from 'electron-updater';
-import { dialog } from 'electron';
+import { app, dialog } from 'electron';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import type { BrowserWindow } from 'electron';
 import type { IpcResponse } from '@shared/types';
 
@@ -15,6 +17,10 @@ const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const INITIAL_DELAY_MS = 10 * 1000; // 10 seconds
 const CHECK_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
 
+function getPreferencePath(): string {
+  return join(app.getPath('userData'), 'update-preferences.json');
+}
+
 function send(channel: string, ...args: unknown[]): void {
   try {
     if (mainWindow && !mainWindow.isDestroyed()) {
@@ -25,18 +31,55 @@ function send(channel: string, ...args: unknown[]): void {
   }
 }
 
+function clearTimers(): void {
+  if (checkInterval) {
+    clearInterval(checkInterval);
+    checkInterval = null;
+  }
+  if (initialCheckTimer) {
+    clearTimeout(initialCheckTimer);
+    initialCheckTimer = null;
+  }
+}
+
+function startTimers(): void {
+  clearTimers();
+  initialCheckTimer = setTimeout(() => {
+    initialCheckTimer = null;
+    autoUpdater.checkForUpdates().catch(() => {});
+  }, INITIAL_DELAY_MS);
+  checkInterval = setInterval(() => {
+    autoUpdater.checkForUpdates().catch(() => {});
+  }, CHECK_INTERVAL_MS);
+}
+
 export class AutoUpdateService {
+  static readPreference(): boolean {
+    try {
+      const path = getPreferencePath();
+      if (!existsSync(path)) return true;
+      const raw = JSON.parse(readFileSync(path, 'utf-8'));
+      return raw?.autoUpdateEnabled !== false;
+    } catch {
+      return true;
+    }
+  }
+
+  static writePreference(enabled: boolean): void {
+    try {
+      writeFileSync(
+        getPreferencePath(),
+        JSON.stringify({ autoUpdateEnabled: enabled }, null, 2),
+        'utf-8',
+      );
+    } catch (err) {
+      console.error('[AutoUpdate] Failed to persist preference:', err);
+    }
+  }
+
   static initialize(window: BrowserWindow): void {
-    // Clean up any previous listeners to prevent duplicates
     autoUpdater.removeAllListeners();
-    if (checkInterval) {
-      clearInterval(checkInterval);
-      checkInterval = null;
-    }
-    if (initialCheckTimer) {
-      clearTimeout(initialCheckTimer);
-      initialCheckTimer = null;
-    }
+    clearTimers();
 
     mainWindow = window;
     state = 'idle';
@@ -79,20 +122,25 @@ export class AutoUpdateService {
       });
     });
 
-    // Initial check after delay
-    initialCheckTimer = setTimeout(() => {
-      initialCheckTimer = null;
-      autoUpdater.checkForUpdates().catch(() => {});
-    }, INITIAL_DELAY_MS);
-
-    // Periodic checks
-    checkInterval = setInterval(() => {
-      autoUpdater.checkForUpdates().catch(() => {});
-    }, CHECK_INTERVAL_MS);
+    if (AutoUpdateService.readPreference()) {
+      startTimers();
+    }
   }
 
   static setWindow(window: BrowserWindow): void {
     mainWindow = window;
+  }
+
+  static setEnabled(enabled: boolean): IpcResponse<void> {
+    AutoUpdateService.writePreference(enabled);
+    if (enabled) {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        startTimers();
+      }
+    } else {
+      clearTimers();
+    }
+    return { success: true };
   }
 
   static async checkForUpdates(): Promise<IpcResponse<void>> {
@@ -154,14 +202,7 @@ export class AutoUpdateService {
   }
 
   static cleanup(): void {
-    if (checkInterval) {
-      clearInterval(checkInterval);
-      checkInterval = null;
-    }
-    if (initialCheckTimer) {
-      clearTimeout(initialCheckTimer);
-      initialCheckTimer = null;
-    }
+    clearTimers();
     autoUpdater.removeAllListeners();
     mainWindow = null;
   }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -95,6 +95,14 @@ export function App() {
   const [desktopNotification, setDesktopNotification] = useState(() => {
     return localStorage.getItem('desktopNotification') === 'true';
   });
+  const [autoUpdateEnabled, setAutoUpdateEnabled] = useState(() => {
+    const stored = localStorage.getItem('autoUpdateEnabled');
+    return stored === null ? true : stored === 'true';
+  });
+  const [updateNotificationsEnabled, setUpdateNotificationsEnabled] = useState(() => {
+    const stored = localStorage.getItem('updateNotificationsEnabled');
+    return stored === null ? true : stored === 'true';
+  });
   const [shellDrawerEnabled, setShellDrawerEnabled] = useState(() => {
     const stored = localStorage.getItem('shellDrawerEnabled');
     return stored === null ? true : stored === 'true';
@@ -242,6 +250,26 @@ export function App() {
       enabled: desktopNotification,
     });
   }, [desktopNotification]);
+
+  // Hydrate auto-update preference from main (file is source of truth) on mount
+  useEffect(() => {
+    let cancelled = false;
+    window.electronAPI.autoUpdateGetEnabled?.().then((res) => {
+      if (cancelled) return;
+      if (res.success && typeof res.data === 'boolean') {
+        setAutoUpdateEnabled(res.data);
+        localStorage.setItem('autoUpdateEnabled', String(res.data));
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Sync auto-update enabled to main process
+  useEffect(() => {
+    window.electronAPI.autoUpdateSetEnabled?.(autoUpdateEnabled);
+  }, [autoUpdateEnabled]);
   // Sync commit attribution to main process
   useEffect(() => {
     window.electronAPI.setCommitAttribution?.(commitAttribution);
@@ -1848,6 +1876,16 @@ export function App() {
             setDesktopNotification(v);
             localStorage.setItem('desktopNotification', String(v));
           }}
+          autoUpdateEnabled={autoUpdateEnabled}
+          onAutoUpdateEnabledChange={(v) => {
+            setAutoUpdateEnabled(v);
+            localStorage.setItem('autoUpdateEnabled', String(v));
+          }}
+          updateNotificationsEnabled={updateNotificationsEnabled}
+          onUpdateNotificationsEnabledChange={(v) => {
+            setUpdateNotificationsEnabled(v);
+            localStorage.setItem('updateNotificationsEnabled', String(v));
+          }}
           activeProjectPath={activeProject?.path}
           preferredIDE={preferredIDE}
           onPreferredIDEChange={(v) => {
@@ -2016,7 +2054,7 @@ export function App() {
         />
       )}
 
-      <ToastContainer />
+      <ToastContainer updateNotificationsEnabled={updateNotificationsEnabled} />
     </div>
   );
 }

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -56,6 +56,10 @@ interface SettingsModalProps {
   onNotificationSoundChange: (value: NotificationSound) => void;
   desktopNotification: boolean;
   onDesktopNotificationChange: (value: boolean) => void;
+  autoUpdateEnabled: boolean;
+  onAutoUpdateEnabledChange: (value: boolean) => void;
+  updateNotificationsEnabled: boolean;
+  onUpdateNotificationsEnabledChange: (value: boolean) => void;
   showRateLimits: boolean;
   onShowRateLimitsChange: (value: boolean) => void;
   showUsageInline: boolean;
@@ -969,6 +973,10 @@ export function SettingsModal({
   onNotificationSoundChange,
   desktopNotification,
   onDesktopNotificationChange,
+  autoUpdateEnabled,
+  onAutoUpdateEnabledChange,
+  updateNotificationsEnabled,
+  onUpdateNotificationsEnabledChange,
   showRateLimits,
   onShowRateLimitsChange,
   showUsageInline,
@@ -1457,6 +1465,25 @@ export function SettingsModal({
                 <label className="block text-[12px] font-medium text-foreground mb-3">
                   Updates
                 </label>
+                <div className="space-y-3 mb-4">
+                  <ToggleSwitch
+                    enabled={autoUpdateEnabled}
+                    onToggle={onAutoUpdateEnabledChange}
+                    label="Check for updates automatically"
+                  />
+                  <p className="text-[10px] text-foreground/80 -mt-1">
+                    When off, Dash won't check for updates in the background. You can still check
+                    manually below.
+                  </p>
+                  <ToggleSwitch
+                    enabled={updateNotificationsEnabled}
+                    onToggle={onUpdateNotificationsEnabledChange}
+                    label="Show update notifications"
+                  />
+                  <p className="text-[10px] text-foreground/80 -mt-1">
+                    Toast popups when an update is available, downloaded, or fails.
+                  </p>
+                </div>
                 <div className="flex items-center gap-3">
                   <p className="text-[13px] text-foreground/80 font-mono">{appVersion || '...'}</p>
                   {updateStatus === 'ready' ? (

--- a/src/renderer/components/Toast.tsx
+++ b/src/renderer/components/Toast.tsx
@@ -1,7 +1,16 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Toaster, toast } from 'sonner';
 
-export function ToastContainer() {
+interface ToastContainerProps {
+  updateNotificationsEnabled: boolean;
+}
+
+export function ToastContainer({ updateNotificationsEnabled }: ToastContainerProps) {
+  const updateNotificationsRef = useRef(updateNotificationsEnabled);
+  useEffect(() => {
+    updateNotificationsRef.current = updateNotificationsEnabled;
+  }, [updateNotificationsEnabled]);
+
   useEffect(() => {
     return window.electronAPI.onToast((data) => {
       if (data.url) {
@@ -21,6 +30,7 @@ export function ToastContainer() {
   // Auto-update: update available
   useEffect(() => {
     return window.electronAPI.onAutoUpdateAvailable((info) => {
+      if (!updateNotificationsRef.current) return;
       toast(`Update v${info.version} available`, {
         duration: Infinity,
         action: {
@@ -36,6 +46,7 @@ export function ToastContainer() {
   // Auto-update: download complete
   useEffect(() => {
     return window.electronAPI.onAutoUpdateDownloaded(() => {
+      if (!updateNotificationsRef.current) return;
       toast('Update ready to install', {
         duration: Infinity,
         action: {
@@ -51,6 +62,7 @@ export function ToastContainer() {
   // Auto-update: error
   useEffect(() => {
     return window.electronAPI.onAutoUpdateError((info) => {
+      if (!updateNotificationsRef.current) return;
       toast.error(`${info.message}. ${info.detail}`, {
         duration: 10000,
         action: {

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -319,6 +319,8 @@ export interface ElectronAPI {
   autoUpdateCheck: () => Promise<IpcResponse<void>>;
   autoUpdateDownload: () => Promise<IpcResponse<void>>;
   autoUpdateQuitAndInstall: () => Promise<IpcResponse<void>>;
+  autoUpdateGetEnabled: () => Promise<IpcResponse<boolean>>;
+  autoUpdateSetEnabled: (enabled: boolean) => Promise<IpcResponse<void>>;
   onAutoUpdateAvailable: (callback: (info: { version: string }) => void) => () => void;
   onAutoUpdateNotAvailable: (callback: () => void) => () => void;
   onAutoUpdateDownloadProgress: (


### PR DESCRIPTION
## Summary
- Adds two toggles under Settings → General → Updates: **Check for updates automatically** and **Show update notifications**
- Background update checks (10s after launch + every 4h) can now be turned off; the manual *Check for Updates* button still works
- Update toast popups (available / downloaded / error) can be silenced independently of background checks
- The auto-update preference is persisted to \`update-preferences.json\` in userData so the main process can read it synchronously at startup; defaults to enabled when the file is missing (back-compat for existing users). The notification preference lives in localStorage since it's a renderer-only gate.

## Test plan
- [ ] Open Settings → General → Updates and confirm both new toggles render with helper text
- [ ] Turn **Check for updates automatically** off, restart the app, and confirm no \`[AutoUpdate]\` log lines fire after 10 s; confirm *Check for Updates* button still triggers a check
- [ ] Turn **Show update notifications** off, trigger a manual check that finds an update, and confirm no toast appears while the Settings panel still shows the *Download v…* button
- [ ] Toggle each setting back on at runtime and confirm behavior re-engages without restarting
- [ ] Delete \`~/Library/Application Support/Dash/update-preferences.json\` and relaunch — auto-update defaults to enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)