### PR TITLE
chore(deps): tier 1 — drizzle-orm 0.32 → 0.45

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@xterm/headless": "^5.5.0",
     "better-sqlite3": "^12.4.1",
     "cmdk": "^1.1.1",
-    "drizzle-orm": "^0.32.0",
+    "drizzle-orm": "^0.45.2",
     "electron-log": "^5.4.4",
     "electron-updater": "^6.8.9",
     "marked": "^18.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       drizzle-orm:
-        specifier: ^0.32.0
-        version: 0.32.2(@types/better-sqlite3@7.6.13)(@types/react@18.3.31)(better-sqlite3@12.11.1)(react@18.3.1)
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)
       electron-log:
         specifier: ^5.4.4
         version: 5.4.4
@@ -1757,35 +1757,36 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
-  drizzle-orm@0.32.2:
-    resolution: {integrity: sha512-3fXKzPzrgZIcnWCSLiERKN5Opf9Iagrag75snfFlKeKSYB1nlgPBshzW3Zn6dQymkyiib+xc4nIz0t8U+Xdpuw==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
-      '@cloudflare/workers-types': '>=3'
-      '@electric-sql/pglite': '>=0.1.1'
-      '@libsql/client': '*'
-      '@neondatabase/serverless': '>=0.1'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
       '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1'
+      '@planetscale/database': '>=1.13'
       '@prisma/client': '*'
       '@tidbcloud/serverless': '*'
       '@types/better-sqlite3': '*'
       '@types/pg': '*'
-      '@types/react': '>=18'
       '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
       better-sqlite3: '>=7'
       bun-types: '*'
-      expo-sqlite: '>=13.2.0'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
       knex: '*'
       kysely: '*'
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
       prisma: '*'
-      react: '>=18'
       sql.js: '>=1'
       sqlite3: '>=5'
     peerDependenciesMeta:
@@ -1796,6 +1797,8 @@ packages:
       '@electric-sql/pglite':
         optional: true
       '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
         optional: true
       '@neondatabase/serverless':
         optional: true
@@ -1813,9 +1816,9 @@ packages:
         optional: true
       '@types/pg':
         optional: true
-      '@types/react':
-        optional: true
       '@types/sql.js':
+        optional: true
+      '@upstash/redis':
         optional: true
       '@vercel/postgres':
         optional: true
@@ -1826,6 +1829,8 @@ packages:
       bun-types:
         optional: true
       expo-sqlite:
+        optional: true
+      gel:
         optional: true
       knex:
         optional: true
@@ -1838,8 +1843,6 @@ packages:
       postgres:
         optional: true
       prisma:
-        optional: true
-      react:
         optional: true
       sql.js:
         optional: true
@@ -5374,12 +5377,10 @@ snapshots:
 
   dotenv@16.6.1: {}
 
-  drizzle-orm@0.32.2(@types/better-sqlite3@7.6.13)(@types/react@18.3.31)(better-sqlite3@12.11.1)(react@18.3.1):
+  drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1):
     optionalDependencies:
       '@types/better-sqlite3': 7.6.13
-      '@types/react': 18.3.31
       better-sqlite3: 12.11.1
-      react: 18.3.1
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
**Tier 1** of the modernization (data layer). Isolated as its own PR for easy review/revert.

Bumps `drizzle-orm` 0.32.2 → **0.45.2** (13 minor versions).

### Why this is low-risk for Dash
Dash uses drizzle-orm **only for the query builder + schema types**. Migrations are **hand-written raw SQL** in `src/main/db/migrate.ts` — not drizzle-kit (which isn't installed, and there's no `drizzle.config.*`). So the usual drizzle upgrade hazards (migration-format changes, `drizzle-kit up`, journal snapshots) **don't apply here**. No code changes were needed.

### Verification (Node 24)
- `pnpm type-check` clean — query/schema API compatible
- `pnpm test` — 831 pass
- drizzle 0.45 runtime smoke under Electron ABI: insert / select / update / `where(eq())` via the better-sqlite3 driver all pass

### Note (out of scope)
The `drizzle:generate` npm script references `drizzle-kit`, which isn't a dependency and has no config — it's effectively dead. Worth removing or wiring up properly in a follow-up, but left untouched here.

Base `integrate-local-main`. Next: Tier 2 (React 19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)