### PR TITLE
chore(gitignore): track docs/, keep scratch plans local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ release/
 .claude/settings.local.json.tmp-*
 .claude/task-context.json
 claude.local.md
-docs/
+docs/plans/
 state.md
 .superpowers/
 mockups/sidebar/


### PR DESCRIPTION
`docs/` was blanket-ignored, which blocked real documentation from being committed (only `docs/screenshot.png` is tracked, via a force-add). This narrows the ignore to `docs/plans/` — the local scratch planning area (e.g. existing `docs/plans/2026-06-21-task-from-pr.md`) — so the rest of `docs/` can be tracked going forward while planning scratch stays local.

One line:
```diff
-docs/
+docs/plans/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)