### PR TITLE
Add HTML preview toggle to the diff viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/main/ipc/fileIpc.ts
+++ b/src/main/ipc/fileIpc.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { promises as fs, statSync } from 'fs';
+import { promises as fs } from 'fs';
 import * as path from 'path';
 
 // Cap the size of files we'll load into the renderer for preview. HTML pages
@@ -12,15 +12,26 @@ export function registerFileIpc(): void {
   // itself only carries hunks).
   ipcMain.handle('file:readText', async (_event, args: { cwd: string; filePath: string }) => {
     try {
-      const base = path.resolve(args.cwd);
-      const abs = path.resolve(base, args.filePath);
+      // Resolve real paths (following symlinks) on both sides so the guard
+      // can't be bypassed by a symlink inside the worktree that points out of
+      // it. realpath on `base` also normalizes platform symlinks (e.g. macOS
+      // /var → /private/var) so legitimate files still pass.
+      const base = await fs.realpath(path.resolve(args.cwd));
+      const requested = path.resolve(base, args.filePath);
+
+      let abs: string;
+      try {
+        abs = await fs.realpath(requested);
+      } catch {
+        return { success: false, error: 'File not found' };
+      }
 
       // Path-traversal guard: the resolved file must live inside `cwd`.
       if (abs !== base && !abs.startsWith(base + path.sep)) {
         return { success: false, error: 'Path escapes the working directory' };
       }
 
-      const stat = statSync(abs);
+      const stat = await fs.stat(abs);
       if (!stat.isFile()) {
         return { success: false, error: 'Not a file' };
       }

--- a/src/main/ipc/fileIpc.ts
+++ b/src/main/ipc/fileIpc.ts
@@ -1,0 +1,37 @@
+import { ipcMain } from 'electron';
+import { promises as fs, statSync } from 'fs';
+import * as path from 'path';
+
+// Cap the size of files we'll load into the renderer for preview. HTML pages
+// large enough to exceed this are almost certainly not single-file previews.
+const MAX_PREVIEW_SIZE = 5 * 1024 * 1024; // 5 MB
+
+export function registerFileIpc(): void {
+  // Read a UTF-8 text file from within a task worktree. Used by the diff
+  // viewer's HTML preview to load the full on-disk file content (the diff
+  // itself only carries hunks).
+  ipcMain.handle('file:readText', async (_event, args: { cwd: string; filePath: string }) => {
+    try {
+      const base = path.resolve(args.cwd);
+      const abs = path.resolve(base, args.filePath);
+
+      // Path-traversal guard: the resolved file must live inside `cwd`.
+      if (abs !== base && !abs.startsWith(base + path.sep)) {
+        return { success: false, error: 'Path escapes the working directory' };
+      }
+
+      const stat = statSync(abs);
+      if (!stat.isFile()) {
+        return { success: false, error: 'Not a file' };
+      }
+      if (stat.size > MAX_PREVIEW_SIZE) {
+        return { success: false, error: 'File too large to preview' };
+      }
+
+      const contents = await fs.readFile(abs, 'utf8');
+      return { success: true, data: contents };
+    } catch (error) {
+      return { success: false, error: String(error) };
+    }
+  });
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -10,6 +10,7 @@ import { registerRtkIpc } from './rtkIpc';
 import { registerTelemetryIpc } from './telemetryIpc';
 import { registerSkillsIpc } from './skillsIpc';
 import { registerSessionIpc } from './sessionIpc';
+import { registerFileIpc } from './fileIpc';
 
 export function registerAllIpc(): void {
   registerAppIpc();
@@ -24,4 +25,5 @@ export function registerAllIpc(): void {
   registerTelemetryIpc();
   registerSkillsIpc();
   registerSessionIpc();
+  registerFileIpc();
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -201,6 +201,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('git:getDiff', args),
   gitGetDiffUntracked: (args: { cwd: string; filePath: string; contextLines?: number }) =>
     ipcRenderer.invoke('git:getDiffUntracked', args),
+  readFileText: (args: { cwd: string; filePath: string }) =>
+    ipcRenderer.invoke('file:readText', args),
   gitStageFile: (args: { cwd: string; filePath: string }) =>
     ipcRenderer.invoke('git:stageFile', args),
   gitStageAll: (cwd: string) => ipcRenderer.invoke('git:stageAll', cwd),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2126,6 +2126,7 @@ export function App() {
           diff={diffResult}
           loading={diffLoading}
           activeTaskId={activeTaskId}
+          taskPath={activeTask?.path ?? ''}
           onClose={() => {
             setShowDiff(false);
             setDiffResult(null);

--- a/src/renderer/components/DiffViewer.tsx
+++ b/src/renderer/components/DiffViewer.tsx
@@ -545,203 +545,203 @@ export function DiffViewer({ diff, loading, activeTaskId, taskPath, onClose }: D
             )
           ) : (
             <>
-          <div
-            ref={contentRef}
-            className="h-full overflow-auto font-mono text-[12px] leading-[20px] relative"
-          >
-            {loading && (
-              <div className="flex items-center justify-center h-full">
-                <div className="flex items-center gap-3">
-                  <div className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
-                  <span className="text-[13px] text-muted-foreground/50">Loading diff...</span>
-                </div>
-              </div>
-            )}
-
-            {diff?.isBinary && (
-              <div className="flex items-center justify-center h-full">
-                <span className="text-[13px] text-muted-foreground/40">
-                  Binary file — cannot display diff
-                </span>
-              </div>
-            )}
-
-            {diff && !diff.isBinary && diff.hunks.length === 0 && (
-              <div className="flex items-center justify-center h-full">
-                <span className="text-[13px] text-muted-foreground/40">No differences</span>
-              </div>
-            )}
-
-            {diff && !diff.isBinary && diff.hunks.length > 0 && (
-              <div className="inline-block min-w-full">
-                {diff.hunks.map((hunk, hi) => (
-                  <div key={hi}>
-                    {/* Hunk header */}
-                    <div className="diff-hunk px-5 py-1.5 text-[hsl(var(--git-renamed))]/70 border-y border-border/20 sticky top-0 backdrop-blur-sm text-[11px]">
-                      {hunk.header}
-                    </div>
-
-                    {/* Lines */}
-                    {hunk.lines.map((line, li) => {
-                      const isAdd = line.type === 'add';
-                      const isDel = line.type === 'delete';
-                      const selected = isLineInSelection(hi, li);
-                      const commented = isLineCommented(hi, li);
-                      const commentStart = isFirstLineOfComment(hi, li);
-
-                      return (
-                        <div
-                          key={`${hi}-${li}`}
-                          data-hunk={hi}
-                          data-line={li}
-                          className={[
-                            'flex',
-                            selected
-                              ? 'diff-line-selected'
-                              : isAdd
-                                ? 'diff-add'
-                                : isDel
-                                  ? 'diff-delete'
-                                  : '',
-                            commented && !selected ? 'diff-line-commented' : '',
-                            'transition-colors duration-75',
-                          ].join(' ')}
-                        >
-                          {/* Comment indicator */}
-                          {commentStart && !selected && (
-                            <span className="w-0 relative">
-                              <MessageSquare
-                                size={10}
-                                strokeWidth={2}
-                                className="absolute -left-0.5 top-[5px] text-primary/60"
-                              />
-                            </span>
-                          )}
-
-                          {/* Old line number */}
-                          <span
-                            className="w-14 flex-shrink-0 text-right pr-3 text-muted-foreground/20 select-none border-r border-border/10 tabular-nums diff-gutter-clickable"
-                            onMouseDown={(e) => handleGutterMouseDown(e, hi, li)}
-                          >
-                            {line.oldLineNumber ?? ''}
-                          </span>
-                          {/* New line number */}
-                          <span
-                            className="w-14 flex-shrink-0 text-right pr-3 text-muted-foreground/20 select-none border-r border-border/10 tabular-nums diff-gutter-clickable"
-                            onMouseDown={(e) => handleGutterMouseDown(e, hi, li)}
-                          >
-                            {line.newLineNumber ?? ''}
-                          </span>
-                          {/* Marker */}
-                          <span
-                            className={`w-8 flex-shrink-0 text-center select-none ${
-                              isAdd
-                                ? 'text-[hsl(var(--git-added))]/60'
-                                : isDel
-                                  ? 'text-[hsl(var(--git-deleted))]/60'
-                                  : 'text-muted-foreground/15'
-                            }`}
-                          >
-                            {isAdd ? '+' : isDel ? '-' : ' '}
-                          </span>
-                          {/* Content */}
-                          <span
-                            className={`flex-1 pr-5 whitespace-pre ${
-                              isAdd
-                                ? 'text-[hsl(var(--git-added))]/80'
-                                : isDel
-                                  ? 'text-[hsl(var(--git-deleted))]/80'
-                                  : 'text-foreground/70'
-                            }`}
-                          >
-                            {line.content}
-                          </span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {/* Comment popover */}
-            {popover && (
               <div
-                ref={popoverRef}
-                className="absolute z-10 w-[320px] bg-card border border-border/60 rounded-lg shadow-xl shadow-black/30 overflow-hidden animate-scale-in"
-                style={{ top: popover.top, left: Math.max(8, popover.left) }}
+                ref={contentRef}
+                className="h-full overflow-auto font-mono text-[12px] leading-[20px] relative"
               >
-                <div className="p-3">
-                  <textarea
-                    ref={textareaRef}
-                    value={popoverText}
-                    onChange={(e) => setPopoverText(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && e.metaKey) {
-                        e.preventDefault();
-                        handleAddComment();
-                      }
-                      if (e.key === 'Escape') {
-                        e.preventDefault();
-                        handleCancelComment();
-                      }
-                    }}
-                    placeholder="Add a comment..."
-                    rows={3}
-                    className="w-full text-[12px] bg-background/60 border border-border/60 rounded-md px-2.5 py-1.5 resize-none placeholder:text-muted-foreground/30 focus:outline-none focus:border-primary/40 font-sans"
-                  />
-                  <div className="flex gap-2 justify-end mt-2">
-                    <button
-                      onClick={handleCancelComment}
-                      className="px-3 py-1.5 rounded-md text-[11px] text-muted-foreground/60 hover:text-foreground hover:bg-accent/60 transition-all duration-150"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      onClick={handleAddComment}
-                      disabled={!popoverText.trim()}
-                      className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-primary/15 text-primary hover:bg-primary/25 disabled:opacity-30 disabled:cursor-not-allowed transition-all duration-150"
-                    >
-                      Add comment
-                    </button>
+                {loading && (
+                  <div className="flex items-center justify-center h-full">
+                    <div className="flex items-center gap-3">
+                      <div className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+                      <span className="text-[13px] text-muted-foreground/50">Loading diff...</span>
+                    </div>
                   </div>
-                </div>
-              </div>
-            )}
-          </div>
+                )}
 
-          {/* Scrollbar change minimap */}
-          {diff && !diff.isBinary && changeMarkers.length > 0 && (
-            <div
-              className="absolute right-0 top-0 bottom-0 w-[8px] z-20 pointer-events-auto"
-              onClick={(e) => {
-                if (!contentRef.current) return;
-                const rect = e.currentTarget.getBoundingClientRect();
-                const ratio = (e.clientY - rect.top) / rect.height;
-                contentRef.current.scrollTop =
-                  ratio * (contentRef.current.scrollHeight - contentRef.current.clientHeight);
-              }}
-            >
-              {changeMarkers.map((marker, i) => (
+                {diff?.isBinary && (
+                  <div className="flex items-center justify-center h-full">
+                    <span className="text-[13px] text-muted-foreground/40">
+                      Binary file — cannot display diff
+                    </span>
+                  </div>
+                )}
+
+                {diff && !diff.isBinary && diff.hunks.length === 0 && (
+                  <div className="flex items-center justify-center h-full">
+                    <span className="text-[13px] text-muted-foreground/40">No differences</span>
+                  </div>
+                )}
+
+                {diff && !diff.isBinary && diff.hunks.length > 0 && (
+                  <div className="inline-block min-w-full">
+                    {diff.hunks.map((hunk, hi) => (
+                      <div key={hi}>
+                        {/* Hunk header */}
+                        <div className="diff-hunk px-5 py-1.5 text-[hsl(var(--git-renamed))]/70 border-y border-border/20 sticky top-0 backdrop-blur-sm text-[11px]">
+                          {hunk.header}
+                        </div>
+
+                        {/* Lines */}
+                        {hunk.lines.map((line, li) => {
+                          const isAdd = line.type === 'add';
+                          const isDel = line.type === 'delete';
+                          const selected = isLineInSelection(hi, li);
+                          const commented = isLineCommented(hi, li);
+                          const commentStart = isFirstLineOfComment(hi, li);
+
+                          return (
+                            <div
+                              key={`${hi}-${li}`}
+                              data-hunk={hi}
+                              data-line={li}
+                              className={[
+                                'flex',
+                                selected
+                                  ? 'diff-line-selected'
+                                  : isAdd
+                                    ? 'diff-add'
+                                    : isDel
+                                      ? 'diff-delete'
+                                      : '',
+                                commented && !selected ? 'diff-line-commented' : '',
+                                'transition-colors duration-75',
+                              ].join(' ')}
+                            >
+                              {/* Comment indicator */}
+                              {commentStart && !selected && (
+                                <span className="w-0 relative">
+                                  <MessageSquare
+                                    size={10}
+                                    strokeWidth={2}
+                                    className="absolute -left-0.5 top-[5px] text-primary/60"
+                                  />
+                                </span>
+                              )}
+
+                              {/* Old line number */}
+                              <span
+                                className="w-14 flex-shrink-0 text-right pr-3 text-muted-foreground/20 select-none border-r border-border/10 tabular-nums diff-gutter-clickable"
+                                onMouseDown={(e) => handleGutterMouseDown(e, hi, li)}
+                              >
+                                {line.oldLineNumber ?? ''}
+                              </span>
+                              {/* New line number */}
+                              <span
+                                className="w-14 flex-shrink-0 text-right pr-3 text-muted-foreground/20 select-none border-r border-border/10 tabular-nums diff-gutter-clickable"
+                                onMouseDown={(e) => handleGutterMouseDown(e, hi, li)}
+                              >
+                                {line.newLineNumber ?? ''}
+                              </span>
+                              {/* Marker */}
+                              <span
+                                className={`w-8 flex-shrink-0 text-center select-none ${
+                                  isAdd
+                                    ? 'text-[hsl(var(--git-added))]/60'
+                                    : isDel
+                                      ? 'text-[hsl(var(--git-deleted))]/60'
+                                      : 'text-muted-foreground/15'
+                                }`}
+                              >
+                                {isAdd ? '+' : isDel ? '-' : ' '}
+                              </span>
+                              {/* Content */}
+                              <span
+                                className={`flex-1 pr-5 whitespace-pre ${
+                                  isAdd
+                                    ? 'text-[hsl(var(--git-added))]/80'
+                                    : isDel
+                                      ? 'text-[hsl(var(--git-deleted))]/80'
+                                      : 'text-foreground/70'
+                                }`}
+                              >
+                                {line.content}
+                              </span>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* Comment popover */}
+                {popover && (
+                  <div
+                    ref={popoverRef}
+                    className="absolute z-10 w-[320px] bg-card border border-border/60 rounded-lg shadow-xl shadow-black/30 overflow-hidden animate-scale-in"
+                    style={{ top: popover.top, left: Math.max(8, popover.left) }}
+                  >
+                    <div className="p-3">
+                      <textarea
+                        ref={textareaRef}
+                        value={popoverText}
+                        onChange={(e) => setPopoverText(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' && e.metaKey) {
+                            e.preventDefault();
+                            handleAddComment();
+                          }
+                          if (e.key === 'Escape') {
+                            e.preventDefault();
+                            handleCancelComment();
+                          }
+                        }}
+                        placeholder="Add a comment..."
+                        rows={3}
+                        className="w-full text-[12px] bg-background/60 border border-border/60 rounded-md px-2.5 py-1.5 resize-none placeholder:text-muted-foreground/30 focus:outline-none focus:border-primary/40 font-sans"
+                      />
+                      <div className="flex gap-2 justify-end mt-2">
+                        <button
+                          onClick={handleCancelComment}
+                          className="px-3 py-1.5 rounded-md text-[11px] text-muted-foreground/60 hover:text-foreground hover:bg-accent/60 transition-all duration-150"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          onClick={handleAddComment}
+                          disabled={!popoverText.trim()}
+                          className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-primary/15 text-primary hover:bg-primary/25 disabled:opacity-30 disabled:cursor-not-allowed transition-all duration-150"
+                        >
+                          Add comment
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Scrollbar change minimap */}
+              {diff && !diff.isBinary && changeMarkers.length > 0 && (
                 <div
-                  key={i}
-                  className={
-                    marker.type === 'add'
-                      ? 'bg-[hsl(var(--git-added))]'
-                      : 'bg-[hsl(var(--git-deleted))]'
-                  }
-                  style={{
-                    position: 'absolute',
-                    top: `${marker.position * 100}%`,
-                    left: 0,
-                    right: 0,
-                    height: `max(2px, ${marker.span * 100}%)`,
-                    opacity: 0.7,
+                  className="absolute right-0 top-0 bottom-0 w-[8px] z-20 pointer-events-auto"
+                  onClick={(e) => {
+                    if (!contentRef.current) return;
+                    const rect = e.currentTarget.getBoundingClientRect();
+                    const ratio = (e.clientY - rect.top) / rect.height;
+                    contentRef.current.scrollTop =
+                      ratio * (contentRef.current.scrollHeight - contentRef.current.clientHeight);
                   }}
-                />
-              ))}
-            </div>
-          )}
+                >
+                  {changeMarkers.map((marker, i) => (
+                    <div
+                      key={i}
+                      className={
+                        marker.type === 'add'
+                          ? 'bg-[hsl(var(--git-added))]'
+                          : 'bg-[hsl(var(--git-deleted))]'
+                      }
+                      style={{
+                        position: 'absolute',
+                        top: `${marker.position * 100}%`,
+                        left: 0,
+                        right: 0,
+                        height: `max(2px, ${marker.span * 100}%)`,
+                        opacity: 0.7,
+                      }}
+                    />
+                  ))}
+                </div>
+              )}
             </>
           )}
         </div>

--- a/src/renderer/components/DiffViewer.tsx
+++ b/src/renderer/components/DiffViewer.tsx
@@ -532,7 +532,7 @@ export function DiffViewer({ diff, loading, activeTaskId, taskPath, onClose }: D
 
         {/* Content */}
         <div className="flex-1 relative overflow-hidden">
-          {mode === 'preview' ? (
+          {isHtml && mode === 'preview' ? (
             previewLoading || previewContent === null ? (
               <div className="flex items-center justify-center h-full">
                 <div className="flex items-center gap-3">

--- a/src/renderer/components/DiffViewer.tsx
+++ b/src/renderer/components/DiffViewer.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useRef, useMemo, useEffect, useCallback } from 'react';
-import { X, FileText, MessageSquare, Send } from 'lucide-react';
+import { X, FileText, MessageSquare, Send, Code2, Eye } from 'lucide-react';
 import type { DiffResult, DiffLine, DiffHunk } from '../../shared/types';
 import { sessionRegistry } from '../terminal/SessionRegistry';
+import { HtmlPreview } from './HtmlPreview';
 
 // ── Internal Types ──────────────────────────────────────────
 
@@ -67,6 +68,7 @@ function getLanguageFromPath(filePath: string): string {
     css: 'css',
     scss: 'scss',
     html: 'html',
+    htm: 'html',
     json: 'json',
     yaml: 'yaml',
     yml: 'yaml',
@@ -175,11 +177,15 @@ interface DiffViewerProps {
   diff: DiffResult | null;
   loading: boolean;
   activeTaskId: string | null;
+  taskPath: string;
   onClose: () => void;
 }
 
-export function DiffViewer({ diff, loading, activeTaskId, onClose }: DiffViewerProps) {
+export function DiffViewer({ diff, loading, activeTaskId, taskPath, onClose }: DiffViewerProps) {
   const [comments, setComments] = useState<DiffComment[]>([]);
+  const [mode, setMode] = useState<'code' | 'preview'>('code');
+  const [previewContent, setPreviewContent] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
   const [selection, setSelection] = useState<SelectionState | null>(null);
   const [popover, setPopover] = useState<PopoverState | null>(null);
   const [popoverText, setPopoverText] = useState('');
@@ -196,6 +202,37 @@ export function DiffViewer({ diff, loading, activeTaskId, onClose }: DiffViewerP
     () => (diff?.hunks ? buildChangeMarkers(diff.hunks) : []),
     [diff?.hunks],
   );
+
+  const isHtml = !!diff && getLanguageFromPath(diff.filePath) === 'html';
+
+  // Reset to source view and clear cached preview whenever a new file opens.
+  useEffect(() => {
+    setMode('code');
+    setPreviewContent(null);
+    setPreviewLoading(false);
+  }, [diff?.filePath]);
+
+  // Lazily load the full on-disk file content when entering preview mode.
+  useEffect(() => {
+    if (mode !== 'preview' || !diff || previewContent !== null || previewLoading) return;
+    let cancelled = false;
+    setPreviewLoading(true);
+    window.electronAPI
+      .readFileText({ cwd: taskPath, filePath: diff.filePath })
+      .then((res) => {
+        if (cancelled) return;
+        setPreviewContent(res.success && res.data != null ? res.data : '');
+      })
+      .catch(() => {
+        if (!cancelled) setPreviewContent('');
+      })
+      .finally(() => {
+        if (!cancelled) setPreviewLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, diff, taskPath, previewContent, previewLoading]);
 
   // ── Selection helpers ───────────────────────────────────
 
@@ -449,6 +486,32 @@ export function DiffViewer({ diff, loading, activeTaskId, onClose }: DiffViewerP
           </div>
 
           <div className="flex items-center gap-2">
+            {isHtml && (
+              <div className="flex items-center gap-0.5 p-0.5 rounded-full bg-[hsl(var(--surface-3))]">
+                <button
+                  onClick={() => setMode('code')}
+                  className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-medium transition-all duration-150 ${
+                    mode === 'code'
+                      ? 'bg-primary/15 text-primary'
+                      : 'text-muted-foreground/60 hover:text-foreground'
+                  }`}
+                >
+                  <Code2 size={11} strokeWidth={2} />
+                  Code
+                </button>
+                <button
+                  onClick={() => setMode('preview')}
+                  className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-medium transition-all duration-150 ${
+                    mode === 'preview'
+                      ? 'bg-primary/15 text-primary'
+                      : 'text-muted-foreground/60 hover:text-foreground'
+                  }`}
+                >
+                  <Eye size={11} strokeWidth={2} />
+                  Preview
+                </button>
+              </div>
+            )}
             {comments.length > 0 && (
               <button
                 onClick={handleAddToPrompt}
@@ -469,6 +532,19 @@ export function DiffViewer({ diff, loading, activeTaskId, onClose }: DiffViewerP
 
         {/* Content */}
         <div className="flex-1 relative overflow-hidden">
+          {mode === 'preview' ? (
+            previewLoading || previewContent === null ? (
+              <div className="flex items-center justify-center h-full">
+                <div className="flex items-center gap-3">
+                  <div className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+                  <span className="text-[13px] text-muted-foreground/50">Loading preview...</span>
+                </div>
+              </div>
+            ) : (
+              <HtmlPreview html={previewContent} />
+            )
+          ) : (
+            <>
           <div
             ref={contentRef}
             className="h-full overflow-auto font-mono text-[12px] leading-[20px] relative"
@@ -665,6 +741,8 @@ export function DiffViewer({ diff, loading, activeTaskId, onClose }: DiffViewerP
                 />
               ))}
             </div>
+          )}
+            </>
           )}
         </div>
       </div>

--- a/src/renderer/components/HtmlPreview.tsx
+++ b/src/renderer/components/HtmlPreview.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface HtmlPreviewProps {
+  html: string;
+}
+
+/**
+ * Render an HTML string in a sandboxed iframe via `srcDoc`. The sandbox grants
+ * scripts/forms/popups but deliberately omits `allow-same-origin`, so the
+ * preview cannot reach the app's origin, storage, or `window.electronAPI`.
+ * Relative asset references won't resolve (no base URL) — self-contained pages
+ * with inline or absolute/CDN resources render as expected.
+ */
+export function HtmlPreview({ html }: HtmlPreviewProps) {
+  return (
+    <iframe
+      title="HTML preview"
+      srcDoc={html}
+      sandbox="allow-scripts allow-popups allow-forms allow-modals"
+      className="w-full h-full border-0 bg-white"
+    />
+  );
+}

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -244,6 +244,7 @@ export interface ElectronAPI {
     filePath: string;
     contextLines?: number;
   }) => Promise<IpcResponse<DiffResult>>;
+  readFileText: (args: { cwd: string; filePath: string }) => Promise<IpcResponse<string>>;
   gitStageFile: (args: { cwd: string; filePath: string }) => Promise<IpcResponse<void>>;
   gitStageAll: (cwd: string) => Promise<IpcResponse<void>>;
   gitUnstageFile: (args: { cwd: string; filePath: string }) => Promise<IpcResponse<void>>;


### PR DESCRIPTION
## What

When Claude creates or edits an `.html`/`.htm` file, the file-view modal (`DiffViewer`) now has a **Code | Preview** toggle in its header. Preview renders the live page so users can see the result, not just the source.

Previously, clicking a changed file only ever showed a unified diff — there was no way to see an HTML file rendered.

## How

- **New `file:readText` IPC handler** (`src/main/ipc/fileIpc.ts`) — the diff only carries hunks, so preview loads the full on-disk content. Includes a path-traversal guard (resolved path must stay inside the worktree) and a 5 MB size cap.
- **`HtmlPreview` component** — renders the HTML in a sandboxed `<iframe srcDoc>` with `sandbox="allow-scripts allow-popups allow-forms allow-modals"`. No `allow-same-origin`, so the preview is isolated from the app origin and cannot reach `window.electronAPI` or app storage.
- **`DiffViewer`** — gains a `taskPath` prop, HTML detection (reuses `getLanguageFromPath`, added `htm`), the segmented toggle (HTML files only), lazy content fetch on first preview, and a body switch between diff and preview. Defaults to Code; resets when a new file opens.

## Notes / limitations

- Self-contained by design: inline styles/scripts and absolute/CDN URLs render; relative `./asset` references won't resolve (no base URL). Fits the typical single-file HTML Claude generates.
- No Electron security changes — `<webview>` stays disabled; a sandboxed iframe is the right primitive.

## Test plan

- [ ] Create a self-contained HTML file in a task; click it in the changed-files panel → modal opens in **Code** mode showing the diff.
- [ ] Click **Preview** → page renders in the sandboxed iframe; toggle back to **Code** → diff + comment selection still work.
- [ ] Non-HTML files show **no** toggle.
- [ ] Path guard rejects paths outside the worktree and files over the size cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)