### PR TITLE
Add X-High and Max effort levels to settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -509,13 +509,15 @@ function ClaudeCodeTab({
       {/* Effort Level */}
       <div>
         <label className="block text-[12px] font-medium text-foreground mb-3">Effort Level</label>
-        <div className="grid grid-cols-4 gap-2">
+        <div className="grid grid-cols-3 gap-2">
           {(
             [
               { value: 'auto', label: 'Auto' },
               { value: 'low', label: 'Low' },
               { value: 'medium', label: 'Medium' },
               { value: 'high', label: 'High' },
+              { value: 'xhigh', label: 'X-High' },
+              { value: 'max', label: 'Max' },
             ] as const
           ).map(({ value, label }) => {
             const isActive = effortLevel === value;
@@ -535,7 +537,9 @@ function ClaudeCodeTab({
           })}
         </div>
         <p className="text-[10px] text-foreground/80 mt-2">
-          Controls how much effort Claude spends reasoning. Auto lets the model decide.
+          Controls how much effort Claude spends reasoning. Auto lets the model decide. X-High and
+          Max apply on newer models (e.g. Opus 4.8); others fall back to their highest supported
+          level.
         </p>
       </div>
 


### PR DESCRIPTION
## What

Extends the **Effort Level** selector (Settings → Claude Code) with the two higher levels — **X-High** (`xhigh`) and **Max** (`max`) — that newer models support (Opus 4.8, Fable 5, Opus 4.7). The selector goes from Auto/Low/Medium/High to the full range: Auto / Low / Medium / High / X-High / Max.

The effort feature itself already exists (defaults to `auto`, remembers the choice in `localStorage`, applies it via the `CLAUDE_CODE_EFFORT_LEVEL` env var passed to the spawned `claude` process). This PR only adds the two missing levels.

## Why

Per the [Claude Code model-config docs](https://code.claude.com/docs/en/model-config), Opus 4.8 / Fable 5 / Opus 4.7 support `low, medium, high, xhigh, max`. The UI previously capped at `high`, so users couldn't select the top two on models that support them.

`CLAUDE_CODE_EFFORT_LEVEL` (the mechanism Dash already uses) accepts `xhigh` and `max`, and the persistence/sync path is value-agnostic — so no changes were needed beyond the option list.

## Implementation

- `SettingsModal.tsx`: add `xhigh` (label "X-High") and `max` (label "Max") to the effort option list; switch the grid to `grid-cols-3` (two clean rows of three); helper text notes that models which don't support a level fall back to their highest supported one.

## Not included: ultracode

`ultracode` is intentionally **not** added to this selector. Per the docs it's a session-only *mode* (sends `xhigh` **and** orchestrates multi-agent workflows), not a reasoning level — and it cannot be set via `CLAUDE_CODE_EFFORT_LEVEL`, `--effort`, or the `effortLevel` settings key (only via `--settings '{"ultracode": true}'` at launch). If we want it, it belongs as a separate launch toggle, not in the effort buttons.

## Test plan

- [ ] Open Settings → Claude Code → Effort Level; confirm six options render in two rows and selecting X-High or Max highlights correctly.
- [ ] Select Max, reopen the app, confirm the choice persists (localStorage `claudeEffortLevel`).
- [ ] Start a Claude session and confirm `CLAUDE_CODE_EFFORT_LEVEL=max` is in the spawned process env; selecting Auto removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)