### PR TITLE
Fix notarization 401 by restoring hard-coded APPLE_TEAM_ID

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_TEAM_ID: 2DD8ZKZ975
         run: |
           DMG_PATH=$(ls release/*.dmg 2>/dev/null | head -1)
           if [ -z "$DMG_PATH" ]; then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",


### PR DESCRIPTION
## Problem

CI's `build-mac` → **Notarize** step fails with:

```
Error: HTTP status code: 401. Invalid credentials. Username or password is incorrect.
```

(See run [27988505578](https://github.com/syv-ai/dash/actions/runs/27988505578).)

## Root cause

Signing succeeds — electron-builder signs `Dash.app` fine via `CSC_LINK`. But `xcrun notarytool submit` authenticates the Apple ID + app-specific password **scoped to a team ID**. `APPLE_TEAM_ID` had been switched from the literal `2DD8ZKZ975` to `${{ secrets.APPLE_TEAM_ID }}`, which is unset/incorrect in the repo, so notary auth returns a 401.

## Fix

Restore the known-good literal team ID that was in place when notarization last worked (commit `4d3695d`). A team ID is not sensitive — it's embedded in every distributed signed app — so hard-coding it is fine. `APPLE_ID` and `APPLE_APP_SPECIFIC_PASSWORD` remain secrets, which is correct.

> Note: notarization only runs on push to `main` (the mac build is gated to `github.event_name != 'pull_request'`), so this PR won't exercise the fix until merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)