### PR TITLE
Pin Windows CI runner to windows-2022 (VS2026 incompatibility)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,9 @@ jobs:
 
   build-windows:
     if: github.event_name != 'pull_request'
-    runs-on: windows-latest
+    # Pinned to windows-2022 because windows-latest/windows-2025 ships VS2026 (v18),
+    # which node-gyp can't detect — electron-rebuild fails on node-pty/better-sqlite3.
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",


### PR DESCRIPTION
## Summary
- \`windows-latest\` now resolves to \`windows-2025-vs2026\`, which ships Visual Studio 2026 (v18)
- node-gyp can't detect VS18 — \`electron-rebuild\` fails compiling \`node-pty\` and \`better-sqlite3\` (broke the build-windows job on main after #134 merged)
- Pin the Windows runner to \`windows-2022\` (VS2022 / v17) until node-gyp ships v18 support

## Test plan
- [ ] CI build-windows job goes green on this PR
- [ ] Resulting Windows build artifact still publishes successfully on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)