### PR TITLE
Add ultracode launch toggle to settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -338,6 +338,15 @@ export function registerAppIpc(): void {
     }
   });
 
+  ipcMain.on('app:setUltracode', async (_event, enabled: boolean) => {
+    try {
+      const { setUltracode } = await import('../services/ptyManager');
+      setUltracode(enabled);
+    } catch (err) {
+      console.error('[app:setUltracode] Failed:', err);
+    }
+  });
+
   ipcMain.handle('app:detectClaude', async () => {
     try {
       // Import cached result from main

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -156,6 +156,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setClaudeEnvVars: (vars: Record<string, string>) =>
     ipcRenderer.send('app:setClaudeEnvVars', vars),
   setSyncShellEnv: (enabled: boolean) => ipcRenderer.send('app:setSyncShellEnv', enabled),
+  setUltracode: (enabled: boolean) => ipcRenderer.send('app:setUltracode', enabled),
   getClaudeAttribution: (projectPath?: string) =>
     ipcRenderer.invoke('app:getClaudeAttribution', projectPath),
 

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -73,6 +73,12 @@ let claudeEnvVars: Record<string, string> = {};
 // When true, inherit the full parent process.env as a base instead of the minimal set.
 let syncShellEnv = false;
 
+// When true, launch Claude sessions with ultracode (xhigh reasoning + workflow
+// orchestration) via `--settings '{"ultracode":true}'`. ultracode is session-only
+// and can't be set through CLAUDE_CODE_EFFORT_LEVEL or --effort, so it's applied
+// per-spawn here rather than through the effort env var.
+let ultracode = false;
+
 const RESERVED_ENV_KEYS = new Set([
   'PATH',
   'HOME',
@@ -129,6 +135,10 @@ export function setClaudeEnvVars(vars: Record<string, string>): void {
 
 export function setSyncShellEnv(enabled: boolean): void {
   syncShellEnv = enabled;
+}
+
+export function setUltracode(enabled: boolean): void {
+  ultracode = enabled;
 }
 
 // Lazy-load node-pty to avoid native binding issues at startup
@@ -715,6 +725,13 @@ export async function startDirectPty(options: {
   if (options.autoApprove) {
     args.push('--dangerously-skip-permissions');
   }
+
+  // ultracode is session-scoped; re-apply it on every spawn so the user's
+  // toggle effectively sticks across the sessions Dash launches.
+  if (ultracode) {
+    args.push('--settings', JSON.stringify({ ultracode: true }));
+  }
+
   const env = buildDirectEnv(options.isDark ?? true);
 
   writeHookSettings(options.cwd, options.id);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -173,6 +173,9 @@ export function App() {
   const [syncShellEnv, setSyncShellEnv] = useState(() => {
     return localStorage.getItem('syncShellEnv') === 'true';
   });
+  const [ultracode, setUltracode] = useState(() => {
+    return localStorage.getItem('ultracode') === 'true';
+  });
   const [customClaudeEnvVars, setCustomClaudeEnvVars] = useState<Record<string, string>>(() => {
     try {
       return JSON.parse(localStorage.getItem('customClaudeEnvVars') || '{}');
@@ -257,6 +260,10 @@ export function App() {
   useEffect(() => {
     window.electronAPI.setSyncShellEnv?.(syncShellEnv);
   }, [syncShellEnv]);
+  // Sync ultracode toggle to main process (applied as a spawn arg)
+  useEffect(() => {
+    window.electronAPI.setUltracode?.(ultracode);
+  }, [ultracode]);
   // Sync Claude Code env vars to main process
   useEffect(() => {
     const vars: Record<string, string> = { ...customClaudeEnvVars };
@@ -2013,6 +2020,11 @@ export function App() {
           onSyncShellEnvChange={(v) => {
             setSyncShellEnv(v);
             localStorage.setItem('syncShellEnv', String(v));
+          }}
+          ultracode={ultracode}
+          onUltracodeChange={(v) => {
+            setUltracode(v);
+            localStorage.setItem('ultracode', String(v));
           }}
           customClaudeEnvVars={customClaudeEnvVars}
           onCustomClaudeEnvVarsChange={(v) => {

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -82,6 +82,8 @@ interface SettingsModalProps {
   onEffortLevelChange: (value: string) => void;
   syncShellEnv: boolean;
   onSyncShellEnvChange: (value: boolean) => void;
+  ultracode: boolean;
+  onUltracodeChange: (value: boolean) => void;
   customClaudeEnvVars: Record<string, string>;
   onCustomClaudeEnvVarsChange: (value: Record<string, string>) => void;
   activeProjectPath?: string;
@@ -421,6 +423,8 @@ function ClaudeCodeTab({
   onEffortLevelChange,
   syncShellEnv,
   onSyncShellEnvChange,
+  ultracode,
+  onUltracodeChange,
   customEnvVars,
   onCustomEnvVarsChange,
   claudeInfo,
@@ -429,6 +433,8 @@ function ClaudeCodeTab({
   onEffortLevelChange: (v: string) => void;
   syncShellEnv: boolean;
   onSyncShellEnvChange: (v: boolean) => void;
+  ultracode: boolean;
+  onUltracodeChange: (v: boolean) => void;
   customEnvVars: Record<string, string>;
   onCustomEnvVarsChange: (v: Record<string, string>) => void;
   claudeInfo: { installed: boolean; version: string | null; path: string | null } | null;
@@ -540,6 +546,21 @@ function ClaudeCodeTab({
           Controls how much effort Claude spends reasoning. Auto lets the model decide. X-High and
           Max apply on newer models (e.g. Opus 4.8); others fall back to their highest supported
           level.
+        </p>
+      </div>
+
+      {/* Ultracode */}
+      <div>
+        <label className="block text-[12px] font-medium text-foreground mb-3">Ultracode</label>
+        <ToggleSwitch
+          enabled={ultracode}
+          onToggle={onUltracodeChange}
+          label="Launch new sessions in ultracode mode"
+        />
+        <p className="text-[10px] text-foreground/80 mt-2">
+          Sends X-High reasoning and has Claude orchestrate multi-agent workflows for substantive
+          tasks. Applied per session via <code>--settings</code>; uses more tokens and runs slower.
+          Effort buttons above don&apos;t control this — ultracode isn&apos;t a saved effort level.
         </p>
       </div>
 
@@ -656,6 +677,8 @@ export function SettingsModal({
   onEffortLevelChange,
   syncShellEnv,
   onSyncShellEnvChange,
+  ultracode,
+  onUltracodeChange,
   customClaudeEnvVars,
   onCustomClaudeEnvVarsChange,
   activeProjectPath,
@@ -1334,6 +1357,8 @@ export function SettingsModal({
               onEffortLevelChange={onEffortLevelChange}
               syncShellEnv={syncShellEnv}
               onSyncShellEnvChange={onSyncShellEnvChange}
+              ultracode={ultracode}
+              onUltracodeChange={onUltracodeChange}
               customEnvVars={customClaudeEnvVars}
               onCustomEnvVarsChange={onCustomClaudeEnvVarsChange}
               claudeInfo={claudeInfo}

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -178,6 +178,7 @@ export interface ElectronAPI {
   setCommitAttribution: (value: string | undefined) => void;
   setClaudeEnvVars: (vars: Record<string, string>) => void;
   setSyncShellEnv: (enabled: boolean) => void;
+  setUltracode: (enabled: boolean) => void;
   getClaudeAttribution: (projectPath?: string) => Promise<IpcResponse<string | null>>;
 
   // GitHub


### PR DESCRIPTION
## What

Adds a per-session **Ultracode** toggle to Settings → Claude Code, separate from the effort-level buttons.

> ⚠️ Stacked on #152 (base branch = `effort-levels-xhigh-max`). Merge #152 first, or merge this after rebasing onto `main`.

## Why it's a separate toggle (not an effort level)

ultracode is a Claude Code **mode**, not a reasoning level: it sends `xhigh` to the model **and** has Claude orchestrate multi-agent workflows for substantive tasks (more tokens, slower). I verified against the docs and the installed CLI (v2.1.181) that it **cannot** be set through the mechanism the effort selector uses:

- `CLAUDE_CODE_EFFORT_LEVEL=ultracode` → silently ignored (no effect)
- `--effort ultracode` → CLI warns *"Unknown --effort value 'ultracode' … Valid values: low, medium, high, xhigh, max"*
- `effortLevel` in settings.json → docs: *"`max` and `ultracode` are session-only and are not accepted here"*

The **only** non-interactive mechanism is `--settings '{"ultracode": true}'` at launch (docs: *"pass `\"ultracode\": true` via `--settings`…"*). It's also session-only and can't be a saved default — so the toggle re-applies it on every spawn, which makes the choice effectively stick across the sessions Dash launches.

## Implementation

Mirrors the existing `syncShellEnv` boolean-setting pattern end-to-end:

- `ptyManager.ts`: new `ultracode` module flag + `setUltracode()`; `startDirectPty` appends `--settings '{"ultracode":true}'` to the spawn args when enabled.
- `appIpc.ts` / `preload.ts` / `electron-api.d.ts`: `app:setUltracode` IPC + `setUltracode` bridge/type.
- `App.tsx`: `ultracode` state persisted in `localStorage`, synced to main on change.
- `SettingsModal.tsx`: a `ToggleSwitch` under the effort buttons with copy explaining it's xhigh + workflows, applied per session, and not controlled by the effort buttons.

## Verification

- `pnpm type-check` ✓, `pnpm build` ✓, Prettier/ESLint (pre-commit) ✓.
- Ran the exact argv the code builds: `claude --settings '{"ultracode":true}' --print "say ok"` → returns cleanly with **no** warning (vs. `--effort ultracode`, which warns), confirming the right mechanism.

Note: a one-shot `--print` can't surface the workflow-orchestration behavior, so this confirms the flag is accepted as documented but doesn't visually demonstrate workflows firing.

## Test plan

- [ ] Settings → Claude Code → toggle Ultracode on; confirm it persists across app restart (localStorage `ultracode`).
- [ ] Start a new task session and confirm the spawned `claude` process args include `--settings {"ultracode":true}`; toggle off → arg absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)