### PR TITLE
Fix Windows paste: correct layer, correct chunk size, correct clipboard API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -962,14 +962,74 @@ export function sendRemoteControl(id: string): void {
   setTimeout(() => writePty(id, '\r'), 100);
 }
 
+// ConPTY on Windows silently drops writes that overflow its input pipe before the
+// VT parser can drain it (node-pty ignores Socket.write()'s backpressure signal).
+// Fix: each PTY has a shared write buffer that drains at 1 KB / 20 ms. All writes
+// for the same PTY are serialized through the buffer so that concurrent pastes
+// (which carry bracketed-paste escape sequences) never interleave and corrupt each
+// other. Typed characters are written immediately when no drain is active.
+const WIN_CHUNK = 1024;
+const WIN_CHUNK_DELAY_MS = 20;
+const ptyWriteBuffers = new Map<string, string>();
+const ptyWriteTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function drainPtyWriteBuffer(id: string): void {
+  ptyWriteTimers.delete(id);
+  const buffer = ptyWriteBuffers.get(id);
+  if (!buffer) return;
+  const record = ptys.get(id);
+  if (!record) {
+    ptyWriteBuffers.delete(id);
+    return;
+  }
+  record.proc.write(buffer.slice(0, WIN_CHUNK));
+  const remaining = buffer.slice(WIN_CHUNK);
+  if (remaining.length > 0) {
+    ptyWriteBuffers.set(id, remaining);
+    ptyWriteTimers.set(
+      id,
+      setTimeout(() => drainPtyWriteBuffer(id), WIN_CHUNK_DELAY_MS),
+    );
+  } else {
+    ptyWriteBuffers.delete(id);
+  }
+}
+
+function clearPtyWriteBuffer(id: string): void {
+  const timer = ptyWriteTimers.get(id);
+  if (timer !== undefined) clearTimeout(timer);
+  ptyWriteTimers.delete(id);
+  ptyWriteBuffers.delete(id);
+}
+
 /**
  * Send data to a PTY.
  */
 export function writePty(id: string, data: string): void {
   const record = ptys.get(id);
-  if (record) {
+  if (!record) return;
+
+  if (process.platform !== 'win32') {
     record.proc.write(data);
+    return;
   }
+
+  const existing = ptyWriteBuffers.get(id);
+  if (existing !== undefined) {
+    // A chunked drain is already running — append so writes stay serialized.
+    ptyWriteBuffers.set(id, existing + data);
+    return;
+  }
+
+  if (data.length <= WIN_CHUNK) {
+    // No active drain and small enough to write directly.
+    record.proc.write(data);
+    return;
+  }
+
+  // Large write with no active drain — start one.
+  ptyWriteBuffers.set(id, data);
+  drainPtyWriteBuffer(id);
 }
 
 /**
@@ -994,6 +1054,7 @@ export function killPty(id: string): void {
   if (record) {
     // Delete first so the guarded onExit handler becomes a no-op
     ptys.delete(id);
+    clearPtyWriteBuffer(id);
     activityMonitor.unregister(id);
     remoteControlService.unregister(id);
     contextUsageService.unregister(id);

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -140,21 +140,24 @@ export class TerminalSessionManager {
     this.terminal.attachCustomKeyEventHandler((e) => {
       if (e.type !== 'keydown') return true;
 
-      const isMac = navigator.userAgent.includes('Mac');
+      const platform = window.electronAPI.getPlatform();
+      const isMac = platform === 'darwin';
+      const isWin = platform === 'win32';
 
       // Match by physical key (e.code) so alternate keyboard layouts where
       // Ctrl+Shift+C reports e.key as something other than 'C' still work.
       const isKeyC = e.code === 'KeyC';
       const isKeyV = e.code === 'KeyV';
 
-      // Copy: Cmd+C (macOS) or Ctrl+Shift+C (Linux) — copy terminal selection.
+      // Copy: Cmd+C (macOS), Ctrl+Shift+C (Linux), Ctrl+C (Windows).
       // Also Ctrl+C on any platform when there's an active selection (matches
       // native terminal behaviour: Ctrl+C copies when selected, sends SIGINT
       // otherwise). Explicit shortcuts fall back to lastSelection so users can
       // still copy after the TUI has cleared xterm's highlight.
       const isExplicitCopy =
         (isMac && e.metaKey && isKeyC && !e.ctrlKey) ||
-        (!isMac && e.ctrlKey && e.shiftKey && isKeyC);
+        (isWin && e.ctrlKey && !e.shiftKey && isKeyC && this.terminal.hasSelection()) ||
+        (!isMac && !isWin && e.ctrlKey && e.shiftKey && isKeyC);
       const isPlainCtrlC = e.ctrlKey && !e.shiftKey && isKeyC && this.terminal.hasSelection();
       if (isExplicitCopy || isPlainCtrlC) {
         const sel = this.terminal.getSelection() || (isExplicitCopy ? this.lastSelection : '');
@@ -165,14 +168,15 @@ export class TerminalSessionManager {
         }
       }
 
-      // Paste: Cmd+V (macOS) or Ctrl+Shift+V (Linux)
+      // Paste: Cmd+V (macOS), Ctrl+V (Windows), Ctrl+Shift+V (Linux)
       if (
         (isMac && e.metaKey && isKeyV && !e.ctrlKey) ||
-        (!isMac && e.ctrlKey && e.shiftKey && isKeyV)
+        (isWin && e.ctrlKey && isKeyV) ||
+        (!isMac && !isWin && e.ctrlKey && e.shiftKey && isKeyV)
       ) {
         e.preventDefault();
         window.electronAPI.clipboardReadText().then((text) => {
-          if (text) window.electronAPI.ptyInput({ id: this.id, data: text });
+          if (text) this.writePasteData(text);
         });
         return false;
       }
@@ -523,6 +527,10 @@ export class TerminalSessionManager {
       clearTimeout(this.fitDebounceTimer);
       this.fitDebounceTimer = null;
     }
+    if (this.pasteTimer) {
+      clearTimeout(this.pasteTimer);
+      this.pasteTimer = null;
+    }
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
       this.resizeObserver = null;
@@ -549,6 +557,34 @@ export class TerminalSessionManager {
 
   writeInput(data: string) {
     window.electronAPI.ptyInput({ id: this.id, data });
+  }
+
+  private pasteTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Write pasted text in chunks to avoid overflowing the PTY input buffer
+  // (conpty on Windows drops data beyond ~4 KB written in a single call).
+  private writePasteData(text: string) {
+    if (this.pasteTimer) {
+      clearTimeout(this.pasteTimer);
+      this.pasteTimer = null;
+    }
+    const CHUNK = 4096;
+    if (text.length <= CHUNK) {
+      window.electronAPI.ptyInput({ id: this.id, data: text });
+      return;
+    }
+    let offset = 0;
+    const writeNext = () => {
+      if (offset >= text.length || this.disposed) {
+        this.pasteTimer = null;
+        return;
+      }
+      const end = Math.min(offset + CHUNK, text.length);
+      window.electronAPI.ptyInput({ id: this.id, data: text.slice(offset, end) });
+      offset = end;
+      this.pasteTimer = setTimeout(writeNext, 12);
+    };
+    writeNext();
   }
 
   focus() {

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -37,6 +37,7 @@ export class TerminalSessionManager {
   private _currentCwd: string;
   private onCwdChangeCallback: ((cwd: string) => void) | null = null;
   private fitDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private isPasting = false;
   private lastPtyCols = 0;
   private lastPtyRows = 0;
   private savedViewportY: number | null = null;
@@ -171,18 +172,39 @@ export class TerminalSessionManager {
       }
 
       // Paste: Cmd+V (macOS), Ctrl+V (Windows), Ctrl+Shift+V (Linux)
+      // We read via Electron's native clipboard API rather than relying on the
+      // paste DOM event's e.clipboardData, which Chromium on Windows returns
+      // empty when the clipboard content hasn't changed between pastes (same
+      // sequence number). Bracketed paste mode is applied manually so Claude Code
+      // still sees the \x1b[200~...\x1b[201~ markers it uses for the paste indicator.
       if (
         (isMac && e.metaKey && isKeyV && !e.ctrlKey) ||
         (isWin && e.ctrlKey && isKeyV) ||
         (!isMac && !isWin && e.ctrlKey && e.shiftKey && isKeyV)
       ) {
         e.preventDefault();
+        this.isPasting = true;
         window.electronAPI
           .clipboardReadText()
           .then((text) => {
-            if (text) this.writePasteData(text);
+            if (!text) {
+              this.isPasting = false;
+              return;
+            }
+            // Strip \r from paste content: ConPTY on Windows handles \r inside
+            // bracketed-paste blocks inconsistently (see github.com/remcovolmer/
+            // command/pull/118). Keep \n as the line separator inside BPM brackets.
+            const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '');
+            window.electronAPI.ptyInput({
+              id: this.id,
+              data: `\x1b[200~${normalized}\x1b[201~`,
+            });
+            setTimeout(() => {
+              this.isPasting = false;
+            }, 0);
           })
           .catch((err) => {
+            this.isPasting = false;
             console.warn('[terminal] clipboardReadText failed:', err);
           });
         return false;
@@ -220,8 +242,10 @@ export class TerminalSessionManager {
       return true;
     });
 
-    // Send input to PTY
+    // Send input to PTY. Guard against the native paste DOM event also reaching
+    // xterm.js while our clipboardReadText path is already handling the same paste.
     this.terminal.onData((data) => {
+      if (this.isPasting) return;
       window.electronAPI.ptyInput({ id: this.id, data });
     });
   }
@@ -534,10 +558,6 @@ export class TerminalSessionManager {
       clearTimeout(this.fitDebounceTimer);
       this.fitDebounceTimer = null;
     }
-    if (this.pasteTimer) {
-      clearTimeout(this.pasteTimer);
-      this.pasteTimer = null;
-    }
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
       this.resizeObserver = null;
@@ -564,35 +584,6 @@ export class TerminalSessionManager {
 
   writeInput(data: string) {
     window.electronAPI.ptyInput({ id: this.id, data });
-  }
-
-  private pasteTimer: ReturnType<typeof setTimeout> | null = null;
-
-  // Write pasted text in chunks to avoid overflowing the PTY input buffer
-  // (conpty on Windows drops data beyond ~4 KB written in a single call).
-  private writePasteData(text: string) {
-    if (this.disposed) return;
-    if (this.pasteTimer) {
-      clearTimeout(this.pasteTimer);
-      this.pasteTimer = null;
-    }
-    const CHUNK = 4096;
-    if (text.length <= CHUNK) {
-      window.electronAPI.ptyInput({ id: this.id, data: text });
-      return;
-    }
-    let offset = 0;
-    const writeNext = () => {
-      if (offset >= text.length || this.disposed) {
-        this.pasteTimer = null;
-        return;
-      }
-      const end = Math.min(offset + CHUNK, text.length);
-      window.electronAPI.ptyInput({ id: this.id, data: text.slice(offset, end) });
-      offset = end;
-      this.pasteTimer = setTimeout(writeNext, 12);
-    };
-    writeNext();
   }
 
   focus() {

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -149,11 +149,13 @@ export class TerminalSessionManager {
       const isKeyC = e.code === 'KeyC';
       const isKeyV = e.code === 'KeyV';
 
-      // Copy: Cmd+C (macOS), Ctrl+Shift+C (Linux), Ctrl+C (Windows).
+      // Copy: Cmd+C (macOS), Ctrl+Shift+C (Linux), Ctrl+C (Windows, only when text is selected).
       // Also Ctrl+C on any platform when there's an active selection (matches
       // native terminal behaviour: Ctrl+C copies when selected, sends SIGINT
-      // otherwise). Explicit shortcuts fall back to lastSelection so users can
-      // still copy after the TUI has cleared xterm's highlight.
+      // otherwise). macOS and Linux explicit shortcuts fall back to lastSelection
+      // so users can still copy after the TUI has cleared xterm's highlight.
+      // Windows does not use lastSelection — Ctrl+C without a live selection
+      // should always send SIGINT.
       const isExplicitCopy =
         (isMac && e.metaKey && isKeyC && !e.ctrlKey) ||
         (isWin && e.ctrlKey && !e.shiftKey && isKeyC && this.terminal.hasSelection()) ||
@@ -175,9 +177,14 @@ export class TerminalSessionManager {
         (!isMac && !isWin && e.ctrlKey && e.shiftKey && isKeyV)
       ) {
         e.preventDefault();
-        window.electronAPI.clipboardReadText().then((text) => {
-          if (text) this.writePasteData(text);
-        });
+        window.electronAPI
+          .clipboardReadText()
+          .then((text) => {
+            if (text) this.writePasteData(text);
+          })
+          .catch((err) => {
+            console.warn('[terminal] clipboardReadText failed:', err);
+          });
         return false;
       }
 
@@ -564,6 +571,7 @@ export class TerminalSessionManager {
   // Write pasted text in chunks to avoid overflowing the PTY input buffer
   // (conpty on Windows drops data beyond ~4 KB written in a single call).
   private writePasteData(text: string) {
+    if (this.disposed) return;
     if (this.pasteTimer) {
       clearTimeout(this.pasteTimer);
       this.pasteTimer = null;


### PR DESCRIPTION
## Summary

- Fix Windows paste truncation for content larger than ~2 KB
- Fix identical consecutive pastes sending empty string on Windows
- Fix double-send from competing paste paths (keydown + paste DOM event)
- Strip `\r` inside bracketed-paste blocks for ConPTY reliability

Closes #133. Supersedes mahope's initial fix with a deeper root-cause analysis and correct fix at the right layer.

---

## Background

PR #133 added Windows Ctrl+V support and chunked large pastes at the renderer layer. After review, hands-on testing confirmed large pastes (>~2 KB) still truncated. The initial chunk size (4 096 bytes) exceeded ConPTY's real buffer limit and the chunking was at the wrong layer (renderer IPC instead of main process). Extended diagnostic testing found three separate root causes.

---

## Root Cause Analysis

### Root Cause 1 — ConPTY backpressure silently dropped by node-pty

`node-pty` v1.1.0 `windowsTerminal.ts` ignores the `boolean` return value of `Socket.write()`. When ConPTY's named-pipe input buffer fills (around 2 KB of fast writes), Node.js signals backpressure via a `false` return — but node-pty discards that signal. Bytes beyond the buffer limit are silently dropped with no error.

**Fix:** `writePty()` in `src/main/services/ptyManager.ts` now chunks all Windows writes at 1 024 bytes / 20 ms. A `ptyWriteBuffers` Map serializes all writes per PTY so concurrent chunks never interleave. Writes under 1 KB bypass the buffer entirely for zero-latency typing.

**Why main process, not renderer?** The renderer has no business knowing ConPTY buffer limits. `writePty()` is the single point that calls `record.proc.write()` — it is the correct and only correct place to apply this throttle.

### Root Cause 2 — Chromium clipboard sequence number blocks identical pastes

Chromium on Windows returns an empty string from `e.clipboardData.getData('text')` when the clipboard content hasn't changed since the last read (same OS sequence number). Two consecutive pastes of identical content: first works, second sends empty string.

**Fix:** Use `window.electronAPI.clipboardReadText()` (Electron's native `clipboard.readText()` via IPC) which always returns the current clipboard content regardless of sequence number.

### Root Cause 3 — Double-send from competing paste paths

xterm.js fires both a `keydown` event (intercepted by our handler) and a `paste` DOM event for the same Ctrl+V keypress. Without coordination, both paths forwarded data to the PTY — doubling input or corrupting the bracketed-paste sequence.

**Fix:** `isPasting` flag set synchronously before the async IPC call blocks the `onData` handler from forwarding the `paste` DOM event's data. Cleared via `setTimeout(0)` after `ptyInput` is dispatched.

### Bonus — `\r` inside bracketed-paste blocks on Windows

ConPTY handles `\r` bytes inside bracketed-paste markers inconsistently (per remcovolmer/command PR #118). Sending `\n` as the line separator inside BPM is more reliable.

**Fix:** `text.replace(/\r\n/g, '\n').replace(/\r/g, '')` before BPM-wrapping.

---

## Diagnostic Note — Alternating [Pasted text #N] indicator

During testing we observed that every second paste of identical content showed raw text instead of the `[Pasted text #N]` collapsed indicator. This is **not a bug**. Claude Code has an intentional "paste again to expand" UX feature — identical consecutive pastes expand the collapsed indicator inline. PTY response capture confirmed paste #1's response contained the hint `"paste again to expand"` and paste #2's response showed character-by-character inline rendering. Content was delivered correctly on all pastes.

---

## Solution B — Why not upgrade node-pty or switch packages?

Before committing to Solution A, we evaluated whether a library upgrade or replacement could eliminate the need for the application-level workaround.

### node-pty maintenance — healthy, but Windows write path unaddressed

- Last commit: May 7, 2026. Latest stable: v1.1.0 (Dec 22, 2025). Active beta track.
- Microsoft/VSCode team actively maintains the repo.
- **node-pty PR #831** (merged Dec 13, 2025) — *macOS/Unix ONLY*. It fixes POSIX `EAGAIN` on non-blocking file descriptors by switching to raw `fs.write(fd)` with retry. Windows uses a named pipe, not a file descriptor; the fix does not apply. `windowsTerminal.ts` is unchanged from before PR #831.
- The Windows write-drop problem has **no tracking issue in node-pty**. No PR is planned. The maintainer's focus has been entirely on Unix/macOS write performance.
- Upgrading node-pty does not fix Windows today.

### Alternative packages — nothing viable on Windows

| Package | Verdict |
|---------|---------|
| `@replit/ruspty` | Linux-only — `#[cfg(target_os = "linux")]` throughout source; no Windows CI |
| WinPTY (node-pty fallback) | Fully removed; `useConpty` option deprecated and ignored |
| `node-rust-pty` | v0.0.0, 1 star; README: "Windows support lacks full ConPTY integration" |
| `xterm-pty`, `pty.js`, forks | Browser-only, abandoned, or identical underlying code |

ConPTY is the only Windows PTY API accessible from Node.js/Electron. There is no viable drop-in replacement for node-pty on Windows today.

**Conclusion:** Solution A (application-level chunking) is the correct and only viable fix. When node-pty ships a Windows backpressure fix in a future release, the `writePty()` chunking block can be removed and the write path simplified back to a direct `record.proc.write(data)`.

---

## Files Changed

- `src/main/services/ptyManager.ts` — `writePty()` chunking + `ptyWriteBuffers` + drain/clear helpers
- `src/renderer/terminal/TerminalSessionManager.ts` — `clipboardReadText()`, `isPasting` guard, manual BPM wrapping, `\r` normalization; remove renderer-side `writePasteData()`

## Test Plan

- [ ] Paste content > 2 KB on Windows — no truncation
- [ ] Paste the same content twice consecutively — both pastes arrive in full
- [ ] Type normally between pastes — zero latency, no dropped keystrokes
- [ ] Paste on macOS/Linux — behavior unchanged (Windows-only path in `writePty()`)
- [ ] Close/kill a PTY mid-paste — no orphaned timers (verified via `clearPtyWriteBuffer` in `killPty`)