### PR TITLE
Bump version to 0.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",


### PR DESCRIPTION
Bumps version from 0.11.2 to 0.11.3. The v0.11.2 tag is already released, so the release guard required a version bump before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)