### PR TITLE
Add setting to toggle git branch in shell prompt

### DIFF
--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -338,6 +338,15 @@ export function registerAppIpc(): void {
     }
   });
 
+  ipcMain.on('app:setShowShellBranch', async (_event, enabled: boolean) => {
+    try {
+      const { setShowShellBranch } = await import('../services/ptyManager');
+      setShowShellBranch(enabled);
+    } catch (err) {
+      console.error('[app:setShowShellBranch] Failed:', err);
+    }
+  });
+
   ipcMain.handle('app:detectClaude', async () => {
     try {
       // Import cached result from main

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -156,6 +156,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setClaudeEnvVars: (vars: Record<string, string>) =>
     ipcRenderer.send('app:setClaudeEnvVars', vars),
   setSyncShellEnv: (enabled: boolean) => ipcRenderer.send('app:setSyncShellEnv', enabled),
+  setShowShellBranch: (enabled: boolean) => ipcRenderer.send('app:setShowShellBranch', enabled),
   getClaudeAttribution: (projectPath?: string) =>
     ipcRenderer.invoke('app:getClaudeAttribution', projectPath),
 

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -73,6 +73,9 @@ let claudeEnvVars: Record<string, string> = {};
 // When true, inherit the full parent process.env as a base instead of the minimal set.
 let syncShellEnv = false;
 
+// When true, show git branch name in the shell prompt (default: true).
+let showShellBranch = true;
+
 const RESERVED_ENV_KEYS = new Set([
   'PATH',
   'HOME',
@@ -129,6 +132,10 @@ export function setClaudeEnvVars(vars: Record<string, string>): void {
 
 export function setSyncShellEnv(enabled: boolean): void {
   syncShellEnv = enabled;
+}
+
+export function setShowShellBranch(enabled: boolean): void {
+  showShellBranch = enabled;
 }
 
 // Lazy-load node-pty to avoid native binding issues at startup
@@ -818,7 +825,7 @@ __dash_prompt_precmd() {
 
   local dir="%F{12}%~%f"
   local branch=""
-  if [[ -n "\${vcs_info_msg_0_}" ]]; then
+  if [[ "\${DASH_PROMPT_SHOW_BRANCH:-1}" == "1" && -n "\${vcs_info_msg_0_}" ]]; then
     local dirty=""
     # Fast dirty check: staged + unstaged + untracked
     if ! git diff --quiet HEAD -- 2>/dev/null || [[ -n "$(git ls-files --others --exclude-standard 2>/dev/null | head -1)" ]]; then
@@ -911,6 +918,7 @@ export async function startPty(options: {
     // Inject custom prompt for zsh via ZDOTDIR
     if (shell.endsWith('/zsh') || shell === 'zsh') {
       env.ZDOTDIR = ensureShellConfig();
+      env.DASH_PROMPT_SHOW_BRANCH = showShellBranch ? '1' : '0';
     }
   }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -175,6 +175,10 @@ export function App() {
   const [syncShellEnv, setSyncShellEnv] = useState(() => {
     return localStorage.getItem('syncShellEnv') === 'true';
   });
+  const [showShellBranch, setShowShellBranch] = useState(() => {
+    const stored = localStorage.getItem('showShellBranch');
+    return stored === null ? true : stored === 'true';
+  });
   const [customClaudeEnvVars, setCustomClaudeEnvVars] = useState<Record<string, string>>(() => {
     try {
       return JSON.parse(localStorage.getItem('customClaudeEnvVars') || '{}');
@@ -279,6 +283,10 @@ export function App() {
   useEffect(() => {
     window.electronAPI.setSyncShellEnv?.(syncShellEnv);
   }, [syncShellEnv]);
+  // Sync shell branch visibility to main process
+  useEffect(() => {
+    window.electronAPI.setShowShellBranch?.(showShellBranch);
+  }, [showShellBranch]);
   // Sync Claude Code env vars to main process
   useEffect(() => {
     const vars: Record<string, string> = { ...customClaudeEnvVars };
@@ -1964,6 +1972,11 @@ export function App() {
           onShellDrawerEnabledChange={(v) => {
             setShellDrawerEnabled(v);
             localStorage.setItem('shellDrawerEnabled', String(v));
+          }}
+          showShellBranch={showShellBranch}
+          onShowShellBranchChange={(v) => {
+            setShowShellBranch(v);
+            localStorage.setItem('showShellBranch', String(v));
           }}
           shellDrawerPosition={shellDrawerPosition}
           onShellDrawerPositionChange={(v) => {

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -72,6 +72,8 @@ interface SettingsModalProps {
   onShowActiveTasksSectionChange: (value: boolean) => void;
   shellDrawerEnabled: boolean;
   onShellDrawerEnabledChange: (value: boolean) => void;
+  showShellBranch: boolean;
+  onShowShellBranchChange: (value: boolean) => void;
   shellDrawerPosition: 'left' | 'main' | 'right';
   onShellDrawerPositionChange: (value: 'left' | 'main' | 'right') => void;
   terminalTheme: string;
@@ -1319,6 +1321,18 @@ export function SettingsModal({
                 <p className="text-[10px] text-foreground/80 mt-2">
                   Toggle with Cmd+J. Run git, npm, and other commands alongside Claude.
                 </p>
+                {shellDrawerEnabled && (
+                  <div className="mt-3">
+                    <ToggleSwitch
+                      enabled={showShellBranch}
+                      onToggle={onShowShellBranchChange}
+                      label="Show git branch in prompt"
+                    />
+                    <p className="text-[10px] text-foreground/80 mt-1">
+                      Applies to new terminal sessions.
+                    </p>
+                  </div>
+                )}
               </div>
 
               {/* Preferred IDE */}

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -180,6 +180,7 @@ export interface ElectronAPI {
   setCommitAttribution: (value: string | undefined) => void;
   setClaudeEnvVars: (vars: Record<string, string>) => void;
   setSyncShellEnv: (enabled: boolean) => void;
+  setShowShellBranch: (enabled: boolean) => void;
   getClaudeAttribution: (projectPath?: string) => Promise<IpcResponse<string | null>>;
 
   // GitHub


### PR DESCRIPTION
Needs to be tested before I am ready for a review.

## Summary

- Adds a toggle under Settings > Shell Terminal to show/hide the git branch in the terminal prompt
- Useful when working in worktrees where the branch name already appears in the directory path
- Default: on (preserves current behavior)
- Applies to new terminal sessions

## Test plan

- [ ] Open Settings > General > Shell Terminal
- [ ] Toggle "Show git branch in prompt" off
- [ ] Open a new shell terminal — branch name should not appear in prompt
- [ ] Toggle back on, open new terminal — branch should reappear
- [ ] Verify toggle only shows when shell drawer is enabled