### PR TITLE
docs: add Homebrew install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The main idea: you open a project, create tasks, and each task gets an isolated 
 
 ## Install
 
+Requires macOS on Apple Silicon (arm64). There is currently no Intel Mac build.
+
 ### Homebrew
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ The main idea: you open a project, create tasks, and each task gets an isolated 
 
 ## Install
 
+### Homebrew
+
+```bash
+brew install --cask dash-syv-ai
+```
+
+The cask token is `dash-syv-ai` (not `dash`, which is taken by Kapeli's Dash). Homebrew handles updates, though the app can also update itself in the background.
+
+### Manual
+
 Download the latest build from [Releases](https://github.com/syv-ai/dash/releases/latest). Open the `.dmg` and drag `Dash.app` to `/Applications`.
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ The main idea: you open a project, create tasks, and each task gets an isolated 
 
 ## Install
 
-Requires macOS on Apple Silicon (arm64). There is currently no Intel Mac build.
+### macOS
 
-### Homebrew
+The macOS build is Apple Silicon (arm64) only; there is currently no Intel Mac build.
+
+Install with Homebrew:
 
 ```bash
 brew install --cask dash-syv-ai
@@ -38,9 +40,15 @@ brew install --cask dash-syv-ai
 
 The cask token is `dash-syv-ai` (not `dash`, which is taken by Kapeli's Dash). Homebrew handles updates, though the app can also update itself in the background.
 
-### Manual
+Or download the `.dmg` from [Releases](https://github.com/syv-ai/dash/releases/latest), open it, and drag `Dash.app` to `/Applications`.
 
-Download the latest build from [Releases](https://github.com/syv-ai/dash/releases/latest). Open the `.dmg` and drag `Dash.app` to `/Applications`.
+### Windows
+
+Download the `.exe` from [Releases](https://github.com/syv-ai/dash/releases/latest) and run it.
+
+### Linux
+
+Download the `.AppImage` from [Releases](https://github.com/syv-ai/dash/releases/latest), make it executable (`chmod +x`), and run it.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ The macOS build is Apple Silicon (arm64) only; there is currently no Intel Mac b
 Install with Homebrew:
 
 ```bash
-brew install --cask dash-syv-ai
+brew install --cask syv-ai-dash
 ```
 
-The cask token is `dash-syv-ai` (not `dash`, which is taken by Kapeli's Dash). Homebrew handles updates, though the app can also update itself in the background.
+The cask token is `syv-ai-dash` (not `dash`, which is taken by Kapeli's Dash). Homebrew handles updates, though the app can also update itself in the background.
 
 Or download the `.dmg` from [Releases](https://github.com/syv-ai/dash/releases/latest), open it, and drag `Dash.app` to `/Applications`.
 


### PR DESCRIPTION
Adds a Homebrew install option and restructures the Install section by platform.

```bash
brew install --cask syv-ai-dash
```

### Changes
- **macOS**: documents Homebrew (`brew install --cask syv-ai-dash`) alongside the existing `.dmg` download, and notes the build is Apple Silicon (arm64) only.
- **Windows** / **Linux**: adds short download instructions for the `.exe` and `.AppImage` assets that are already published in Releases (the previous README only mentioned the macOS `.dmg`).

### Notes
- The cask token is `syv-ai-dash`, not `dash`. The `dash` token is already taken in homebrew-cask by Kapeli's Dash (API documentation browser), so the vendor-prefixed form is used per Homebrew's naming convention for conflicting names.
- The cask is submitted to homebrew-cask in Homebrew/homebrew-cask#270120. The Homebrew line works once that cask PR is accepted, so merge order matters.
- The cask is arm64-only (matching the only macOS build) and uses `auto_updates true` since Dash self-updates via electron-updater.
- I added Windows/Linux instructions because those builds are in Releases. If they're experimental or unsupported and were omitted on purpose, say the word and I'll drop those sections.

I'm an external contributor, so happy to adjust wording, placement, or the token name.
