### PR TITLE
Add post-update "what's new" toast linking to GitHub release notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/renderer/components/ui/Toast.tsx
+++ b/src/renderer/components/ui/Toast.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { Toaster, toast } from 'sonner';
 import { useWizardToasts } from '../ports/useWizardToasts';
+import { useReleaseNotesToast } from './useReleaseNotesToast';
 
 interface ToastContainerProps {
   updateNotificationsEnabled: boolean;
@@ -8,6 +9,7 @@ interface ToastContainerProps {
 
 export function ToastContainer({ updateNotificationsEnabled }: ToastContainerProps) {
   useWizardToasts();
+  useReleaseNotesToast();
   const updateNotificationsRef = useRef(updateNotificationsEnabled);
   useEffect(() => {
     updateNotificationsRef.current = updateNotificationsEnabled;

--- a/src/renderer/components/ui/useReleaseNotesToast.ts
+++ b/src/renderer/components/ui/useReleaseNotesToast.ts
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+import { toast } from 'sonner';
+import { useSettings } from '../../stores/settingsStore';
+import { normalizeVersion, releaseUrl, shouldShowReleaseNotes } from '../../utils/releaseNotes';
+
+/**
+ * On the first launch after an update, surface a once-per-version toast linking
+ * to that version's GitHub release notes. "First launch after an update" is
+ * detected by comparing the running version to the last version the user was
+ * shown (persisted in settings) — so it also covers manual .dmg updates, not
+ * just the in-app auto-updater.
+ *
+ * A fresh install (no stored version) catches up silently so it stays quiet,
+ * and `lastSeen` is advanced even when the toast is muted so a muted user isn't
+ * re-evaluated as "new" on every launch.
+ */
+export function useReleaseNotesToast(): void {
+  useEffect(() => {
+    let cancelled = false;
+    void window.electronAPI.getAppVersion().then((current) => {
+      if (cancelled || !current) return;
+      const {
+        lastSeenReleaseNotesVersion,
+        updateNotificationsEnabled,
+        setLastSeenReleaseNotesVersion,
+      } = useSettings.getState();
+
+      // Fresh install: record where we are without nagging about it.
+      if (lastSeenReleaseNotesVersion === undefined) {
+        setLastSeenReleaseNotesVersion(current);
+        return;
+      }
+      if (!shouldShowReleaseNotes(current, lastSeenReleaseNotesVersion)) return;
+
+      setLastSeenReleaseNotesVersion(current);
+      if (!updateNotificationsEnabled) return;
+
+      toast(`Dash updated to v${normalizeVersion(current)}`, {
+        duration: Infinity,
+        action: {
+          label: 'Release notes',
+          onClick: () => {
+            void window.electronAPI.openExternal(releaseUrl(current));
+          },
+        },
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+}

--- a/src/renderer/stores/__tests__/settingsKeys.test.ts
+++ b/src/renderer/stores/__tests__/settingsKeys.test.ts
@@ -108,4 +108,12 @@ describe('settings registry', () => {
     expect(byField.autoUpdateEnabled!.codec.decode('false')).toBe(false);
     expect(byField.updateNotificationsEnabled!.codec.decode(null)).toBe(true);
   });
+
+  it('registers lastSeenReleaseNotesVersion, undefined when absent', () => {
+    const e = SETTINGS_REGISTRY.find((r) => r.field === 'lastSeenReleaseNotesVersion')!;
+    expect(e.key).toBe('lastSeenReleaseNotesVersion');
+    expect(e.codec.decode(null)).toBeUndefined();
+    expect(e.codec.decode('0.13.0')).toBe('0.13.0');
+    expect(e.codec.encode('0.13.0')).toBe('0.13.0');
+  });
 });

--- a/src/renderer/stores/settingsKeys.ts
+++ b/src/renderer/stores/settingsKeys.ts
@@ -48,6 +48,7 @@ export interface SettingsState {
   portsDrawerCollapsed: boolean;
   autoUpdateEnabled: boolean;
   updateNotificationsEnabled: boolean;
+  lastSeenReleaseNotesVersion: string | undefined;
 }
 
 /** One entry per managed setting: the store field, its existing localStorage
@@ -125,6 +126,7 @@ export const SETTINGS_REGISTRY: RegistryEntry[] = [
   entry('portsDrawerCollapsed', 'portsDrawerCollapsed', boolDefaultTrue()),
   entry('autoUpdateEnabled', 'autoUpdateEnabled', boolDefaultTrue()),
   entry('updateNotificationsEnabled', 'updateNotificationsEnabled', boolDefaultTrue()),
+  entry('lastSeenReleaseNotesVersion', 'lastSeenReleaseNotesVersion', strOrUndefined()),
 ];
 
 /** Initial state = every field decoded from an absent key (its default). */

--- a/src/renderer/utils/__tests__/releaseNotes.test.ts
+++ b/src/renderer/utils/__tests__/releaseNotes.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  compareVersions,
+  normalizeVersion,
+  releaseUrl,
+  shouldShowReleaseNotes,
+} from '../releaseNotes';
+
+describe('compareVersions', () => {
+  it('orders by major, then minor, then patch', () => {
+    expect(compareVersions('1.0.0', '0.9.9')).toBe(1);
+    expect(compareVersions('0.13.0', '0.12.9')).toBe(1);
+    expect(compareVersions('0.13.1', '0.13.0')).toBe(1);
+    expect(compareVersions('0.13.0', '0.13.1')).toBe(-1);
+    expect(compareVersions('0.13.0', '0.13.0')).toBe(0);
+  });
+
+  it('tolerates a leading v and the .DEV / pre-release suffix', () => {
+    expect(compareVersions('v0.13.0', '0.13.0')).toBe(0);
+    expect(compareVersions('0.13.0.DEV', '0.13.0')).toBe(0);
+    expect(compareVersions('0.14.0-beta.1', '0.13.0')).toBe(1);
+  });
+
+  it('treats missing or malformed parts as 0', () => {
+    expect(compareVersions('0.13', '0.13.0')).toBe(0);
+    expect(compareVersions('garbage', '0.0.0')).toBe(0);
+    expect(compareVersions('1', '0.99.99')).toBe(1);
+  });
+});
+
+describe('normalizeVersion', () => {
+  it('strips the v prefix and any suffix to a clean major.minor.patch', () => {
+    expect(normalizeVersion('v0.13.0')).toBe('0.13.0');
+    expect(normalizeVersion('0.13.0.DEV')).toBe('0.13.0');
+    expect(normalizeVersion('0.14.0-beta.1')).toBe('0.14.0');
+    expect(normalizeVersion('0.13')).toBe('0.13.0');
+  });
+});
+
+describe('shouldShowReleaseNotes', () => {
+  it('is false on a fresh install (no last-seen version)', () => {
+    expect(shouldShowReleaseNotes('0.13.0', undefined)).toBe(false);
+  });
+
+  it('is true only when the running version is strictly newer', () => {
+    expect(shouldShowReleaseNotes('0.13.0', '0.12.0')).toBe(true);
+    expect(shouldShowReleaseNotes('0.13.0', '0.13.0')).toBe(false);
+    expect(shouldShowReleaseNotes('0.12.0', '0.13.0')).toBe(false);
+  });
+
+  it('ignores a dev .DEV suffix when comparing', () => {
+    expect(shouldShowReleaseNotes('0.13.0.DEV', '0.13.0')).toBe(false);
+    expect(shouldShowReleaseNotes('0.14.0.DEV', '0.13.0')).toBe(true);
+  });
+});
+
+describe('releaseUrl', () => {
+  it('builds the GitHub release tag URL with a normalized version', () => {
+    expect(releaseUrl('0.13.0')).toBe('https://github.com/syv-ai/dash/releases/tag/v0.13.0');
+    expect(releaseUrl('v0.13.0')).toBe('https://github.com/syv-ai/dash/releases/tag/v0.13.0');
+    expect(releaseUrl('0.13.0.DEV')).toBe('https://github.com/syv-ai/dash/releases/tag/v0.13.0');
+  });
+});

--- a/src/renderer/utils/releaseNotes.ts
+++ b/src/renderer/utils/releaseNotes.ts
@@ -1,0 +1,48 @@
+// Logic for the "what's new" toast shown on the first launch after an update.
+// Pure and dependency-free so it can be unit-tested under the node runner.
+
+const RELEASE_TAG_BASE = 'https://github.com/syv-ai/dash/releases/tag';
+
+/** Parse a version into [major, minor, patch]. Tolerates a leading `v`, a
+ *  pre-release/build suffix (`-beta.1`, `+build`), and the dev `.DEV` marker
+ *  (a 4th dotted segment, simply ignored). Missing or non-numeric parts → 0. */
+function parseVersion(version: string): [number, number, number] {
+  const core = version.replace(/^v/i, '').split(/[-+]/)[0]!;
+  const parts = core.split('.');
+  const at = (i: number) => {
+    const n = parseInt(parts[i] ?? '', 10);
+    return Number.isNaN(n) ? 0 : n;
+  };
+  return [at(0), at(1), at(2)];
+}
+
+/** The clean `major.minor.patch` form, dropping any `v` prefix or suffix. */
+export function normalizeVersion(version: string): string {
+  const [major, minor, patch] = parseVersion(version);
+  return `${major}.${minor}.${patch}`;
+}
+
+/** -1 / 0 / 1 by semantic precedence of the numeric core (suffixes ignored). */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i]! > pb[i]!) return 1;
+    if (pa[i]! < pb[i]!) return -1;
+  }
+  return 0;
+}
+
+/** Whether to surface the release-notes toast: only when `current` is strictly
+ *  newer than the last version the user was shown. An unset `lastSeen` (fresh
+ *  install) returns false — the caller catches up silently so first launches
+ *  stay quiet; a downgrade (e.g. running a dev build) also stays quiet. */
+export function shouldShowReleaseNotes(current: string, lastSeen: string | undefined): boolean {
+  if (!lastSeen) return false;
+  return compareVersions(current, lastSeen) === 1;
+}
+
+/** GitHub release page for a version, e.g. `…/releases/tag/v0.13.0`. */
+export function releaseUrl(version: string): string {
+  return `${RELEASE_TAG_BASE}/v${normalizeVersion(version)}`;
+}


### PR DESCRIPTION
## What

On the first launch after an update, Dash now shows a once-per-version toast — *"Dash updated to v{X}"* with a **"Release notes"** action that opens that version's GitHub release page in the browser.

No in-app modal, no markdown rendering, no network fetch at startup — the toast is the whole surface, and the notes themselves live where they already are (GitHub).

## How it decides to fire

Detection is a version comparison, not an auto-updater event, so it also covers manual `.dmg` updates:

- New `lastSeenReleaseNotesVersion` setting (Zustand `settingsStore`, registry-driven, persisted to localStorage like every other setting).
- Fires only when the running version is **strictly newer** than last-seen.
- **Fresh installs** catch up silently (no toast on first ever launch).
- `lastSeen` advances even when the toast is muted, so a muted user isn't re-evaluated as "new" every launch.
- Gated behind the existing `updateNotificationsEnabled` preference.
- Dev `.DEV` version suffix is tolerated/normalized, so dev builds stay quiet.

## Files

- `utils/releaseNotes.ts` — pure, dep-free `compareVersions` / `normalizeVersion` / `shouldShowReleaseNotes` / `releaseUrl`, with unit tests.
- `components/ui/useReleaseNotesToast.ts` — the hook, wired into `ToastContainer` beside `useWizardToasts()`.
- `stores/settingsKeys.ts` (+ test) — the new setting; its setter is auto-generated by the store registry.

## Testing

- `pnpm type-check`, eslint, prettier — clean.
- `pnpm test` — full suite passes (new `releaseNotes` + `settingsKeys` cases included).
- Manual smoke (renderer can't run headless): in DevTools set `localStorage.setItem('lastSeenReleaseNotesVersion','0.1.0')`, reload → toast appears; "Release notes" opens `…/releases/tag/v0.13.1`.

Version bumped to **0.13.1** for the CI version-check gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)