### PR TITLE
Fix empty diff view for conflicted files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1565,7 +1565,10 @@ export function App() {
       const file = gitStatus?.files.find((f) => f.path === filePath && !f.staged);
       let resp;
       const ctx = diffContextLines ?? undefined;
-      if (file?.status === 'untracked') {
+      if (file?.status === 'untracked' || file?.status === 'conflicted') {
+        // For conflicted files, `git diff` produces a combined-diff format that
+        // our parser doesn't understand. Show the working-tree file (with the
+        // conflict markers) as additions, the same way we render untracked files.
         resp = await window.electronAPI.gitGetDiffUntracked({
           cwd: activeTask.path,
           filePath,


### PR DESCRIPTION
## Summary
- Clicking a conflicted file in the changes panel rendered an empty diff.
- Root cause: `git diff -- <file>` on an unmerged path emits a *combined-diff* header (`@@@ -X,Y -A,B +N,M @@@`) that `GitService.parseDiff` doesn't recognize, so zero hunks are parsed.
- Fix: route conflicted files through the same path as untracked files (`getDiffUntracked` → `git diff --no-index /dev/null <file>`). This produces a standard `@@` hunk and shows the working-tree contents — conflict markers included — which is what's actually useful to see.

## Test plan
- [ ] Create a merge conflict in a task worktree (`git merge` a divergent branch).
- [ ] Open the changes panel, confirm the file appears with the `!` conflicted badge.
- [ ] Click the file → diff viewer shows the full file contents with `<<<<<<<`, `=======`, `>>>>>>>` markers rendered as additions.
- [ ] Untracked and normal modified files continue to render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)