### PR TITLE
Add carbon/energy tracking for Claude Code sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.11.3",
+  "version": "0.11.5",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/main/ipc/carbonIpc.ts
+++ b/src/main/ipc/carbonIpc.ts
@@ -1,0 +1,17 @@
+import { ipcMain } from 'electron';
+import { computeCarbonStats } from '../services/CarbonService';
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function registerCarbonIpc(): void {
+  ipcMain.handle('carbon:getStats', async (_event, paths?: string[]) => {
+    try {
+      return { success: true, data: computeCarbonStats(paths) };
+    } catch (err) {
+      console.error('[carbonIpc.getStats]', err);
+      return { success: false, error: errorMessage(err) };
+    }
+  });
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -10,6 +10,7 @@ import { registerRtkIpc } from './rtkIpc';
 import { registerTelemetryIpc } from './telemetryIpc';
 import { registerSkillsIpc } from './skillsIpc';
 import { registerSessionIpc } from './sessionIpc';
+import { registerCarbonIpc } from './carbonIpc';
 
 export function registerAllIpc(): void {
   registerAppIpc();
@@ -24,4 +25,5 @@ export function registerAllIpc(): void {
   registerTelemetryIpc();
   registerSkillsIpc();
   registerSessionIpc();
+  registerCarbonIpc();
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -291,6 +291,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     };
   },
 
+  // Carbon / energy stats
+  getCarbonStats: (paths?: string[]) => ipcRenderer.invoke('carbon:getStats', paths),
+
   // Telemetry
   telemetryCapture: (event: string, properties?: Record<string, unknown>) =>
     ipcRenderer.invoke('telemetry:capture', { event, properties }),

--- a/src/main/services/CarbonService.ts
+++ b/src/main/services/CarbonService.ts
@@ -1,14 +1,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
 import type { CarbonStats, CarbonProjectStat } from '@shared/types';
-import { computeEnergyFromMessages, sumEnergyStats, type EnergyStats } from '@shared/carbon';
-import type { ParsedSessionMessage } from '@shared/sessionTypes';
-import { parseJsonlLine, deduplicateByRequestId, encodeProjectPath } from '../utils/jsonlParser';
-
-function getProjectsDir(): string {
-  return path.join(os.homedir(), '.claude', 'projects');
-}
+import {
+  computeEnergyFromMessages,
+  sumEnergyStats,
+  emptyTokensByModel,
+  type EnergyStats,
+} from '@shared/carbon';
+import { encodeProjectPath, getProjectsDir, parseSessionFile } from '../utils/jsonlParser';
 
 /** Best-effort readable label for a Claude Code encoded project folder name. */
 function decodeProjectName(folder: string): string {
@@ -20,18 +19,9 @@ function decodeProjectName(folder: string): string {
 }
 
 function energyStatsForFile(filePath: string): EnergyStats | null {
-  let data: string;
-  try {
-    data = fs.readFileSync(filePath, 'utf8');
-  } catch {
-    return null;
-  }
-  const messages: ParsedSessionMessage[] = [];
-  for (const line of data.split('\n')) {
-    const parsed = parseJsonlLine(line);
-    if (parsed) messages.push(parsed);
-  }
-  return computeEnergyFromMessages(deduplicateByRequestId(messages));
+  const parsed = parseSessionFile(filePath);
+  if (!parsed) return null;
+  return computeEnergyFromMessages(parsed.messages);
 }
 
 /**
@@ -48,21 +38,37 @@ export function computeCarbonStats(paths?: string[]): CarbonStats {
   const empty: CarbonStats = {
     tokens: 0,
     energyWh: 0,
-    tokensByModel: { opus: 0, sonnet: 0, haiku: 0 },
+    tokensByModel: emptyTokensByModel(),
     projects: [],
     sessionCount: 0,
   };
 
   // Encode the requested paths to the folder names Claude Code uses. An empty
   // (but defined) list means "no folders match" → return empty rather than all.
-  const allowedFolders =
-    paths !== undefined ? new Set(paths.filter(Boolean).map(encodeProjectPath)) : null;
-  if (allowedFolders && allowedFolders.size === 0) return empty;
+  // Keep each folder's real basename as its display label (the encoded folder
+  // name can't be decoded back to a path); fall back to decodeProjectName when
+  // unscoped (lifetime total, no originating paths available).
+  const allowedFolders = paths !== undefined ? new Set<string>() : null;
+  const folderLabels = new Map<string, string>();
+  if (paths !== undefined) {
+    for (const p of paths.filter(Boolean)) {
+      const folder = encodeProjectPath(p);
+      allowedFolders!.add(folder);
+      folderLabels.set(folder, path.basename(p));
+    }
+    if (allowedFolders!.size === 0) return empty;
+  }
 
   let projectFolders: string[];
   try {
     projectFolders = fs.readdirSync(projectsDir);
-  } catch {
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      console.warn('[CarbonService.computeCarbonStats] readdir projectsDir failed', {
+        projectsDir,
+        err,
+      });
+    }
     return empty;
   }
   if (allowedFolders) projectFolders = projectFolders.filter((f) => allowedFolders.has(f));
@@ -77,7 +83,15 @@ export function computeCarbonStats(paths?: string[]): CarbonStats {
     try {
       if (!fs.statSync(folderPath).isDirectory()) continue;
       entries = fs.readdirSync(folderPath);
-    } catch {
+    } catch (err) {
+      // ENOENT = folder removed mid-scan (benign race); anything else is a real
+      // read problem that would silently drop this project's contribution.
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+        console.warn('[CarbonService.computeCarbonStats] read project folder failed', {
+          folderPath,
+          err,
+        });
+      }
       continue;
     }
 
@@ -94,7 +108,7 @@ export function computeCarbonStats(paths?: string[]): CarbonStats {
     if (projectTotal.tokens === 0) continue;
     perProjectStats.push(projectTotal);
     projectStats.push({
-      project: decodeProjectName(folder),
+      project: folderLabels.get(folder) ?? decodeProjectName(folder),
       tokens: projectTotal.tokens,
       energyWh: projectTotal.energyWh,
     });

--- a/src/main/services/CarbonService.ts
+++ b/src/main/services/CarbonService.ts
@@ -1,0 +1,113 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import type { CarbonStats, CarbonProjectStat } from '@shared/types';
+import { computeEnergyFromMessages, sumEnergyStats, type EnergyStats } from '@shared/carbon';
+import type { ParsedSessionMessage } from '@shared/sessionTypes';
+import { parseJsonlLine, deduplicateByRequestId, encodeProjectPath } from '../utils/jsonlParser';
+
+function getProjectsDir(): string {
+  return path.join(os.homedir(), '.claude', 'projects');
+}
+
+/** Best-effort readable label for a Claude Code encoded project folder name. */
+function decodeProjectName(folder: string): string {
+  // Encoding is lossy ('/' → '-'), so this can't be perfect; show the trailing
+  // segment, which is usually the recognizable project/worktree name.
+  const trimmed = folder.replace(/^-+/, '');
+  const segments = trimmed.split('-').filter(Boolean);
+  return segments.length > 0 ? segments[segments.length - 1] : folder;
+}
+
+function energyStatsForFile(filePath: string): EnergyStats | null {
+  let data: string;
+  try {
+    data = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+  const messages: ParsedSessionMessage[] = [];
+  for (const line of data.split('\n')) {
+    const parsed = parseJsonlLine(line);
+    if (parsed) messages.push(parsed);
+  }
+  return computeEnergyFromMessages(deduplicateByRequestId(messages));
+}
+
+/**
+ * Scan Claude Code session files under ~/.claude/projects and aggregate estimated
+ * energy use, broken down by model family and by session folder. Synchronous fs is
+ * fine here — this runs on demand from an IPC handler, not in a hot path.
+ *
+ * @param paths When provided, restricts the scan to the Claude Code project folders
+ *   for these absolute paths (a Dash project's repo path + each task's worktree
+ *   path). Omit to scan everything (lifetime total across all projects).
+ */
+export function computeCarbonStats(paths?: string[]): CarbonStats {
+  const projectsDir = getProjectsDir();
+  const empty: CarbonStats = {
+    tokens: 0,
+    energyWh: 0,
+    tokensByModel: { opus: 0, sonnet: 0, haiku: 0 },
+    projects: [],
+    sessionCount: 0,
+  };
+
+  // Encode the requested paths to the folder names Claude Code uses. An empty
+  // (but defined) list means "no folders match" → return empty rather than all.
+  const allowedFolders =
+    paths !== undefined ? new Set(paths.filter(Boolean).map(encodeProjectPath)) : null;
+  if (allowedFolders && allowedFolders.size === 0) return empty;
+
+  let projectFolders: string[];
+  try {
+    projectFolders = fs.readdirSync(projectsDir);
+  } catch {
+    return empty;
+  }
+  if (allowedFolders) projectFolders = projectFolders.filter((f) => allowedFolders.has(f));
+
+  const perProjectStats: EnergyStats[] = [];
+  const projectStats: CarbonProjectStat[] = [];
+  let sessionCount = 0;
+
+  for (const folder of projectFolders) {
+    const folderPath = path.join(projectsDir, folder);
+    let entries: string[];
+    try {
+      if (!fs.statSync(folderPath).isDirectory()) continue;
+      entries = fs.readdirSync(folderPath);
+    } catch {
+      continue;
+    }
+
+    const fileStats: EnergyStats[] = [];
+    for (const entry of entries) {
+      if (!entry.endsWith('.jsonl')) continue;
+      const stats = energyStatsForFile(path.join(folderPath, entry));
+      if (!stats) continue;
+      sessionCount++;
+      fileStats.push(stats);
+    }
+
+    const projectTotal = sumEnergyStats(fileStats);
+    if (projectTotal.tokens === 0) continue;
+    perProjectStats.push(projectTotal);
+    projectStats.push({
+      project: decodeProjectName(folder),
+      tokens: projectTotal.tokens,
+      energyWh: projectTotal.energyWh,
+    });
+  }
+
+  projectStats.sort((a, b) => b.energyWh - a.energyWh);
+
+  const total = sumEnergyStats(perProjectStats);
+  return {
+    tokens: total.tokens,
+    energyWh: total.energyWh,
+    tokensByModel: total.tokensByModel,
+    projects: projectStats,
+    sessionCount,
+  };
+}

--- a/src/main/services/SessionWatcherService.ts
+++ b/src/main/services/SessionWatcherService.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
 import { BrowserWindow } from 'electron';
 import type {
   ParsedSessionMessage,
@@ -9,9 +8,10 @@ import type {
 } from '../../shared/sessionTypes';
 import {
   parseJsonlLine,
-  deduplicateByRequestId,
   calculateMetrics,
   encodeProjectPath,
+  getProjectsDir,
+  parseSessionFile,
 } from '../utils/jsonlParser';
 
 const DEBOUNCE_MS = 300;
@@ -29,10 +29,6 @@ interface WatchEntry {
 }
 
 const watchers = new Map<string, WatchEntry>();
-
-function getProjectsDir(): string {
-  return path.join(os.homedir(), '.claude', 'projects');
-}
 
 /**
  * Resolve Claude's project dir for a cwd by exact path encoding only.
@@ -77,24 +73,7 @@ function findLatestSessionFile(projectDir: string): string | null {
 }
 
 function parseFullFile(filePath: string): { messages: ParsedSessionMessage[]; bytesRead: number } {
-  let data: string;
-  try {
-    data = fs.readFileSync(filePath, 'utf8');
-  } catch (err) {
-    console.warn('[SessionWatcher.parseFullFile] readFile failed', { filePath, err });
-    return { messages: [], bytesRead: 0 };
-  }
-
-  const messages: ParsedSessionMessage[] = [];
-  for (const line of data.split('\n')) {
-    const parsed = parseJsonlLine(line);
-    if (parsed) messages.push(parsed);
-  }
-
-  return {
-    messages: deduplicateByRequestId(messages),
-    bytesRead: Buffer.byteLength(data, 'utf8'),
-  };
+  return parseSessionFile(filePath) ?? { messages: [], bytesRead: 0 };
 }
 
 function parseIncrementalBytes(entry: WatchEntry): ParsedSessionMessage[] {

--- a/src/main/services/__tests__/CarbonService.test.ts
+++ b/src/main/services/__tests__/CarbonService.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+
+// jsonlParser.getProjectsDir() resolves ~/.claude/projects via os.homedir(); point
+// it at a throwaway temp dir so the scan reads our fixtures instead of the real home.
+const mocked = vi.hoisted(() => ({ home: '' }));
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: () => mocked.home };
+});
+
+import { computeCarbonStats } from '../CarbonService';
+import { encodeProjectPath } from '../../utils/jsonlParser';
+
+// Exercises computeCarbonStats's load-bearing branches:
+//   - a defined-but-empty path list means "nothing matches" (NOT "scan everything")
+//   - scoping restricts the scan to the encoded folders for the given paths
+//   - the per-project label is the path basename, not the lossy decoded folder
+//   - projects are sorted by descending energy, and zero-token folders are dropped
+//   - an unreadable/garbage session file is skipped without aborting the scan
+
+const PROJ_A = '/tmp/dash-test/projectA';
+const PROJ_B = '/tmp/dash-test/projectB';
+const PROJ_EMPTY = '/tmp/dash-test/projectEmpty';
+
+/** A single assistant session line as Claude Code writes it. */
+function sessionLine(uuid: string, model: string, inputTokens: number): string {
+  return JSON.stringify({
+    uuid,
+    type: 'assistant',
+    requestId: uuid,
+    message: { role: 'assistant', model, usage: { input_tokens: inputTokens, output_tokens: 0 } },
+  });
+}
+
+function writeSession(projectPath: string, file: string, lines: string[]): void {
+  const folder = path.join(mocked.home, '.claude', 'projects', encodeProjectPath(projectPath));
+  mkdirSync(folder, { recursive: true });
+  writeFileSync(path.join(folder, file), lines.join('\n'));
+}
+
+beforeEach(() => {
+  mocked.home = mkdtempSync(path.join(os.tmpdir(), 'dash-carbon-'));
+
+  // projectA: opus-heavy → more energy than sonnet projectB.
+  writeSession(PROJ_A, 'a.jsonl', [sessionLine('a1', 'claude-opus-4-8', 1000)]);
+  // projectB: sonnet, fewer tokens.
+  writeSession(PROJ_B, 'b.jsonl', [sessionLine('b1', 'claude-sonnet-4-6', 200)]);
+  // projectEmpty: a file with no usage-bearing lines → 0 tokens, must be dropped.
+  writeSession(PROJ_EMPTY, 'e.jsonl', ['not json', '{"uuid":"e1","type":"user"}']);
+});
+
+afterEach(() => {
+  rmSync(mocked.home, { recursive: true, force: true });
+});
+
+describe('computeCarbonStats', () => {
+  it('returns empty for a defined-but-empty path list (does not scan everything)', () => {
+    const stats = computeCarbonStats([]);
+    expect(stats.tokens).toBe(0);
+    expect(stats.sessionCount).toBe(0);
+    expect(stats.projects).toEqual([]);
+  });
+
+  it('scopes the scan to the encoded folders for the given paths', () => {
+    const stats = computeCarbonStats([PROJ_A]);
+    expect(stats.projects).toHaveLength(1);
+    expect(stats.tokensByModel.opus).toBe(1000);
+    expect(stats.tokensByModel.sonnet).toBe(0);
+  });
+
+  it('labels each project with the path basename, not the lossy decoded folder', () => {
+    const stats = computeCarbonStats([PROJ_A]);
+    expect(stats.projects[0].project).toBe('projectA');
+  });
+
+  it('scans every folder when no paths are given', () => {
+    const scoped = computeCarbonStats([PROJ_A]);
+    const all = computeCarbonStats();
+    expect(all.sessionCount).toBeGreaterThan(scoped.sessionCount);
+    expect(all.tokens).toBeGreaterThan(scoped.tokens);
+  });
+
+  it('sorts projects by descending energy and drops zero-token folders', () => {
+    const stats = computeCarbonStats([PROJ_A, PROJ_B, PROJ_EMPTY]);
+    expect(stats.projects.map((p) => p.project)).toEqual(['projectA', 'projectB']);
+    expect(stats.projects[0].energyWh).toBeGreaterThan(stats.projects[1].energyWh);
+  });
+
+  it('counts the unreadable/garbage session file without aborting the scan', () => {
+    // projectEmpty's file is unparseable but must not throw or drop the others.
+    const stats = computeCarbonStats([PROJ_A, PROJ_B, PROJ_EMPTY]);
+    expect(stats.tokens).toBe(1200);
+    expect(stats.sessionCount).toBe(3); // all three files were read
+  });
+});

--- a/src/main/utils/__tests__/jsonlParser.test.ts
+++ b/src/main/utils/__tests__/jsonlParser.test.ts
@@ -106,6 +106,7 @@ describe('calculateMetrics', () => {
       outputTokens: 0,
       cacheReadTokens: 0,
       messageCount: 0,
+      energyWh: 0,
     });
   });
 

--- a/src/main/utils/jsonlParser.ts
+++ b/src/main/utils/jsonlParser.ts
@@ -1,3 +1,4 @@
+import { computeEnergyFromMessages } from '../../shared/carbon';
 import {
   EMPTY_METRICS,
   type ContentBlock,
@@ -206,5 +207,6 @@ export function calculateMetrics(messages: ParsedSessionMessage[]): SessionMetri
     outputTokens,
     cacheReadTokens,
     messageCount: messages.length,
+    energyWh: computeEnergyFromMessages(messages).energyWh,
   };
 }

--- a/src/main/utils/jsonlParser.ts
+++ b/src/main/utils/jsonlParser.ts
@@ -1,3 +1,6 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 import { computeEnergyFromMessages } from '../../shared/carbon';
 import {
   EMPTY_METRICS,
@@ -22,6 +25,38 @@ export function encodeProjectPath(absolutePath: string): string {
     return absolutePath.replace(/[\\/:]/g, '-');
   }
   return absolutePath.replace(/\//g, '-');
+}
+
+/** Directory Claude Code stores per-project session folders under. */
+export function getProjectsDir(): string {
+  return path.join(os.homedir(), '.claude', 'projects');
+}
+
+/**
+ * Read a Claude Code session .jsonl and parse it into deduplicated messages.
+ * Returns null (and logs) when the file can't be read; the benign ENOENT race
+ * (file removed between readdir and read) is silent.
+ */
+export function parseSessionFile(
+  filePath: string,
+): { messages: ParsedSessionMessage[]; bytesRead: number } | null {
+  let data: string;
+  try {
+    data = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      console.warn('[jsonlParser.parseSessionFile] readFile failed', { filePath, err });
+    }
+    return null;
+  }
+
+  const messages: ParsedSessionMessage[] = [];
+  for (const line of data.split('\n')) {
+    const parsed = parseJsonlLine(line);
+    if (parsed) messages.push(parsed);
+  }
+
+  return { messages: deduplicateByRequestId(messages), bytesRead: Buffer.byteLength(data, 'utf8') };
 }
 
 export function extractToolCalls(content: ContentBlock[] | string): ToolCallInfo[] {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -27,6 +27,8 @@ import { ToastContainer } from './components/Toast';
 import { toast } from 'sonner';
 import { useStatusLine } from './hooks/useStatusLine';
 import { useThresholdAlerts } from './hooks/useThresholdAlerts';
+import { useSessionCarbon } from './hooks/useSessionCarbon';
+import { useGridIntensity } from './hooks/useGridIntensity';
 import type {
   Project,
   Task,
@@ -451,6 +453,9 @@ export function App() {
     }
     return null;
   })();
+
+  const activeSessionEnergyWh = useSessionCarbon(activeTaskId);
+  const [gridIntensity] = useGridIntensity();
 
   // All non-archived tasks for the active project (for cycling)
   const activeProjectTasks = activeProjectId
@@ -1759,10 +1764,19 @@ export function App() {
                     const rawCtx = activeTask ? contextUsage[activeTask.id] : undefined;
                     const activeCtx = showUsageInline ? rawCtx : undefined;
                     const rateLimits = showRateLimits && latestRateLimits ? latestRateLimits : {};
+                    const sessionEnergyWh = showUsageInline ? activeSessionEnergyWh : undefined;
                     const hasRateLimits = rateLimits.fiveHour || rateLimits.sevenDay;
                     const hasCtx = activeCtx && activeCtx.percentage > 0;
-                    if (!hasRateLimits && !hasCtx) return null;
-                    return <UsageWidget rateLimits={rateLimits} contextUsage={activeCtx} />;
+                    const hasCarbon = sessionEnergyWh && sessionEnergyWh > 0;
+                    if (!hasRateLimits && !hasCtx && !hasCarbon) return null;
+                    return (
+                      <UsageWidget
+                        rateLimits={rateLimits}
+                        contextUsage={activeCtx}
+                        sessionEnergyWh={sessionEnergyWh}
+                        gridIntensity={gridIntensity}
+                      />
+                    );
                   })()}
                 <ShellDrawerWrapper
                   enabled={

--- a/src/renderer/components/CarbonPanel.tsx
+++ b/src/renderer/components/CarbonPanel.tsx
@@ -1,0 +1,232 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Leaf, Zap, RefreshCw, ChevronRight, ChevronDown, Info } from 'lucide-react';
+import type { CarbonStats } from '../../shared/types';
+import { carbonGramsFromWh, householdComparison, flightComparison } from '../../shared/carbon';
+import { formatEnergy, formatCarbon, formatTokens } from '../../shared/format';
+import { useGridIntensity } from '../hooks/useGridIntensity';
+import { Tooltip } from './ui/Tooltip';
+
+const MODEL_ORDER: Array<{ key: string; label: string }> = [
+  { key: 'opus', label: 'Opus' },
+  { key: 'sonnet', label: 'Sonnet' },
+  { key: 'haiku', label: 'Haiku' },
+];
+
+function StatBlock({
+  icon,
+  label,
+  value,
+  sub,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="flex items-center gap-2.5 min-w-0">
+      <div className="flex-shrink-0">{icon}</div>
+      <div className="min-w-0">
+        <div className="text-[15px] font-semibold text-foreground tabular-nums truncate">
+          {value}
+        </div>
+        <div className="text-[10px] text-muted-foreground uppercase tracking-wide">{label}</div>
+        {sub && <div className="text-[10px] text-muted-foreground/70 truncate">{sub}</div>}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Estimated energy/carbon for a set of Claude Code paths. Pass `paths` to scope to
+ * a project (its repo path + each task's worktree path); omit for the lifetime total.
+ */
+export function CarbonPanel({ paths }: { paths?: string[] }) {
+  const [stats, setStats] = useState<CarbonStats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [gridIntensity, setGridIntensity] = useGridIntensity();
+
+  // Stable key so the fetch effect re-runs when the project's path set changes,
+  // not on every parent re-render (which hands us a fresh array reference).
+  const pathsKey = paths ? paths.join('\n') : '';
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await window.electronAPI.getCarbonStats(
+        pathsKey ? pathsKey.split('\n') : undefined,
+      );
+      if (res.success && res.data) setStats(res.data);
+      else setError(res.error ?? 'Failed to load carbon stats');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [pathsKey]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const grams = stats ? carbonGramsFromWh(stats.energyWh, gridIntensity) : 0;
+
+  function renderBody(): React.ReactNode {
+    if (error) {
+      return <div className="px-4 py-4 text-[12px] text-destructive">{error}</div>;
+    }
+    if (!stats) {
+      return (
+        <div className="px-4 py-4 text-[12px] text-muted-foreground">
+          {loading ? 'Calculating…' : 'No data yet.'}
+        </div>
+      );
+    }
+    if (stats.tokens === 0) {
+      return (
+        <div className="px-4 py-4 text-[12px] text-muted-foreground">
+          No Claude Code sessions recorded for this project yet.
+        </div>
+      );
+    }
+
+    return (
+      <>
+        {/* Hero stats */}
+        <div className="px-4 py-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <StatBlock
+            icon={<Leaf size={20} strokeWidth={1.6} className="text-emerald-400" />}
+            label="CO₂e (est.)"
+            value={formatCarbon(grams)}
+            sub={flightComparison(grams)}
+          />
+          <StatBlock
+            icon={<Zap size={20} strokeWidth={1.6} className="text-amber-400" />}
+            label="Energy (est.)"
+            value={formatEnergy(stats.energyWh)}
+            sub={householdComparison(stats.energyWh)}
+          />
+          <StatBlock
+            icon={<span className="text-[20px] leading-none text-sky-400 font-semibold">∑</span>}
+            label="Tokens"
+            value={formatTokens(stats.tokens)}
+            sub={`${stats.sessionCount} session${stats.sessionCount === 1 ? '' : 's'}`}
+          />
+        </div>
+
+        {/* Grid intensity control */}
+        <div className="px-4 pb-3 flex items-center gap-2 text-[11px] text-muted-foreground">
+          <label htmlFor="grid-intensity">Grid intensity</label>
+          <input
+            id="grid-intensity"
+            type="number"
+            min={1}
+            value={gridIntensity}
+            onChange={(e) => setGridIntensity(Number(e.target.value))}
+            className="w-20 px-2 py-1 rounded-md bg-[hsl(var(--surface-2))] border border-border text-foreground tabular-nums focus:outline-none focus:border-primary/50"
+          />
+          <span>gCO₂e/kWh</span>
+        </div>
+
+        {/* Expandable breakdown */}
+        <button
+          onClick={() => setExpanded((p) => !p)}
+          className="w-full flex items-center gap-1.5 px-4 py-2 border-t border-border/40 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {expanded ? (
+            <ChevronDown size={13} strokeWidth={2} />
+          ) : (
+            <ChevronRight size={13} strokeWidth={2} />
+          )}
+          Breakdown
+        </button>
+
+        {expanded && (
+          <div className="px-4 pb-4 space-y-4">
+            {/* By model */}
+            <div>
+              <div className="text-[10px] text-muted-foreground/70 uppercase tracking-wide mb-1.5">
+                By model (effective tokens)
+              </div>
+              <div className="space-y-1">
+                {MODEL_ORDER.map(({ key, label }) => {
+                  const t = stats.tokensByModel[key] ?? 0;
+                  if (t === 0) return null;
+                  const pct = stats.tokens > 0 ? (t / stats.tokens) * 100 : 0;
+                  return (
+                    <div key={key} className="flex items-center gap-2 text-[11px]">
+                      <span className="w-14 text-foreground/80">{label}</span>
+                      <div className="flex-1 h-1.5 rounded-full bg-border/40 overflow-hidden">
+                        <div
+                          className="h-full rounded-full bg-emerald-400/70"
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                      <span className="w-16 text-right tabular-nums text-muted-foreground">
+                        {formatTokens(t)}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* By worktree — only meaningful when the project spans more than one folder */}
+            {stats.projects.length > 1 && (
+              <div>
+                <div className="text-[10px] text-muted-foreground/70 uppercase tracking-wide mb-1.5">
+                  By worktree
+                </div>
+                <div className="space-y-1">
+                  {stats.projects.slice(0, 8).map((p) => (
+                    <div
+                      key={p.project}
+                      className="flex items-center justify-between gap-3 text-[11px]"
+                    >
+                      <span className="truncate text-foreground/80">{p.project}</span>
+                      <span className="flex-shrink-0 tabular-nums text-muted-foreground">
+                        {formatCarbon(carbonGramsFromWh(p.energyWh, gridIntensity))} ·{' '}
+                        {formatEnergy(p.energyWh)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-[hsl(var(--surface-1))] overflow-hidden mb-4">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border/40">
+        <div className="flex items-center gap-2">
+          <Leaf size={15} strokeWidth={1.8} className="text-emerald-400" />
+          <span className="text-[12px] font-medium text-foreground">Energy &amp; Carbon</span>
+          <Tooltip
+            content={`Rough estimate from this project's Claude Code token usage. Coefficients are inferred from pricing ratios and public research — treat as ballpark figures, not measurements.`}
+          >
+            <Info size={12} strokeWidth={1.8} className="text-muted-foreground/60" />
+          </Tooltip>
+        </div>
+        <button
+          onClick={() => void load()}
+          disabled={loading}
+          className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+          title="Recalculate"
+        >
+          <RefreshCw size={12} strokeWidth={1.8} className={loading ? 'animate-spin' : ''} />
+          Refresh
+        </button>
+      </div>
+
+      {renderBody()}
+    </div>
+  );
+}

--- a/src/renderer/components/CarbonPanel.tsx
+++ b/src/renderer/components/CarbonPanel.tsx
@@ -1,16 +1,16 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Leaf, Zap, RefreshCw, ChevronRight, ChevronDown, Info } from 'lucide-react';
 import type { CarbonStats } from '../../shared/types';
-import { carbonGramsFromWh, householdComparison, flightComparison } from '../../shared/carbon';
-import { formatEnergy, formatCarbon, formatTokens } from '../../shared/format';
+import { carbonDisplay, CARBON_MODELS, type CarbonModel } from '../../shared/carbon';
+import { formatTokens } from '../../shared/format';
 import { useGridIntensity } from '../hooks/useGridIntensity';
 import { Tooltip } from './ui/Tooltip';
 
-const MODEL_ORDER: Array<{ key: string; label: string }> = [
-  { key: 'opus', label: 'Opus' },
-  { key: 'sonnet', label: 'Sonnet' },
-  { key: 'haiku', label: 'Haiku' },
-];
+const MODEL_LABELS: Record<CarbonModel, string> = {
+  opus: 'Opus',
+  sonnet: 'Sonnet',
+  haiku: 'Haiku',
+};
 
 function StatBlock({
   icon,
@@ -72,8 +72,6 @@ export function CarbonPanel({ paths }: { paths?: string[] }) {
     void load();
   }, [load]);
 
-  const grams = stats ? carbonGramsFromWh(stats.energyWh, gridIntensity) : 0;
-
   function renderBody(): React.ReactNode {
     if (error) {
       return <div className="px-4 py-4 text-[12px] text-destructive">{error}</div>;
@@ -93,6 +91,8 @@ export function CarbonPanel({ paths }: { paths?: string[] }) {
       );
     }
 
+    const display = carbonDisplay(stats.energyWh, gridIntensity);
+
     return (
       <>
         {/* Hero stats */}
@@ -100,14 +100,14 @@ export function CarbonPanel({ paths }: { paths?: string[] }) {
           <StatBlock
             icon={<Leaf size={20} strokeWidth={1.6} className="text-emerald-400" />}
             label="CO₂e (est.)"
-            value={formatCarbon(grams)}
-            sub={flightComparison(grams)}
+            value={display.carbon}
+            sub={display.flight}
           />
           <StatBlock
             icon={<Zap size={20} strokeWidth={1.6} className="text-amber-400" />}
             label="Energy (est.)"
-            value={formatEnergy(stats.energyWh)}
-            sub={householdComparison(stats.energyWh)}
+            value={display.energy}
+            sub={display.household}
           />
           <StatBlock
             icon={<span className="text-[20px] leading-none text-sky-400 font-semibold">∑</span>}
@@ -152,13 +152,13 @@ export function CarbonPanel({ paths }: { paths?: string[] }) {
                 By model (effective tokens)
               </div>
               <div className="space-y-1">
-                {MODEL_ORDER.map(({ key, label }) => {
-                  const t = stats.tokensByModel[key] ?? 0;
+                {CARBON_MODELS.map((key) => {
+                  const t = stats.tokensByModel[key];
                   if (t === 0) return null;
                   const pct = stats.tokens > 0 ? (t / stats.tokens) * 100 : 0;
                   return (
                     <div key={key} className="flex items-center gap-2 text-[11px]">
-                      <span className="w-14 text-foreground/80">{label}</span>
+                      <span className="w-14 text-foreground/80">{MODEL_LABELS[key]}</span>
                       <div className="flex-1 h-1.5 rounded-full bg-border/40 overflow-hidden">
                         <div
                           className="h-full rounded-full bg-emerald-400/70"
@@ -181,18 +181,20 @@ export function CarbonPanel({ paths }: { paths?: string[] }) {
                   By worktree
                 </div>
                 <div className="space-y-1">
-                  {stats.projects.slice(0, 8).map((p) => (
-                    <div
-                      key={p.project}
-                      className="flex items-center justify-between gap-3 text-[11px]"
-                    >
-                      <span className="truncate text-foreground/80">{p.project}</span>
-                      <span className="flex-shrink-0 tabular-nums text-muted-foreground">
-                        {formatCarbon(carbonGramsFromWh(p.energyWh, gridIntensity))} ·{' '}
-                        {formatEnergy(p.energyWh)}
-                      </span>
-                    </div>
-                  ))}
+                  {stats.projects.slice(0, 8).map((p) => {
+                    const pd = carbonDisplay(p.energyWh, gridIntensity);
+                    return (
+                      <div
+                        key={p.project}
+                        className="flex items-center justify-between gap-3 text-[11px]"
+                      >
+                        <span className="truncate text-foreground/80">{p.project}</span>
+                        <span className="flex-shrink-0 tabular-nums text-muted-foreground">
+                          {pd.carbon} · {pd.energy}
+                        </span>
+                      </div>
+                    );
+                  })}
                 </div>
               </div>
             )}

--- a/src/renderer/components/ProjectOverview.tsx
+++ b/src/renderer/components/ProjectOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { openInIde } from '../lib/openInIde';
 import {
   GitBranch,
@@ -18,6 +18,7 @@ import type { Project, Task, ActivityInfo } from '../../shared/types';
 import { linkedItemUrl } from '../../shared/urls';
 import { IconButton } from './ui/IconButton';
 import { Tooltip } from './ui/Tooltip';
+import { CarbonPanel } from './CarbonPanel';
 
 interface ProjectOverviewProps {
   project: Project;
@@ -110,6 +111,17 @@ export function ProjectOverview({
   onRestoreTask,
 }: ProjectOverviewProps) {
   const [showArchived, setShowArchived] = useState(false);
+
+  // Claude Code paths owned by this project: the repo path plus each task's
+  // worktree path. Scopes the carbon panel to this project rather than all of them.
+  const carbonPaths = useMemo(() => {
+    const set = new Set<string>();
+    if (project.path) set.add(project.path);
+    for (const t of tasks) if (t.path) set.add(t.path);
+    for (const t of archivedTasks) if (t.path) set.add(t.path);
+    return Array.from(set);
+  }, [project.path, tasks, archivedTasks]);
+
   const busyCount = tasks.filter((t) => taskActivity[t.id]?.state === 'busy').length;
   const waitingCount = tasks.filter((t) => taskActivity[t.id]?.state === 'waiting').length;
   const errorCount = tasks.filter((t) => taskActivity[t.id]?.state === 'error').length;
@@ -222,6 +234,7 @@ export function ProjectOverview({
       {/* Scrollable content */}
       <div className="flex-1 overflow-y-auto px-14 py-6">
         <div className="w-full">
+          <CarbonPanel paths={carbonPaths} />
           {tasks.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-20 text-center">
               <p className="text-[13px] text-muted-foreground mb-4">

--- a/src/renderer/components/UsageWidget.tsx
+++ b/src/renderer/components/UsageWidget.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Leaf } from 'lucide-react';
 import type { RateLimits, ContextUsage } from '../../shared/types';
-import { formatResetTime, formatTokens, formatEnergy, formatCarbon } from '../../shared/format';
-import { carbonGramsFromWh, householdComparison, flightComparison } from '../../shared/carbon';
+import { formatResetTime, formatTokens } from '../../shared/format';
+import { carbonDisplay } from '../../shared/carbon';
 import { UsageBar } from './ui/UsageBar';
 
 export function UsageWidget({
@@ -18,7 +18,8 @@ export function UsageWidget({
   gridIntensity?: number;
 }) {
   const ctx = contextUsage && contextUsage.percentage > 0 ? contextUsage : null;
-  const carbon = sessionEnergyWh && sessionEnergyWh > 0 ? sessionEnergyWh : null;
+  const carbon =
+    sessionEnergyWh && sessionEnergyWh > 0 ? carbonDisplay(sessionEnergyWh, gridIntensity) : null;
   if (!rateLimits.fiveHour && !rateLimits.sevenDay && !ctx && !carbon) return null;
 
   return (
@@ -67,17 +68,15 @@ export function UsageWidget({
       {carbon && (
         <div
           className="flex items-center justify-between text-[10px]"
-          title={`Estimated · ${householdComparison(carbon)} · ${flightComparison(
-            carbonGramsFromWh(carbon, gridIntensity),
-          )}`}
+          title={`Estimated · ${carbon.household} · ${carbon.flight}`}
         >
           <span className="flex items-center gap-1 text-muted-foreground/70 uppercase tracking-wide">
             <Leaf size={11} strokeWidth={1.8} className="text-emerald-400" />
             Carbon (est.)
           </span>
           <span className="tabular-nums font-medium text-foreground/60">
-            {formatCarbon(carbonGramsFromWh(carbon, gridIntensity))}
-            <span className="text-foreground/40 font-normal ml-1.5">· {formatEnergy(carbon)}</span>
+            {carbon.carbon}
+            <span className="text-foreground/40 font-normal ml-1.5">· {carbon.energy}</span>
           </span>
         </div>
       )}

--- a/src/renderer/components/UsageWidget.tsx
+++ b/src/renderer/components/UsageWidget.tsx
@@ -1,17 +1,25 @@
 import React from 'react';
+import { Leaf } from 'lucide-react';
 import type { RateLimits, ContextUsage } from '../../shared/types';
-import { formatResetTime, formatTokens } from '../../shared/format';
+import { formatResetTime, formatTokens, formatEnergy, formatCarbon } from '../../shared/format';
+import { carbonGramsFromWh, householdComparison, flightComparison } from '../../shared/carbon';
 import { UsageBar } from './ui/UsageBar';
 
 export function UsageWidget({
   rateLimits,
   contextUsage,
+  sessionEnergyWh,
+  gridIntensity,
 }: {
   rateLimits: RateLimits;
   contextUsage?: ContextUsage;
+  /** Estimated energy (Wh) for the active task's session. Omit to hide the carbon row. */
+  sessionEnergyWh?: number;
+  gridIntensity?: number;
 }) {
   const ctx = contextUsage && contextUsage.percentage > 0 ? contextUsage : null;
-  if (!rateLimits.fiveHour && !rateLimits.sevenDay && !ctx) return null;
+  const carbon = sessionEnergyWh && sessionEnergyWh > 0 ? sessionEnergyWh : null;
+  if (!rateLimits.fiveHour && !rateLimits.sevenDay && !ctx && !carbon) return null;
 
   return (
     <div
@@ -55,6 +63,23 @@ export function UsageWidget({
           labelClassName="text-[10px] text-muted-foreground/70 uppercase tracking-wide"
           detailClassName="text-[10px]"
         />
+      )}
+      {carbon && (
+        <div
+          className="flex items-center justify-between text-[10px]"
+          title={`Estimated · ${householdComparison(carbon)} · ${flightComparison(
+            carbonGramsFromWh(carbon, gridIntensity),
+          )}`}
+        >
+          <span className="flex items-center gap-1 text-muted-foreground/70 uppercase tracking-wide">
+            <Leaf size={11} strokeWidth={1.8} className="text-emerald-400" />
+            Carbon (est.)
+          </span>
+          <span className="tabular-nums font-medium text-foreground/60">
+            {formatCarbon(carbonGramsFromWh(carbon, gridIntensity))}
+            <span className="text-foreground/40 font-normal ml-1.5">· {formatEnergy(carbon)}</span>
+          </span>
+        </div>
       )}
     </div>
   );

--- a/src/renderer/hooks/useGridIntensity.ts
+++ b/src/renderer/hooks/useGridIntensity.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState, useCallback } from 'react';
+import { DEFAULT_GRID_INTENSITY_G_PER_KWH } from '../../shared/carbon';
+
+const STORAGE_KEY = 'carbonGridIntensity';
+
+function read(): number {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  const parsed = stored !== null ? Number(stored) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_GRID_INTENSITY_G_PER_KWH;
+}
+
+/**
+ * Grid carbon intensity (gCO2e/kWh) used to convert estimated energy to carbon.
+ * Backed by localStorage and synced across components/windows via the storage event.
+ */
+export function useGridIntensity(): [number, (value: number) => void] {
+  const [intensity, setIntensity] = useState<number>(read);
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) setIntensity(read());
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  const update = useCallback((value: number) => {
+    const safe = Number.isFinite(value) && value > 0 ? value : DEFAULT_GRID_INTENSITY_G_PER_KWH;
+    localStorage.setItem(STORAGE_KEY, String(safe));
+    setIntensity(safe);
+    // Same-window listeners (storage event only fires cross-window).
+    window.dispatchEvent(new StorageEvent('storage', { key: STORAGE_KEY, newValue: String(safe) }));
+  }, []);
+
+  return [intensity, update];
+}

--- a/src/renderer/hooks/useSessionCarbon.ts
+++ b/src/renderer/hooks/useSessionCarbon.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import type { SessionUpdate } from '../../shared/sessionTypes';
+
+/**
+ * Tracks the latest estimated energy (Wh) per task, derived from the same
+ * `session:update` stream the structured view consumes. Returns the energy for
+ * the active task's current session, or undefined if none seen yet.
+ */
+export function useSessionCarbon(taskId: string | null | undefined): number | undefined {
+  const [energyByTask, setEnergyByTask] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    const unsubscribe = window.electronAPI.onSessionUpdate((update: SessionUpdate) => {
+      setEnergyByTask((prev) => {
+        const next = update.metrics.energyWh;
+        if (prev[update.taskId] === next) return prev;
+        return { ...prev, [update.taskId]: next };
+      });
+    });
+    return unsubscribe;
+  }, []);
+
+  return taskId ? energyByTask[taskId] : undefined;
+}

--- a/src/shared/__tests__/carbon.test.ts
+++ b/src/shared/__tests__/carbon.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeModel,
+  effectiveTokens,
+  energyWhForTokens,
+  carbonGramsFromWh,
+  computeEnergyFromMessages,
+  sumEnergyStats,
+  householdComparison,
+  flightComparison,
+  FLIGHT_G_CO2E_PER_KM,
+  PUE,
+  MODEL_ENERGY_J_PER_TOKEN,
+  DEFAULT_GRID_INTENSITY_G_PER_KWH,
+} from '../carbon';
+import type { ParsedSessionMessage } from '../sessionTypes';
+
+function msg(partial: Partial<ParsedSessionMessage>): ParsedSessionMessage {
+  return {
+    uuid: 'u',
+    parentUuid: null,
+    type: 'assistant',
+    timestamp: '2025-01-01T00:00:00Z',
+    content: '',
+    isSidechain: false,
+    isMeta: false,
+    toolCalls: [],
+    toolResults: [],
+    ...partial,
+  };
+}
+
+describe('normalizeModel', () => {
+  it('maps Claude model ids to energy families', () => {
+    expect(normalizeModel('claude-opus-4-8')).toBe('opus');
+    expect(normalizeModel('claude-sonnet-4-6')).toBe('sonnet');
+    expect(normalizeModel('claude-haiku-4-5-20251001')).toBe('haiku');
+  });
+
+  it('falls back to sonnet for unknown / missing models', () => {
+    expect(normalizeModel(undefined)).toBe('sonnet');
+    expect(normalizeModel('some-other-model')).toBe('sonnet');
+  });
+});
+
+describe('effectiveTokens', () => {
+  it('returns 0 for missing usage', () => {
+    expect(effectiveTokens(undefined)).toBe(0);
+  });
+
+  it('sums base input + weighted cache + output (read 0.1x, create 1.25x)', () => {
+    // 100 + round(1000*0.1)=100 + round(200*1.25)=250 + 50 = 500
+    expect(
+      effectiveTokens({
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 1000,
+        cache_creation_input_tokens: 200,
+      }),
+    ).toBe(500);
+  });
+});
+
+describe('energy & carbon math', () => {
+  it('matches the documented formula tokens × J/token × PUE / 3600', () => {
+    // 3600 sonnet tokens (1 J/token) × PUE 1.2 = 4320 J = 1.2 Wh
+    const wh = energyWhForTokens(3600, 'sonnet');
+    expect(wh).toBeCloseTo((3600 * MODEL_ENERGY_J_PER_TOKEN.sonnet * PUE) / 3600, 6);
+    expect(wh).toBeCloseTo(1.2, 6);
+  });
+
+  it('opus costs 2x sonnet, haiku 0.3x, for the same tokens', () => {
+    expect(energyWhForTokens(1000, 'opus')).toBeCloseTo(energyWhForTokens(1000, 'sonnet') * 2, 6);
+    expect(energyWhForTokens(1000, 'haiku')).toBeCloseTo(
+      energyWhForTokens(1000, 'sonnet') * 0.3,
+      6,
+    );
+  });
+
+  it('converts Wh to grams CO2e at the grid intensity', () => {
+    expect(carbonGramsFromWh(1000)).toBeCloseTo(DEFAULT_GRID_INTENSITY_G_PER_KWH, 6);
+    expect(carbonGramsFromWh(1000, 500)).toBeCloseTo(500, 6);
+  });
+});
+
+describe('computeEnergyFromMessages', () => {
+  it('charges each message at its own model rate and groups tokens by model', () => {
+    const stats = computeEnergyFromMessages([
+      msg({ model: 'claude-opus-4-8', usage: { input_tokens: 100, output_tokens: 0 } }),
+      msg({ model: 'claude-haiku-4-5', usage: { input_tokens: 100, output_tokens: 0 } }),
+      msg({ type: 'user', usage: undefined }),
+    ]);
+    expect(stats.tokens).toBe(200);
+    expect(stats.tokensByModel).toEqual({ opus: 100, sonnet: 0, haiku: 100 });
+    expect(stats.energyWh).toBeCloseTo(
+      energyWhForTokens(100, 'opus') + energyWhForTokens(100, 'haiku'),
+      6,
+    );
+  });
+});
+
+describe('sumEnergyStats', () => {
+  it('adds tokens, energy, and per-model breakdowns', () => {
+    const a = computeEnergyFromMessages([
+      msg({ model: 'claude-opus-4-8', usage: { input_tokens: 10, output_tokens: 0 } }),
+    ]);
+    const b = computeEnergyFromMessages([
+      msg({ model: 'claude-sonnet-4-6', usage: { input_tokens: 20, output_tokens: 0 } }),
+    ]);
+    const total = sumEnergyStats([a, b]);
+    expect(total.tokens).toBe(30);
+    expect(total.tokensByModel).toEqual({ opus: 10, sonnet: 20, haiku: 0 });
+  });
+});
+
+describe('flightComparison', () => {
+  it('scales from metres to thousands of km', () => {
+    // 15 g / 150 g·km⁻¹ = 0.1 km → 100 m
+    expect(flightComparison(15)).toBe('Flying 100 m');
+    expect(flightComparison(FLIGHT_G_CO2E_PER_KM * 5)).toBe('Flying 5.0 km');
+    expect(flightComparison(FLIGHT_G_CO2E_PER_KM * 250)).toBe('Flying 250 km');
+    expect(flightComparison(FLIGHT_G_CO2E_PER_KM * 5000)).toBe('Flying 5.0k km');
+  });
+});
+
+describe('householdComparison', () => {
+  it('scales units with magnitude', () => {
+    expect(householdComparison(0.005)).toContain('LED bulb');
+    expect(householdComparison(5)).toContain('Phone charge');
+    expect(householdComparison(50)).toContain('Laptop');
+    expect(householdComparison(5000)).toContain('home');
+    expect(householdComparison(500000)).toContain('EV');
+  });
+});

--- a/src/shared/__tests__/carbon.test.ts
+++ b/src/shared/__tests__/carbon.test.ts
@@ -131,4 +131,19 @@ describe('householdComparison', () => {
     expect(householdComparison(5000)).toContain('home');
     expect(householdComparison(500000)).toContain('EV');
   });
+
+  it('reports phone charge as a sane percentage (~10 Wh ≈ a full battery)', () => {
+    // 1–10 Wh maps to 10–100% of a ~10 Wh phone battery, not ~0.05–0.5%.
+    expect(householdComparison(1)).toBe('Phone charge 10%');
+    expect(householdComparison(5)).toBe('Phone charge 50%');
+    expect(householdComparison(9.9)).toBe('Phone charge 99%');
+  });
+
+  it('keeps LED-bulb seconds monotonic across the 0.1 Wh boundary', () => {
+    // Both sub-1 Wh LED readings share the ×100 Wh→seconds scale, so seconds
+    // rise with energy instead of dropping 9× at 0.1 Wh.
+    expect(householdComparison(0.099)).toBe('LED bulb for 9s');
+    expect(householdComparison(0.1)).toBe('LED bulb for 10s');
+    expect(householdComparison(0.5)).toBe('LED bulb for 50s');
+  });
 });

--- a/src/shared/__tests__/format.test.ts
+++ b/src/shared/__tests__/format.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { formatTokens, formatDuration, formatResetTime } from '../format';
+import {
+  formatTokens,
+  formatDuration,
+  formatResetTime,
+  formatEnergy,
+  formatCarbon,
+} from '../format';
 
 describe('formatTokens', () => {
   it('returns raw number below 1000', () => {
@@ -23,6 +29,52 @@ describe('formatTokens', () => {
     expect(formatTokens(1000000)).toBe('1.0m');
     expect(formatTokens(1500000)).toBe('1.5m');
     expect(formatTokens(2345678)).toBe('2.3m');
+  });
+});
+
+describe('formatEnergy', () => {
+  it('formats kWh at/above 1000 Wh', () => {
+    expect(formatEnergy(1000)).toBe('1.0 kWh');
+    expect(formatEnergy(1500)).toBe('1.5 kWh');
+  });
+
+  it('formats whole Wh between 1 and 1000', () => {
+    expect(formatEnergy(1)).toBe('1 Wh');
+    expect(formatEnergy(50)).toBe('50 Wh');
+    expect(formatEnergy(999)).toBe('999 Wh');
+  });
+
+  it('formats sub-Wh values to two decimals', () => {
+    expect(formatEnergy(0.5)).toBe('0.50 Wh');
+    expect(formatEnergy(0.005)).toBe('0.01 Wh'); // rounds up
+  });
+
+  it('guards zero and negatives', () => {
+    expect(formatEnergy(0)).toBe('0 Wh');
+    expect(formatEnergy(-3)).toBe('0 Wh');
+  });
+});
+
+describe('formatCarbon', () => {
+  it('formats kg at/above 1000 g', () => {
+    expect(formatCarbon(1000)).toBe('1.0 kg');
+    expect(formatCarbon(1500)).toBe('1.5 kg');
+  });
+
+  it('formats whole grams between 1 and 1000', () => {
+    expect(formatCarbon(12)).toBe('12 g');
+    // 999.9 rounds to "1000" but stays in grams (below the 1000 kg threshold).
+    expect(formatCarbon(999.9)).toBe('1000 g');
+  });
+
+  it('formats sub-gram values to one decimal', () => {
+    expect(formatCarbon(0.5)).toBe('0.5 g');
+    expect(formatCarbon(0.04)).toBe('0.0 g');
+  });
+
+  it('guards zero and negatives', () => {
+    expect(formatCarbon(0)).toBe('0 g');
+    expect(formatCarbon(-2)).toBe('0 g');
   });
 });
 

--- a/src/shared/carbon.ts
+++ b/src/shared/carbon.ts
@@ -164,10 +164,13 @@ export function flightComparison(gramsCO2e: number): string {
  */
 export function householdComparison(energyWh: number): string {
   if (energyWh < 0.01) return '< 1 sec of an LED bulb';
-  if (energyWh < 0.1) return `LED bulb for ${Math.floor(energyWh / 0.01)}s`;
-  if (energyWh < 1.0) return `LED bulb for ${Math.floor(energyWh * 10)}s`;
+  // Single Wh→seconds scale (×100) for the whole sub-1 Wh range so the reported
+  // seconds stay monotonic (a previous split used ×100 then ×10, which made
+  // 0.099 Wh → 9s but 0.1 Wh → 1s).
+  if (energyWh < 1.0) return `LED bulb for ${Math.floor(energyWh * 100)}s`;
   if (energyWh < 10.0) {
-    const percent = energyWh * 0.05;
+    // ~10 Wh ≈ a full phone battery, so 1–10 Wh maps to 10–100%.
+    const percent = energyWh * 10;
     return `Phone charge ${percent < 1 ? percent.toFixed(1) : percent.toFixed(0)}%`;
   }
   if (energyWh < 100.0) return `Laptop for ${Math.floor((energyWh / 10.0) * 5)} min`;

--- a/src/shared/carbon.ts
+++ b/src/shared/carbon.ts
@@ -1,13 +1,13 @@
 import type { ParsedSessionMessage, TokenUsage } from './sessionTypes';
+import { formatCarbon, formatEnergy } from './format';
 
 /**
  * Energy & carbon estimation for Claude Code token usage.
  *
- * Ported from the claude-carbon project (https://github.com/metztim/claude-carbon,
- * MIT) — specifically its bundled `Methodology.json`, `EnergyCalculator.swift`, and
- * `SessionJSONLMonitor.swift`. The coefficients are rough estimates inferred from
- * pricing ratios and public research, NOT measured figures; surface them as
- * estimates in any UI.
+ * Methodology adapted from the claude-carbon project
+ * (https://github.com/metztim/claude-carbon, MIT). The coefficients are rough
+ * estimates inferred from pricing ratios and public research, NOT measured
+ * figures; surface them as estimates in any UI.
  *
  * Formula:  tokens × J/token × PUE = Joules → /3600 = Wh → × gCO2e/kWh / 1000 = grams
  *
@@ -19,7 +19,10 @@ import type { ParsedSessionMessage, TokenUsage } from './sessionTypes';
 
 export type CarbonModel = 'opus' | 'sonnet' | 'haiku';
 
-/** Joules per token per model family (claude-carbon Methodology.json v1.0). */
+/** All energy families, in display order. Single source of truth for the union. */
+export const CARBON_MODELS: CarbonModel[] = ['opus', 'sonnet', 'haiku'];
+
+/** Joules per token per model family (rough estimate). */
 export const MODEL_ENERGY_J_PER_TOKEN: Record<CarbonModel, number> = {
   opus: 2.0,
   sonnet: 1.0,
@@ -29,6 +32,11 @@ export const MODEL_ENERGY_J_PER_TOKEN: Record<CarbonModel, number> = {
 /** Fallback when a model string doesn't match a known family. */
 export const DEFAULT_CARBON_MODEL: CarbonModel = 'sonnet';
 
+/** Zeroed per-family token buckets. Factory (callers mutate the result). */
+export function emptyTokensByModel(): Record<CarbonModel, number> {
+  return { opus: 0, sonnet: 0, haiku: 0 };
+}
+
 /** Power Usage Effectiveness — datacenter overhead multiplier. */
 export const PUE = 1.2;
 
@@ -37,7 +45,7 @@ export const DEFAULT_GRID_INTENSITY_G_PER_KWH = 384;
 
 /**
  * Cache tokens are weighted relative to a normal input token before being charged
- * at the model's J/token rate (claude-carbon SessionJSONLMonitor):
+ * at the model's J/token rate:
  *  - cache read: 0.1× (retrieval, minimal compute)
  *  - cache creation: 1.25× (extra work to store)
  */
@@ -59,7 +67,8 @@ export function normalizeModel(model: string | undefined): CarbonModel {
 
 /**
  * Effective token count for one message's usage, weighting cache reads/creations.
- * Matches claude-carbon: baseInput + cacheRead·0.1 + cacheCreation·1.25 + output.
+ * = baseInput + round(cacheRead·0.1) + round(cacheCreate·1.25) + output
+ * (cache weights are rounded per-message).
  */
 export function effectiveTokens(usage: TokenUsage | undefined): number {
   if (!usage) return 0;
@@ -104,7 +113,7 @@ export interface EnergyStats {
 export function computeEnergyFromMessages(messages: ParsedSessionMessage[]): EnergyStats {
   let tokens = 0;
   let energyWh = 0;
-  const tokensByModel: Record<CarbonModel, number> = { opus: 0, sonnet: 0, haiku: 0 };
+  const tokensByModel = emptyTokensByModel();
 
   for (const msg of messages) {
     if (!msg.usage) continue;
@@ -131,7 +140,7 @@ export function sumEnergyStats(stats: EnergyStats[]): EnergyStats {
         haiku: acc.tokensByModel.haiku + s.tokensByModel.haiku,
       },
     }),
-    { tokens: 0, energyWh: 0, tokensByModel: { opus: 0, sonnet: 0, haiku: 0 } },
+    { tokens: 0, energyWh: 0, tokensByModel: emptyTokensByModel() },
   );
 }
 
@@ -151,8 +160,7 @@ export function flightComparison(gramsCO2e: number): string {
 }
 
 /**
- * Relatable energy comparison, ported from claude-carbon's HeroComparisonView.
- * Input is energy in Wh.
+ * Relatable energy comparison. Input is energy in Wh.
  */
 export function householdComparison(energyWh: number): string {
   if (energyWh < 0.01) return '< 1 sec of an LED bulb';
@@ -177,4 +185,33 @@ export function householdComparison(energyWh: number): string {
   }
   if (energyWh < 100000.0) return `${(energyWh / 30000.0).toFixed(1)} days of home power`;
   return `EV for ${Math.floor((energyWh / 1000.0) * 3.5)} miles`;
+}
+
+export interface CarbonDisplay {
+  /** Carbon mass in grams CO2e at the given grid intensity. */
+  grams: number;
+  /** Formatted carbon, e.g. "12 g" / "1.3 kg". */
+  carbon: string;
+  /** Formatted energy, e.g. "50 Wh" / "1.5 kWh". */
+  energy: string;
+  /** Relatable carbon comparison ("Flying 5.0 km"). */
+  flight: string;
+  /** Relatable energy comparison ("Laptop for 2 min"). */
+  household: string;
+}
+
+/**
+ * Derive every display string for an energy figure in one place, so the carbon
+ * panel and the inline usage widget can't drift in how they apply grid intensity
+ * or phrase comparisons.
+ */
+export function carbonDisplay(energyWh: number, gridIntensity?: number): CarbonDisplay {
+  const grams = carbonGramsFromWh(energyWh, gridIntensity);
+  return {
+    grams,
+    carbon: formatCarbon(grams),
+    energy: formatEnergy(energyWh),
+    flight: flightComparison(grams),
+    household: householdComparison(energyWh),
+  };
 }

--- a/src/shared/carbon.ts
+++ b/src/shared/carbon.ts
@@ -1,0 +1,180 @@
+import type { ParsedSessionMessage, TokenUsage } from './sessionTypes';
+
+/**
+ * Energy & carbon estimation for Claude Code token usage.
+ *
+ * Ported from the claude-carbon project (https://github.com/metztim/claude-carbon,
+ * MIT) — specifically its bundled `Methodology.json`, `EnergyCalculator.swift`, and
+ * `SessionJSONLMonitor.swift`. The coefficients are rough estimates inferred from
+ * pricing ratios and public research, NOT measured figures; surface them as
+ * estimates in any UI.
+ *
+ * Formula:  tokens × J/token × PUE = Joules → /3600 = Wh → × gCO2e/kWh / 1000 = grams
+ *
+ * energyWh depends only on the (fixed) per-model energy + PUE coefficients, so it
+ * is computed wherever messages are available. gramsCO2e scales linearly with the
+ * grid carbon intensity, which is user-configurable — keep that conversion separate
+ * (see {@link carbonGramsFromWh}) so callers can apply the user's intensity.
+ */
+
+export type CarbonModel = 'opus' | 'sonnet' | 'haiku';
+
+/** Joules per token per model family (claude-carbon Methodology.json v1.0). */
+export const MODEL_ENERGY_J_PER_TOKEN: Record<CarbonModel, number> = {
+  opus: 2.0,
+  sonnet: 1.0,
+  haiku: 0.3,
+};
+
+/** Fallback when a model string doesn't match a known family. */
+export const DEFAULT_CARBON_MODEL: CarbonModel = 'sonnet';
+
+/** Power Usage Effectiveness — datacenter overhead multiplier. */
+export const PUE = 1.2;
+
+/** US grid average 2024, gCO2e/kWh (EPA). User-overridable. */
+export const DEFAULT_GRID_INTENSITY_G_PER_KWH = 384;
+
+/**
+ * Cache tokens are weighted relative to a normal input token before being charged
+ * at the model's J/token rate (claude-carbon SessionJSONLMonitor):
+ *  - cache read: 0.1× (retrieval, minimal compute)
+ *  - cache creation: 1.25× (extra work to store)
+ */
+const CACHE_READ_WEIGHT = 0.1;
+const CACHE_CREATION_WEIGHT = 1.25;
+
+const JOULES_PER_WH = 3600;
+const WH_PER_KWH = 1000;
+
+/** Map a Claude model id (e.g. "claude-opus-4-8") to its energy family. */
+export function normalizeModel(model: string | undefined): CarbonModel {
+  if (!model) return DEFAULT_CARBON_MODEL;
+  const m = model.toLowerCase();
+  if (m.includes('opus')) return 'opus';
+  if (m.includes('haiku')) return 'haiku';
+  if (m.includes('sonnet')) return 'sonnet';
+  return DEFAULT_CARBON_MODEL;
+}
+
+/**
+ * Effective token count for one message's usage, weighting cache reads/creations.
+ * Matches claude-carbon: baseInput + cacheRead·0.1 + cacheCreation·1.25 + output.
+ */
+export function effectiveTokens(usage: TokenUsage | undefined): number {
+  if (!usage) return 0;
+  const baseInput = usage.input_tokens ?? 0;
+  const output = usage.output_tokens ?? 0;
+  const cacheRead = usage.cache_read_input_tokens ?? 0;
+  const cacheCreate = usage.cache_creation_input_tokens ?? 0;
+  return (
+    baseInput +
+    Math.round(cacheRead * CACHE_READ_WEIGHT) +
+    Math.round(cacheCreate * CACHE_CREATION_WEIGHT) +
+    output
+  );
+}
+
+/** Energy (Wh) for a number of effective tokens at a model's rate, including PUE. */
+export function energyWhForTokens(tokens: number, model: CarbonModel): number {
+  const joules = tokens * MODEL_ENERGY_J_PER_TOKEN[model] * PUE;
+  return joules / JOULES_PER_WH;
+}
+
+/** Convert energy (Wh) to carbon (grams CO2e) at a grid intensity (gCO2e/kWh). */
+export function carbonGramsFromWh(
+  energyWh: number,
+  gridIntensity: number = DEFAULT_GRID_INTENSITY_G_PER_KWH,
+): number {
+  return (energyWh * gridIntensity) / WH_PER_KWH;
+}
+
+export interface EnergyStats {
+  /** Effective (cache-weighted) token total. */
+  tokens: number;
+  energyWh: number;
+  /** Effective tokens grouped by model family, for breakdowns. */
+  tokensByModel: Record<CarbonModel, number>;
+}
+
+/**
+ * Aggregate energy across messages, charging each message's effective tokens at
+ * its own model's rate. Non-assistant messages (no usage) contribute nothing.
+ */
+export function computeEnergyFromMessages(messages: ParsedSessionMessage[]): EnergyStats {
+  let tokens = 0;
+  let energyWh = 0;
+  const tokensByModel: Record<CarbonModel, number> = { opus: 0, sonnet: 0, haiku: 0 };
+
+  for (const msg of messages) {
+    if (!msg.usage) continue;
+    const t = effectiveTokens(msg.usage);
+    if (t === 0) continue;
+    const model = normalizeModel(msg.model);
+    tokens += t;
+    tokensByModel[model] += t;
+    energyWh += energyWhForTokens(t, model);
+  }
+
+  return { tokens, energyWh, tokensByModel };
+}
+
+/** Sum a list of energy stats (e.g. across sessions/projects). */
+export function sumEnergyStats(stats: EnergyStats[]): EnergyStats {
+  return stats.reduce<EnergyStats>(
+    (acc, s) => ({
+      tokens: acc.tokens + s.tokens,
+      energyWh: acc.energyWh + s.energyWh,
+      tokensByModel: {
+        opus: acc.tokensByModel.opus + s.tokensByModel.opus,
+        sonnet: acc.tokensByModel.sonnet + s.tokensByModel.sonnet,
+        haiku: acc.tokensByModel.haiku + s.tokensByModel.haiku,
+      },
+    }),
+    { tokens: 0, energyWh: 0, tokensByModel: { opus: 0, sonnet: 0, haiku: 0 } },
+  );
+}
+
+/**
+ * Average emissions of commercial air travel, gCO2e per passenger-km. Economy-class
+ * order-of-magnitude estimate (roughly DEFRA short-haul, excluding radiative forcing)
+ * — a ballpark like the other coefficients here, not a precise figure.
+ */
+export const FLIGHT_G_CO2E_PER_KM = 150;
+
+/** Relatable carbon comparison expressed as distance flown. Input is grams CO2e. */
+export function flightComparison(gramsCO2e: number): string {
+  const km = gramsCO2e / FLIGHT_G_CO2E_PER_KM;
+  if (km < 1) return `Flying ${Math.round(km * 1000)} m`;
+  if (km < 1000) return `Flying ${km.toFixed(km < 10 ? 1 : 0)} km`;
+  return `Flying ${(km / 1000).toFixed(1)}k km`;
+}
+
+/**
+ * Relatable energy comparison, ported from claude-carbon's HeroComparisonView.
+ * Input is energy in Wh.
+ */
+export function householdComparison(energyWh: number): string {
+  if (energyWh < 0.01) return '< 1 sec of an LED bulb';
+  if (energyWh < 0.1) return `LED bulb for ${Math.floor(energyWh / 0.01)}s`;
+  if (energyWh < 1.0) return `LED bulb for ${Math.floor(energyWh * 10)}s`;
+  if (energyWh < 10.0) {
+    const percent = energyWh * 0.05;
+    return `Phone charge ${percent < 1 ? percent.toFixed(1) : percent.toFixed(0)}%`;
+  }
+  if (energyWh < 100.0) return `Laptop for ${Math.floor((energyWh / 10.0) * 5)} min`;
+  if (energyWh < 1000.0) {
+    const hours = energyWh / 100.0;
+    return hours < 1
+      ? `Laptop for ${Math.floor(hours * 60)} min`
+      : `Laptop for ${hours.toFixed(1)} hrs`;
+  }
+  if (energyWh < 30000.0) {
+    const percent = Math.floor(energyWh / 300.0);
+    return percent < 100
+      ? `${percent}% of daily home use`
+      : `${(energyWh / 30000.0).toFixed(1)} days of home power`;
+  }
+  if (energyWh < 100000.0) return `${(energyWh / 30000.0).toFixed(1)} days of home power`;
+  return `EV for ${Math.floor((energyWh / 1000.0) * 3.5)} miles`;
+}

--- a/src/shared/format.ts
+++ b/src/shared/format.ts
@@ -14,6 +14,20 @@ export function formatDuration(ms: number): string {
   return `${h}h ${m % 60}m`;
 }
 
+export function formatEnergy(wh: number): string {
+  if (wh >= 1000) return `${(wh / 1000).toFixed(1)} kWh`;
+  if (wh >= 1) return `${wh.toFixed(0)} Wh`;
+  if (wh <= 0) return '0 Wh';
+  return `${wh.toFixed(2)} Wh`;
+}
+
+export function formatCarbon(grams: number): string {
+  if (grams >= 1000) return `${(grams / 1000).toFixed(1)} kg`;
+  if (grams >= 1) return `${grams.toFixed(0)} g`;
+  if (grams <= 0) return '0 g';
+  return `${grams.toFixed(1)} g`;
+}
+
 export function formatResetTime(epochSeconds: number): string {
   if (!epochSeconds) return '';
   const diffMs = epochSeconds * 1000 - Date.now();

--- a/src/shared/sessionTypes.ts
+++ b/src/shared/sessionTypes.ts
@@ -87,6 +87,12 @@ export interface SessionMetrics {
   outputTokens: number;
   cacheReadTokens: number;
   messageCount: number;
+  /**
+   * Estimated energy use in watt-hours (model-aware, cache-weighted). Grid-intensity
+   * independent — convert to carbon in the renderer with the user's intensity. See
+   * src/shared/carbon.ts.
+   */
+  energyWh: number;
 }
 
 export const EMPTY_METRICS: SessionMetrics = {
@@ -96,6 +102,7 @@ export const EMPTY_METRICS: SessionMetrics = {
   outputTokens: 0,
   cacheReadTokens: 0,
   messageCount: 0,
+  energyWh: 0,
 };
 
 export interface SessionUpdate {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,3 +1,5 @@
+import type { CarbonModel } from './carbon';
+
 export interface Project {
   id: string;
   name: string;
@@ -158,7 +160,7 @@ export interface StatusLineData {
  * configured grid intensity.
  */
 export interface CarbonProjectStat {
-  /** Decoded project path (Claude Code's ~/.claude/projects folder name decoded). */
+  /** Human-readable project label (worktree/folder basename; the full path can't be recovered). */
   project: string;
   tokens: number;
   energyWh: number;
@@ -168,7 +170,7 @@ export interface CarbonStats {
   tokens: number;
   energyWh: number;
   /** Effective tokens grouped by model family: opus / sonnet / haiku. */
-  tokensByModel: Record<string, number>;
+  tokensByModel: Record<CarbonModel, number>;
   /** Per-project breakdown, largest energy first. */
   projects: CarbonProjectStat[];
   /** Number of session .jsonl files scanned. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -151,6 +151,30 @@ export interface StatusLineData {
   updatedAt: number; // epoch ms
 }
 
+/**
+ * Aggregate energy/carbon estimate over Claude Code sessions. Token counts are
+ * cache-weighted (see src/shared/carbon.ts). `energyWh` is grid-intensity
+ * independent; carbon (grams CO2e) is derived in the renderer with the user's
+ * configured grid intensity.
+ */
+export interface CarbonProjectStat {
+  /** Decoded project path (Claude Code's ~/.claude/projects folder name decoded). */
+  project: string;
+  tokens: number;
+  energyWh: number;
+}
+
+export interface CarbonStats {
+  tokens: number;
+  energyWh: number;
+  /** Effective tokens grouped by model family: opus / sonnet / haiku. */
+  tokensByModel: Record<string, number>;
+  /** Per-project breakdown, largest energy first. */
+  projects: CarbonProjectStat[];
+  /** Number of session .jsonl files scanned. */
+  sessionCount: number;
+}
+
 export interface UsageThresholds {
   /** Warn when context window usage exceeds this percentage (0-100), or null to disable. */
   contextPercentage: number | null;

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -29,6 +29,7 @@ import type {
   SkillsSearchArgs,
   SkillsRegistryMeta,
   InstalledSkillsResult,
+  CarbonStats,
 } from '../shared/types';
 import type { ParsedSessionMessage, SessionMetrics, SessionUpdate } from '../shared/sessionTypes';
 
@@ -309,6 +310,9 @@ export interface ElectronAPI {
     taskId: string,
   ) => Promise<IpcResponse<{ messages: ParsedSessionMessage[]; metrics: SessionMetrics } | null>>;
   onSessionUpdate: (callback: (data: SessionUpdate) => void) => () => void;
+
+  // Carbon / energy stats
+  getCarbonStats: (paths?: string[]) => Promise<IpcResponse<CarbonStats>>;
 
   // Telemetry
   telemetryCapture: (event: string, properties?: Record<string, unknown>) => Promise<void>;


### PR DESCRIPTION
## What

Estimates **energy use and CO₂e** from Claude Code token usage, surfaced two ways:

- **Per-project panel** on the project dashboard (`CarbonPanel`) — CO₂e, energy, tokens, with a configurable grid intensity and an expandable per-model / per-worktree breakdown.
- **Per-session line** in the sidebar `UsageWidget` (gated by the existing "show usage inline" toggle).

## How

Rather than integrating the upstream [`claude-carbon`](https://github.com/metztim/claude-carbon) repo (it's a Swift/macOS menu-bar app — won't run in Dash's Electron/Linux build), this ports its **methodology** and rides on plumbing Dash already has:

- `src/shared/carbon.ts` — pure, unit-tested module: per-model J/token, PUE, cache weighting (read ×0.1, create ×1.25), EPA grid intensity, plus household and flight comparisons.
- `CarbonService` + `carbon:getStats` IPC — scans `~/.claude/projects`, **scoped to a project's repo + worktree paths**, broken down by model and worktree. Reuses the existing `jsonlParser` (`parseJsonlLine` / `deduplicateByRequestId`).
- `SessionMetrics` gains a grid-intensity-*independent* `energyWh` field (computed in `calculateMetrics`); grams CO₂e are derived in the renderer with the user's configured intensity, so the setting applies live everywhere.

No new file watchers and no `~/.claude/settings.json` hooks (unlike upstream).

## Notes

- The coefficients are **rough estimates** inferred from pricing ratios / public research, labelled "(est.)" in the UI with a tooltip — not measurements.
- Path→folder scoping relies on a worktree's path matching the folder Claude Code created for it (same exact-path-encoding constraint `SessionWatcherService` already lives with).

## Testing

- `pnpm type-check` (renderer + main): pass
- Carbon + jsonl test suites: green (27 tests)
- ESLint clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)