### PR TITLE
Diff editor: comment view-scoping + review UI, and inline git blame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ state.md
 mockups/sidebar/
 mockups/*
 experiments/cc-startup-signal/
+docs/specs/2026-06-23-diffeditor-git-blame-design.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/main/db/migrate.ts
+++ b/src/main/db/migrate.ts
@@ -69,6 +69,7 @@ export function runMigrations(): void {
       end_line    INTEGER NOT NULL,
       text        TEXT NOT NULL,
       sent        INTEGER NOT NULL DEFAULT 0,
+      view_scope  TEXT NOT NULL DEFAULT 'live',
       created_at  TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
       updated_at  TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     );
@@ -305,6 +306,16 @@ export function runMigrations(): void {
       WHERE ports_setup_dismissed_at IS NOT NULL;
     `);
     rawDb.exec(`ALTER TABLE projects DROP COLUMN ports_setup_dismissed_at`);
+  }
+
+  // Diff comments gained a view scope (anchor to 'live' working/branch diff vs
+  // a frozen 'commit:<hash>'). Existing rows predate scoping → default 'live'.
+  try {
+    rawDb.exec(
+      `ALTER TABLE diff_editor_comments ADD COLUMN view_scope TEXT NOT NULL DEFAULT 'live'`,
+    );
+  } catch {
+    /* already exists */
   }
 
   rawDb.pragma('foreign_keys = ON');

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -105,6 +105,9 @@ export const diffEditorComments = sqliteTable(
     endLine: integer('end_line').notNull(),
     text: text('text').notNull(),
     sent: integer('sent', { mode: 'boolean' }).notNull().default(false),
+    /** Diff state the comment is anchored to: 'live' (working/branch views,
+     *  which share the working file) or 'commit:<hash>' for a frozen commit. */
+    viewScope: text('view_scope').notNull().default('live'),
     createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`),
     updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`),
   },

--- a/src/main/ipc/diffCommentsIpc.ts
+++ b/src/main/ipc/diffCommentsIpc.ts
@@ -14,6 +14,7 @@ interface DiffCommentRow {
   end_line: number;
   text: string;
   sent: number;
+  view_scope: string;
   created_at: string;
   updated_at: string;
 }
@@ -27,6 +28,7 @@ function rowToComment(r: DiffCommentRow): DiffComment {
     endLine: r.end_line,
     text: r.text,
     sent: r.sent === 1,
+    viewScope: r.view_scope,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
   };
@@ -42,7 +44,8 @@ export function computeOrphans(
   return rows.filter((r) => !existing.has(r.file_path)).map((r) => r.id);
 }
 
-const COLS = 'id, task_id, file_path, start_line, end_line, text, sent, created_at, updated_at';
+const COLS =
+  'id, task_id, file_path, start_line, end_line, text, sent, view_scope, created_at, updated_at';
 
 interface Stmts {
   listByTask: Statement;
@@ -71,13 +74,14 @@ function getStmts(): Stmts {
     upsert: db.prepare(
       `INSERT INTO diff_editor_comments
           (${COLS})
-        VALUES (@id, @taskId, @filePath, @startLine, @endLine, @text, @sent, @now, @now)
+        VALUES (@id, @taskId, @filePath, @startLine, @endLine, @text, @sent, @viewScope, @now, @now)
         ON CONFLICT(id) DO UPDATE SET
           file_path  = excluded.file_path,
           start_line = excluded.start_line,
           end_line   = excluded.end_line,
           text       = excluded.text,
           sent       = excluded.sent,
+          view_scope = excluded.view_scope,
           updated_at = excluded.updated_at`,
     ),
     getById: db.prepare(`SELECT ${COLS} FROM diff_editor_comments WHERE id = ?`),

--- a/src/main/ipc/editorIpc.ts
+++ b/src/main/ipc/editorIpc.ts
@@ -5,7 +5,9 @@ import { execFile } from 'child_process';
 import path from 'path';
 import { promisify } from 'util';
 import { parseArgs, errorResponse, ipcError } from './validate';
+import { parseBlameIncremental } from '../services/blameParser';
 import type {
+  EditorBlameResult,
   EditorCommitListItem,
   EditorReadBranchResult,
   EditorReadCommitResult,
@@ -385,6 +387,58 @@ export function registerEditorIpc(): void {
             language: detectLanguage(args.filePath),
           },
         };
+      } catch (err) {
+        return errorResponse(err);
+      }
+    },
+  );
+
+  // ── editor:blame ──────────────────────────────────────────────
+  ipcMain.handle(
+    'editor:blame',
+    async (
+      _event,
+      args: { cwd: string; filePath: string; ref: string | null },
+    ): Promise<IpcResponse<EditorBlameResult>> => {
+      try {
+        parseArgs(
+          'editor:blame',
+          z.looseObject({
+            cwd: z.string(),
+            filePath: z.string(),
+            ref: z.string().nullable(),
+          }),
+          args,
+        );
+        const abs = resolveInsideCwd(args.cwd, args.filePath);
+        const cwdAbs = path.resolve(args.cwd);
+        let cwdReal = cwdAbs;
+        try {
+          cwdReal = safeRealpath(cwdAbs);
+        } catch {
+          /* cwdAbs is fine */
+        }
+        const relForGit = path.relative(cwdReal, abs);
+        const blameArgs = [
+          'blame',
+          '--incremental',
+          ...(args.ref ? [args.ref] : []),
+          '--',
+          relForGit,
+        ];
+
+        let stdout = '';
+        try {
+          ({ stdout } = await execFileAsync('git', blameArgs, {
+            cwd: args.cwd,
+            maxBuffer: LARGE_FILE_BYTES,
+            timeout: 15000,
+          }));
+        } catch {
+          // Untracked / new / binary / unreadable files have no blame.
+          return { success: true, data: { lines: [] } };
+        }
+        return { success: true, data: { lines: parseBlameIncremental(stdout) } };
       } catch (err) {
         return errorResponse(err);
       }

--- a/src/main/ipc/schemas.ts
+++ b/src/main/ipc/schemas.ts
@@ -78,4 +78,5 @@ export const diffCommentInputSchema = z.object({
   endLine: z.number(),
   text: z.string(),
   sent: z.boolean(),
+  viewScope: z.string(),
 });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -402,6 +402,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('editor:listFilesAgainstBase', args),
   editorReadAgainstBase: (args: { cwd: string; filePath: string; base: string }) =>
     ipcRenderer.invoke('editor:readAgainstBase', args),
+  editorBlame: (args: { cwd: string; filePath: string; ref: string | null }) =>
+    ipcRenderer.invoke('editor:blame', args),
 
   // Diff editor comments
   diffCommentsList: (args: { taskId: string }) => ipcRenderer.invoke('diffComments:list', args),

--- a/src/main/services/blameParser.test.ts
+++ b/src/main/services/blameParser.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { parseBlameIncremental, UNCOMMITTED_SHA } from './blameParser';
+
+const A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+// Groups deliberately out of final-line order, and commit A repeats later with
+// its metadata omitted (as --incremental does) to exercise the per-sha cache.
+const FIXTURE = [
+  `${A} 1 1 2`,
+  'author Alice',
+  'author-mail <alice@example.com>',
+  'author-time 1700000000',
+  'author-tz +0000',
+  'committer Alice',
+  'committer-mail <alice@example.com>',
+  'committer-time 1700000000',
+  'committer-tz +0000',
+  'summary First commit',
+  'filename foo.ts',
+  `${A} 5 5 1`, // repeat of commit A, metadata omitted — must resolve from cache
+  `previous ${B} foo.ts`,
+  'filename foo.ts',
+  `${B} 3 3 1`,
+  'author Bob',
+  'author-mail <bob@example.com>',
+  'author-time 1700001000',
+  'author-tz +0000',
+  'summary Second commit',
+  'filename foo.ts',
+  `${UNCOMMITTED_SHA} 4 4 1`,
+  'author Not Committed Yet',
+  'author-mail <not.committed.yet>',
+  'author-time 1700002000',
+  'author-tz +0000',
+  'summary Version of foo.ts',
+  'filename foo.ts',
+  '',
+].join('\n');
+
+describe('parseBlameIncremental', () => {
+  it('returns one entry per line in ascending order', () => {
+    const lines = parseBlameIncremental(FIXTURE);
+    expect(lines.map((l) => l.line)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('maps a multi-line group to its commit metadata', () => {
+    const lines = parseBlameIncremental(FIXTURE);
+    expect(lines[0]).toMatchObject({
+      line: 1,
+      sha: A,
+      shortSha: 'aaaaaaa',
+      author: 'Alice',
+      authorEmail: 'alice@example.com',
+      authorTime: 1700000000,
+      summary: 'First commit',
+      uncommitted: false,
+    });
+    expect(lines[1]).toMatchObject({ line: 2, sha: A, author: 'Alice' });
+  });
+
+  it('reuses cached metadata for a repeated commit with omitted metadata', () => {
+    const lines = parseBlameIncremental(FIXTURE);
+    expect(lines[4]).toMatchObject({
+      line: 5,
+      sha: A,
+      author: 'Alice',
+      summary: 'First commit',
+      uncommitted: false,
+    });
+  });
+
+  it('flags the all-zeros SHA as uncommitted', () => {
+    const lines = parseBlameIncremental(FIXTURE);
+    expect(lines[3]).toMatchObject({
+      line: 4,
+      sha: UNCOMMITTED_SHA,
+      uncommitted: true,
+    });
+  });
+
+  it('returns [] for empty output', () => {
+    expect(parseBlameIncremental('')).toEqual([]);
+  });
+});

--- a/src/main/services/blameParser.ts
+++ b/src/main/services/blameParser.ts
@@ -1,0 +1,99 @@
+import type { BlameLine } from '@shared/types';
+
+/** All-zeros SHA git uses for not-yet-committed (working tree) lines. */
+export const UNCOMMITTED_SHA = '0000000000000000000000000000000000000000';
+
+interface CommitMeta {
+  author: string;
+  authorEmail: string;
+  authorTime: number;
+  summary: string;
+}
+
+const HEADER_RE = /^([0-9a-f]{40}) \d+ (\d+) (\d+)$/;
+
+/**
+ * Parse `git blame --incremental <ref?> -- <path>` output into one BlameLine per
+ * final line, in ascending line order.
+ *
+ * Incremental format: each group starts with a header line
+ * `<sha> <origLine> <finalLine> <numLines>`, followed by commit metadata
+ * key/value lines, and terminates on a `filename` line. Metadata is emitted only
+ * the first time a commit is seen, so we cache it per-sha and reuse it for later
+ * groups of the same commit. Groups can arrive out of final-line order, so we
+ * place each into a line-indexed slot and compact at the end.
+ */
+export function parseBlameIncremental(stdout: string): BlameLine[] {
+  const commits = new Map<string, CommitMeta>();
+  const byLine: BlameLine[] = [];
+
+  let sha = '';
+  let finalLine = 0;
+  let count = 0;
+
+  const metaFor = (key: string): CommitMeta => {
+    let m = commits.get(key);
+    if (!m) {
+      m = { author: '', authorEmail: '', authorTime: 0, summary: '' };
+      commits.set(key, m);
+    }
+    return m;
+  };
+
+  for (const raw of stdout.split('\n')) {
+    if (!raw) continue;
+
+    const header = HEADER_RE.exec(raw);
+    if (header) {
+      sha = header[1]!;
+      finalLine = parseInt(header[2]!, 10);
+      count = parseInt(header[3]!, 10);
+      metaFor(sha); // ensure an entry exists even if metadata is omitted (repeat commit)
+      continue;
+    }
+    if (!sha) continue;
+
+    const sp = raw.indexOf(' ');
+    const key = sp === -1 ? raw : raw.slice(0, sp);
+    const value = sp === -1 ? '' : raw.slice(sp + 1);
+    const meta = metaFor(sha);
+
+    switch (key) {
+      case 'author':
+        meta.author = value;
+        break;
+      case 'author-mail':
+        meta.authorEmail = value.replace(/^<|>$/g, '');
+        break;
+      case 'author-time':
+        meta.authorTime = parseInt(value, 10) || 0;
+        break;
+      case 'summary':
+        meta.summary = value;
+        break;
+      case 'filename': {
+        // Group complete — emit one BlameLine per covered line.
+        const uncommitted = sha === UNCOMMITTED_SHA;
+        const shortSha = sha.slice(0, 7);
+        for (let i = 0; i < count; i++) {
+          const ln = finalLine + i;
+          byLine[ln - 1] = {
+            line: ln,
+            sha,
+            shortSha,
+            author: meta.author,
+            authorEmail: meta.authorEmail,
+            authorTime: meta.authorTime,
+            summary: meta.summary,
+            uncommitted,
+          };
+        }
+        break;
+      }
+      default:
+        break; // committer*, author-tz, previous, boundary — ignored
+    }
+  }
+
+  return byLine.filter(Boolean) as BlameLine[];
+}

--- a/src/renderer/components/diffEditor/DiffEditor.tsx
+++ b/src/renderer/components/diffEditor/DiffEditor.tsx
@@ -104,12 +104,13 @@ export function DiffEditor({
   const clearReveal = useCallback(() => setRevealCommentId(null), []);
 
   // File-tree badges reflect only the open view's scope, so a file never shows
-  // "3 comments" when the diff you're looking at has none of them.
+  // "3 comments" when the diff you're looking at has none of them. Already-sent
+  // comments don't need attention, so they're excluded from the count.
   const currentScope = commentScope(view);
   const commentCounts = useMemo(() => {
     const map = new Map<string, number>();
     for (const [path, list] of Object.entries(commentsByFile)) {
-      const n = list.filter((c) => c.viewScope === currentScope).length;
+      const n = list.filter((c) => c.viewScope === currentScope && !c.sent).length;
       if (n > 0) map.set(path, n);
     }
     return map;

--- a/src/renderer/components/diffEditor/DiffEditor.tsx
+++ b/src/renderer/components/diffEditor/DiffEditor.tsx
@@ -9,6 +9,7 @@ import type { DiffEditorModalProps } from './DiffEditorModal';
 import { useEditorViewData } from './data/useEditorViewData';
 import { resolveHeadSentinel, pickFirstChangedFile } from './data/viewData';
 import { useCommentsStore } from '../../stores/commentsStore';
+import { commentScope, commentCountsByScope } from './comments/commentScope';
 
 /** Composition-root workspace: owns view state, drives the data loaders, and
  *  lays out the sidebar + editor pane. Rendered inside <DiffEditorModal>. */
@@ -86,20 +87,36 @@ export function DiffEditor({
   // once hydration completes, then clears it via onClearReveal.
   const [revealCommentId, setRevealCommentId] = useState<string | null>(null);
 
-  const navigateAcrossFile = useCallback((path: string, commentId: string) => {
+  // Jump to a comment from the menu: switch to its view (scope) if needed,
+  // select the file, and let EditorPane reveal it once it hydrates. A 'live'
+  // comment stays in the current live view (working OR branch); only a commit
+  // comment forces a view change (and a live comment pulls us off a commit).
+  const navigateToComment = useCallback((scope: string, path: string, commentId: string) => {
+    if (scope.startsWith('commit:')) {
+      setView({ kind: 'commit', hash: scope.slice(7) });
+    } else {
+      setView((cur) => (cur.kind === 'commit' ? { kind: 'working', ref: 'HEAD' } : cur));
+    }
     setSelectedPath(path);
     setRevealCommentId(commentId);
   }, []);
 
   const clearReveal = useCallback(() => setRevealCommentId(null), []);
 
+  // File-tree badges reflect only the open view's scope, so a file never shows
+  // "3 comments" when the diff you're looking at has none of them.
+  const currentScope = commentScope(view);
   const commentCounts = useMemo(() => {
     const map = new Map<string, number>();
     for (const [path, list] of Object.entries(commentsByFile)) {
-      if (list.length > 0) map.set(path, list.length);
+      const n = list.filter((c) => c.viewScope === currentScope).length;
+      if (n > 0) map.set(path, n);
     }
     return map;
-  }, [commentsByFile]);
+  }, [commentsByFile, currentScope]);
+
+  // Per-view totals for the commits-drawer badges (all scopes, not just open).
+  const commentCountByScope = useMemo(() => commentCountsByScope(commentsByFile), [commentsByFile]);
 
   // Once the working tree's file list is known, hard-delete any persisted
   // comments whose path no longer exists. Runs once per modal session per
@@ -127,6 +144,7 @@ export function DiffEditor({
             commits={commits}
             commitsLoading={commitsLoading}
             showWorkingTreeRow={workingFiles.length > 0}
+            commentCountByScope={commentCountByScope}
             view={view}
             onSelectView={changeView}
           />
@@ -141,7 +159,7 @@ export function DiffEditor({
             terminalTheme={terminalTheme}
             isDark={isDark}
             revealCommentId={revealCommentId}
-            onNavigateAcrossFile={navigateAcrossFile}
+            onNavigateToComment={navigateToComment}
             onClearReveal={clearReveal}
             onClose={onClose}
             onSelectBase={selectBase}

--- a/src/renderer/components/diffEditor/EditorPane.tsx
+++ b/src/renderer/components/diffEditor/EditorPane.tsx
@@ -6,6 +6,7 @@ import type { LiveComment } from './comments/types';
 import { useCommentsStore } from '../../stores/commentsStore';
 import { useGutterSelection } from './comments/useGutterSelection';
 import { useFileComments } from './comments/useFileComments';
+import { commentScope, scopeLabel } from './comments/commentScope';
 import { useCommentShades } from './comments/useCommentShades';
 import { useCommentBands } from './comments/useCommentBands';
 import { useCommentDraft } from './comments/useCommentDraft';
@@ -46,7 +47,8 @@ interface EditorPaneProps {
   /** When set, the editor reveals the comment with this id once it lives in
    *  the current file's hydrated decorations, then calls onClearReveal. */
   revealCommentId: string | null;
-  onNavigateAcrossFile: (filePath: string, commentId: string) => void;
+  /** Jump to a comment, switching to its view (scope) + file as needed. */
+  onNavigateToComment: (scope: string, filePath: string, commentId: string) => void;
   onClearReveal: () => void;
   onClose: () => void;
   /** Branch-view header chip wiring. Owned by parent so the changed-files
@@ -66,7 +68,7 @@ export function EditorPane({
   terminalTheme,
   isDark,
   revealCommentId,
-  onNavigateAcrossFile,
+  onNavigateToComment,
   onClearReveal,
   onClose,
   onSelectBase,
@@ -102,6 +104,19 @@ export function EditorPane({
   const [hoveredCommentId, setHoveredCommentId] = useState<string | null>(null);
 
   const isCommitView = view.kind === 'commit';
+  // Comments anchor to the view's content state: 'live' (working/branch share
+  // the working file) vs 'commit:<hash>'. The editor shows only this scope's
+  // comments; the menu spans all scopes (grouped by view).
+  const scope = commentScope(view);
+  // Origin tag on bubbles whenever the open view isn't the plain working tree.
+  const bubbleScopeLabel = view.kind === 'working' ? undefined : scopeLabel(scope);
+  // Comment count for the open view — surfaced in the header's "Showing …" pill.
+  const scopeCommentCount = useMemo(() => {
+    let n = 0;
+    for (const list of Object.values(commentsByFile))
+      for (const c of list) if (c.viewScope === scope) n++;
+    return n;
+  }, [commentsByFile, scope]);
 
   const { editor, monaco, themeName, displayed, handleBeforeMount, handleMount } = useMonacoEditor({
     isDark,
@@ -195,6 +210,7 @@ export function EditorPane({
     isFileLoaded,
     editor,
     monaco,
+    scope,
   });
   const liveComments = binding.liveComments;
   const shadeById = useCommentShades(liveComments);
@@ -286,6 +302,7 @@ export function EditorPane({
     monaco,
     liveComments,
     language: state.kind === 'loaded' ? state.language : '',
+    scope,
     onClose,
   });
 
@@ -316,6 +333,7 @@ export function EditorPane({
         onSelectBase={onSelectBase}
         onExitBranchView={onExitBranchView}
         defaultBase={defaultBase}
+        commentCount={scopeCommentCount}
         backgroundColor={terminalTheme.background ?? (isDark ? '#0d0d11' : '#faf8f3')}
       />
 
@@ -363,6 +381,7 @@ export function EditorPane({
               <CommentsMenu
                 commentsByFile={commentsByFile}
                 currentFilePath={filePath}
+                currentScope={scope}
                 getLiveRangeForCurrent={(commentId) => {
                   const target = liveComments.find((c) => c.id === commentId);
                   if (!target) return null;
@@ -370,17 +389,11 @@ export function EditorPane({
                   const r = model?.getDecorationRange(target.decorationId);
                   return r ? { start: r.startLineNumber, end: r.endLineNumber } : null;
                 }}
-                onNavigate={(targetPath, commentId) => {
-                  if (targetPath === filePath) {
-                    const target = liveComments.find((c) => c.id === commentId);
-                    if (target) revealLive(target);
-                  } else {
-                    onNavigateAcrossFile(targetPath, commentId);
-                  }
-                }}
+                onNavigate={onNavigateToComment}
                 onRemove={(_path, id) => useCommentsStore.getState().remove(id)}
                 onUnsend={(id) => useCommentsStore.getState().markUnsent(id)}
-                onSend={promptApi.sendAllUnsent}
+                onSendScope={promptApi.sendScope}
+                onSendAll={promptApi.sendAllUnsent}
                 onEditAndSend={promptApi.openEditAndSend}
                 onSendOne={promptApi.sendOne}
               />
@@ -390,6 +403,7 @@ export function EditorPane({
           <CommentOverlay
             liveComments={liveComments}
             shadeById={shadeById}
+            scopeLabel={bubbleScopeLabel}
             modifiedEditor={modifiedEditor}
             monaco={monaco}
             area={editorAreaEl}

--- a/src/renderer/components/diffEditor/EditorPane.tsx
+++ b/src/renderer/components/diffEditor/EditorPane.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
 import type { editor as monacoEditor } from 'monaco-editor';
 import type { ITheme as XtermTheme } from '@xterm/xterm';
 import type { EditorView } from './types';
@@ -15,6 +17,7 @@ import { useFileFade } from './comments/useFileFade';
 import { CommentOverlay } from './comments/overlay/CommentOverlay';
 import { CommentsMenu } from './comments/CommentsMenu';
 import { EditCommentsModal } from './comments/EditCommentsModal';
+import { useGitBlame } from './blame/useGitBlame';
 import { useFileLoad, type LoadState } from './editor/useFileLoad';
 import { useEditorSave } from './editor/useEditorSave';
 import { useMonacoEditor } from './editor/useMonacoEditor';
@@ -28,6 +31,7 @@ import { SaveErrorBanner } from './editor/SaveErrorBanner';
 import '../../monaco-workers';
 
 const WORDWRAP_KEY = 'diffEditor.wordWrap';
+const BLAME_KEY = 'diffEditor.blame';
 
 /** Which files get a Code | Preview toggle, and how their preview is rendered.
  *  HTML renders as-is; markdown is converted to a styled HTML document. */
@@ -83,6 +87,10 @@ export function EditorPane({
   const [wordWrap, setWordWrap] = useState<boolean>(
     () => localStorage.getItem(WORDWRAP_KEY) === 'on',
   );
+  // Inline git blame defaults ON; only an explicit 'off' disables it.
+  const [blameEnabled, setBlameEnabled] = useState<boolean>(
+    () => localStorage.getItem(BLAME_KEY) !== 'off',
+  );
   const [previewing, setPreviewing] = useState(false);
   const kind = previewKind(filePath);
   const canPreview = kind !== null;
@@ -93,6 +101,7 @@ export function EditorPane({
     setPreviewing(false);
   }, [filePath]);
 
+  const blameLabelRef = useRef<HTMLDivElement | null>(null);
   const selectionDecorations = useRef<monacoEditor.IEditorDecorationsCollection | null>(null);
   const saveCmdRef = useRef<(() => void) | null>(null);
   // State (not ref) so the popover's `container` prop sees the actual node
@@ -248,6 +257,10 @@ export function EditorPane({
     localStorage.setItem(WORDWRAP_KEY, wordWrap ? 'on' : 'off');
   }, [wordWrap]);
 
+  useEffect(() => {
+    localStorage.setItem(BLAME_KEY, blameEnabled ? 'on' : 'off');
+  }, [blameEnabled]);
+
   // Bridge useEditorSave → useMonacoEditor's ⌘S binding. The hook fires
   // saveCmdRef.current() from the keybinding; we keep this ref pointed at
   // the latest save callback so it never goes stale on re-render.
@@ -291,8 +304,44 @@ export function EditorPane({
     hoveredCommentId,
   });
 
+  // Inline git blame: on hover, a same-commit block highlight in the editor body
+  // plus a band + info card on the right overview-ruler strip. Toggled from the
+  // header (and the card's ×) via `blameEnabled`.
+  const { rulerMark, rulerVisible, rulerHost, holdLabel, releaseLabel } = useGitBlame({
+    cwd,
+    filePath,
+    view,
+    modifiedEditor,
+    monaco,
+    enabled: blameEnabled,
+    canBlame: state.kind === 'loaded' && !state.isBinary && !state.isLargeFile,
+  });
+
+  // Keep the blame card fully visible: clamp its top so it never spills past the
+  // editor area's bottom (commits on the last lines of a file). Runs before paint
+  // so the clamp is never seen unapplied.
+  useLayoutEffect(() => {
+    const el = blameLabelRef.current;
+    if (!el || !rulerMark || !editorAreaEl) return;
+    const maxTop = editorAreaEl.clientHeight - el.offsetHeight - 4;
+    el.style.top = `${Math.max(4, Math.min(rulerMark.top, maxTop))}px`;
+  }, [rulerMark, editorAreaEl]);
+
   // In-progress comment (fresh-create vs dbl-click-to-edit) state.
   const draftApi = useCommentDraft({ modifiedEditor, setPendingRange, binding });
+
+  // When a fresh comment draft opens, scroll its anchor line into the centre so
+  // there's room above for the bubble (which renders above the line). Without
+  // this, a draft placed on the last line(s) of a file is clipped at the editor's
+  // bottom with no way to scroll to it (scrollBeyondLastLine is off). Deferred a
+  // frame so the bubble's view-zone exists and the reveal accounts for it.
+  useEffect(() => {
+    if (dragging || !pendingRange || draftApi.editingId || !modifiedEditor || !monaco) return;
+    const raf = requestAnimationFrame(() => {
+      modifiedEditor.revealLineInCenter(pendingRange.start, monaco.editor.ScrollType.Smooth);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [pendingRange, dragging, draftApi.editingId, modifiedEditor, monaco]);
 
   // Prompt assembly + send-to-TUI + edit-and-send modal.
   const promptApi = useCommentPrompt({
@@ -326,6 +375,8 @@ export function EditorPane({
         view={view}
         wordWrap={wordWrap}
         onToggleWordWrap={() => setWordWrap((w) => !w)}
+        blameEnabled={blameEnabled}
+        onToggleBlame={() => setBlameEnabled((b) => !b)}
         canPreview={canPreview}
         previewing={previewing}
         onTogglePreview={setPreviewing}
@@ -400,6 +451,50 @@ export function EditorPane({
             </div>
           )}
           {state.kind === 'loading' && displayed.kind === 'loaded' && <LoadingPill />}
+          {rulerMark &&
+            (() => {
+              const band = (
+                <div
+                  className="monaco-blame-ruler-band"
+                  data-visible={rulerVisible}
+                  style={{ top: rulerMark.top, height: rulerMark.height }}
+                />
+              );
+              return (
+                <>
+                  {rulerHost ? createPortal(band, rulerHost) : band}
+                  <div
+                    ref={blameLabelRef}
+                    className="monaco-blame-ruler-label"
+                    data-visible={rulerVisible}
+                    style={{ top: rulerMark.top }}
+                    onMouseEnter={holdLabel}
+                    onMouseLeave={releaseLabel}
+                  >
+                    <button
+                      type="button"
+                      className="blame-label-close"
+                      title="Hide git blame"
+                      onClick={() => setBlameEnabled(false)}
+                    >
+                      <X size={11} strokeWidth={2} />
+                    </button>
+                    <span className="blame-label-author">{rulerMark.label.author}</span>
+                    {!rulerMark.label.uncommitted && (
+                      <>
+                        <span className="blame-label-meta">
+                          <span className="blame-label-sha">{rulerMark.label.shortSha}</span>
+                          {rulerMark.label.age && <span>{rulerMark.label.age} ago</span>}
+                        </span>
+                        {rulerMark.label.summary && (
+                          <span className="blame-label-summary">{rulerMark.label.summary}</span>
+                        )}
+                      </>
+                    )}
+                  </div>
+                </>
+              );
+            })()}
           <CommentOverlay
             liveComments={liveComments}
             shadeById={shadeById}

--- a/src/renderer/components/diffEditor/EditorPane.tsx
+++ b/src/renderer/components/diffEditor/EditorPane.tsx
@@ -307,7 +307,7 @@ export function EditorPane({
   // Inline git blame: on hover, a same-commit block highlight in the editor body
   // plus a band + info card on the right overview-ruler strip. Toggled from the
   // header (and the card's ×) via `blameEnabled`.
-  const { rulerMark, rulerVisible, rulerHost, holdLabel, releaseLabel } = useGitBlame({
+  const { rulerMark, rulerVisible, rulerSlide, rulerHost, holdLabel, releaseLabel } = useGitBlame({
     cwd,
     filePath,
     view,
@@ -457,6 +457,7 @@ export function EditorPane({
                 <div
                   className="monaco-blame-ruler-band"
                   data-visible={rulerVisible}
+                  data-slide={rulerSlide}
                   style={{ top: rulerMark.top, height: rulerMark.height }}
                 />
               );
@@ -467,6 +468,7 @@ export function EditorPane({
                     ref={blameLabelRef}
                     className="monaco-blame-ruler-label"
                     data-visible={rulerVisible}
+                    data-slide={rulerSlide}
                     style={{ top: rulerMark.top }}
                     onMouseEnter={holdLabel}
                     onMouseLeave={releaseLabel}

--- a/src/renderer/components/diffEditor/EditorSidebar.tsx
+++ b/src/renderer/components/diffEditor/EditorSidebar.tsx
@@ -306,11 +306,22 @@ function FolderEntry({
   commentCounts: Map<string, number>;
 }) {
   // Default-open if the folder has changes OR it contains the file the editor
-  // opened to — so that file is never hidden in a collapsed folder. Computed
-  // once at mount (lazy init); the user's collapse/expand fully owns it after.
+  // opened to — so that file is never hidden in a collapsed folder. The user's
+  // collapse/expand owns it after.
   const [open, setOpen] = useState<boolean>(
     () => folder.changedCount > 0 || selectedPath.startsWith(`${folder.fullPath}/`),
   );
+  // `changedFiles` load async, so at mount `changedCount` is often still 0 and
+  // the lazy init above misses changed folders (an intermittent "collapsed on
+  // open" race). Re-seed open exactly once when a folder *first* gains changed
+  // files; the guard means a later manual collapse is never clobbered.
+  const seededFromChanges = useRef(folder.changedCount > 0);
+  useEffect(() => {
+    if (!seededFromChanges.current && folder.changedCount > 0) {
+      seededFromChanges.current = true;
+      setOpen(true);
+    }
+  }, [folder.changedCount]);
   const tint = folder.dominantStatus ? FOLDER_TINT[folder.dominantStatus] : 'text-foreground/90';
   return (
     <>

--- a/src/renderer/components/diffEditor/EditorSidebar.tsx
+++ b/src/renderer/components/diffEditor/EditorSidebar.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef, useState, useEffect } from 'react';
 import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
 import { ChevronDown, ChevronRight, GitCommit, History } from 'lucide-react';
 import type { FileChange, FileChangeStatus } from '../../../shared/types';
+import { formatRelativeTime } from '@shared/relativeTime';
 import type { CommitSummary, EditorView } from './types';
 import { Popover, PopoverAnchor, PopoverContent } from '../ui/Popover';
 import { Tooltip } from '../ui/Tooltip';
@@ -579,7 +580,7 @@ function CommitRow({ commit, active, commentCount, onSelect }: CommitRowProps) {
           </span>
           {commentCount > 0 && <CommentBadge count={commentCount} />}
           <span className="text-[10px] text-muted-foreground/40 shrink-0 tabular-nums">
-            {relativeTime(commit.authorDate)}
+            {formatRelativeTime(commit.authorDate, Date.now() / 1000)}
           </span>
         </button>
       </PopoverAnchor>
@@ -615,20 +616,11 @@ function CommitRow({ commit, active, commentCount, onSelect }: CommitRowProps) {
           <span className="opacity-50">·</span>
           <span className="truncate">{commit.authorName}</span>
           <span className="opacity-50">·</span>
-          <span className="tabular-nums">{relativeTime(commit.authorDate)}</span>
+          <span className="tabular-nums">
+            {formatRelativeTime(commit.authorDate, Date.now() / 1000)}
+          </span>
         </div>
       </PopoverContent>
     </Popover>
   );
-}
-
-function relativeTime(unixSeconds: number): string {
-  if (!unixSeconds) return '';
-  const s = Math.floor(Date.now() / 1000 - unixSeconds);
-  if (s < 60) return `${s}s`;
-  if (s < 3600) return `${Math.floor(s / 60)}m`;
-  if (s < 86400) return `${Math.floor(s / 3600)}h`;
-  if (s < 86400 * 30) return `${Math.floor(s / 86400)}d`;
-  if (s < 86400 * 365) return `${Math.floor(s / (86400 * 30))}mo`;
-  return `${Math.floor(s / (86400 * 365))}y`;
 }

--- a/src/renderer/components/diffEditor/EditorSidebar.tsx
+++ b/src/renderer/components/diffEditor/EditorSidebar.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronRight, GitCommit, History } from 'lucide-react';
 import type { FileChange, FileChangeStatus } from '../../../shared/types';
 import type { CommitSummary, EditorView } from './types';
 import { Popover, PopoverAnchor, PopoverContent } from '../ui/Popover';
+import { Tooltip } from '../ui/Tooltip';
 
 interface EditorSidebarProps {
   /** All file paths in the current view's source (whole repo, sorted). */
@@ -21,6 +22,8 @@ interface EditorSidebarProps {
   commitsLoading: boolean;
   /** Whether to surface the "Working tree" pinned entry in the commits drawer. */
   showWorkingTreeRow: boolean;
+  /** Comment count per scope ('live' / 'commit:<hash>') → badge on each row. */
+  commentCountByScope: Map<string, number>;
   view: EditorView;
   onSelectView: (view: EditorView) => void;
 }
@@ -55,6 +58,7 @@ export function EditorSidebar(props: EditorSidebarProps) {
             commits={props.commits}
             loading={props.commitsLoading}
             showWorkingTreeRow={props.showWorkingTreeRow}
+            commentCountByScope={props.commentCountByScope}
             view={props.view}
             onSelectView={props.onSelectView}
           />
@@ -236,16 +240,6 @@ function FileTreePanel({
   );
 }
 
-/** Aggregate comment counts for everything under a folder. Mirrors the
- *  changed-count walk in buildRepoTree but uses the external commentCounts
- *  map (which can change without the tree changing). */
-function folderCommentCount(node: TreeFolder, commentCounts: Map<string, number>): number {
-  let total = 0;
-  for (const file of node.files) total += commentCounts.get(file.fullPath) ?? 0;
-  for (const child of node.children.values()) total += folderCommentCount(child, commentCounts);
-  return total;
-}
-
 interface FolderContentsProps {
   node: TreeFolder;
   indent: number;
@@ -317,7 +311,6 @@ function FolderEntry({
     () => folder.changedCount > 0 || selectedPath.startsWith(`${folder.fullPath}/`),
   );
   const tint = folder.dominantStatus ? FOLDER_TINT[folder.dominantStatus] : 'text-foreground/90';
-  const commentCount = folderCommentCount(folder, commentCounts);
   return (
     <>
       <button
@@ -340,7 +333,6 @@ function FolderEntry({
           {folder.name}
           <span className="text-muted-foreground/40">/</span>
         </span>
-        {commentCount > 0 && <CommentBadge count={commentCount} />}
         {folder.changedCount > 0 && (
           <span
             className={`shrink-0 font-mono text-[10px] font-semibold tabular-nums ${
@@ -368,14 +360,16 @@ function FolderEntry({
 }
 
 function CommentBadge({ count }: { count: number }) {
+  const label = `${count} comment${count !== 1 ? 's' : ''}`;
   return (
-    <span
-      title={`${count} comment${count !== 1 ? 's' : ''}`}
-      aria-label={`${count} comment${count !== 1 ? 's' : ''}`}
-      className="shrink-0 inline-flex items-center justify-center min-w-[14px] h-[14px] px-1 rounded-full font-mono text-[9.5px] font-semibold tabular-nums bg-primary/20 text-primary"
-    >
-      {count}
-    </span>
+    <Tooltip content={label}>
+      <span
+        aria-label={label}
+        className="shrink-0 inline-flex items-center justify-center min-w-[14px] h-[14px] px-1 rounded-full font-mono text-[9.5px] font-semibold tabular-nums bg-primary/20 text-primary"
+      >
+        {count}
+      </span>
+    </Tooltip>
   );
 }
 
@@ -452,6 +446,7 @@ interface CommitsDrawerProps {
   commits: CommitSummary[];
   loading: boolean;
   showWorkingTreeRow: boolean;
+  commentCountByScope: Map<string, number>;
   view: EditorView;
   onSelectView: (view: EditorView) => void;
 }
@@ -460,6 +455,7 @@ function CommitsDrawer({
   commits,
   loading,
   showWorkingTreeRow,
+  commentCountByScope,
   view,
   onSelectView,
 }: CommitsDrawerProps) {
@@ -498,6 +494,9 @@ function CommitsDrawer({
           >
             <GitCommit size={11} strokeWidth={1.8} className="opacity-60 shrink-0" />
             <span className="truncate flex-1 font-mono text-[11.5px]">Working tree</span>
+            {(commentCountByScope.get('live') ?? 0) > 0 && (
+              <CommentBadge count={commentCountByScope.get('live')!} />
+            )}
           </button>
         )}
         {loading && commits.length === 0 && (
@@ -510,6 +509,7 @@ function CommitsDrawer({
               key={c.hash}
               commit={c}
               active={active}
+              commentCount={commentCountByScope.get(`commit:${c.hash}`) ?? 0}
               onSelect={() => onSelectView({ kind: 'commit', hash: c.hash })}
             />
           );
@@ -522,10 +522,11 @@ function CommitsDrawer({
 interface CommitRowProps {
   commit: CommitSummary;
   active: boolean;
+  commentCount: number;
   onSelect: () => void;
 }
 
-function CommitRow({ commit, active, onSelect }: CommitRowProps) {
+function CommitRow({ commit, active, commentCount, onSelect }: CommitRowProps) {
   const [hovered, setHovered] = useState(false);
   const openTimer = useRef<number | null>(null);
   const closeTimer = useRef<number | null>(null);
@@ -576,6 +577,7 @@ function CommitRow({ commit, active, onSelect }: CommitRowProps) {
           <span className="truncate flex-1 font-mono text-[11.5px]">
             {commit.subject || '(no subject)'}
           </span>
+          {commentCount > 0 && <CommentBadge count={commentCount} />}
           <span className="text-[10px] text-muted-foreground/40 shrink-0 tabular-nums">
             {relativeTime(commit.authorDate)}
           </span>

--- a/src/renderer/components/diffEditor/blame/formatBlame.test.ts
+++ b/src/renderer/components/diffEditor/blame/formatBlame.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { blameLabel, contiguousBlock } from './formatBlame';
+import type { BlameLine } from '@shared/types';
+
+const NOW = 1_700_000_000;
+
+function line(overrides: Partial<BlameLine> = {}): BlameLine {
+  return {
+    line: 1,
+    sha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    shortSha: 'aaaaaaa',
+    author: 'Nicolai Thomsen',
+    authorEmail: 'nicolai@syv.ai',
+    authorTime: NOW - 3 * 86400,
+    summary: 'Diff comments: robust anchoring',
+    uncommitted: false,
+    ...overrides,
+  };
+}
+
+describe('blameLabel', () => {
+  it('breaks a committed line into structured fields', () => {
+    expect(blameLabel(line(), NOW)).toEqual({
+      author: 'Nicolai Thomsen',
+      age: '3d',
+      shortSha: 'aaaaaaa',
+      summary: 'Diff comments: robust anchoring',
+      uncommitted: false,
+    });
+  });
+
+  it('collapses uncommitted lines to a single phrase', () => {
+    expect(blameLabel(line({ uncommitted: true }), NOW)).toEqual({
+      author: 'Uncommitted changes',
+      age: '',
+      shortSha: '',
+      summary: '',
+      uncommitted: true,
+    });
+  });
+});
+
+describe('contiguousBlock', () => {
+  const lines: BlameLine[] = [
+    line({ line: 1, sha: 'a', shortSha: 'aaaaaaa' }),
+    line({ line: 2, sha: 'a', shortSha: 'aaaaaaa' }),
+    line({ line: 3, sha: 'b', shortSha: 'bbbbbbb' }),
+    line({ line: 4, sha: 'a', shortSha: 'aaaaaaa' }),
+    line({ line: 5, sha: 'a', shortSha: 'aaaaaaa' }),
+  ];
+
+  it('expands to the full same-commit run around the target', () => {
+    expect(contiguousBlock(lines, 1)).toEqual({ start: 1, end: 2 });
+    expect(contiguousBlock(lines, 2)).toEqual({ start: 1, end: 2 });
+    expect(contiguousBlock(lines, 5)).toEqual({ start: 4, end: 5 });
+  });
+
+  it('does not jump across a different commit between two runs of the same sha', () => {
+    expect(contiguousBlock(lines, 4)).toEqual({ start: 4, end: 5 });
+  });
+
+  it('returns a single-line block for an isolated commit', () => {
+    expect(contiguousBlock(lines, 3)).toEqual({ start: 3, end: 3 });
+  });
+
+  it('returns null for an out-of-range line', () => {
+    expect(contiguousBlock(lines, 0)).toBeNull();
+    expect(contiguousBlock(lines, 99)).toBeNull();
+  });
+});

--- a/src/renderer/components/diffEditor/blame/formatBlame.ts
+++ b/src/renderer/components/diffEditor/blame/formatBlame.ts
@@ -1,0 +1,59 @@
+import type { BlameLine } from '@shared/types';
+import { formatRelativeTime } from '@shared/relativeTime';
+
+/** The fields surfaced in the ruler label card, ready to render as rows. */
+export interface BlameLabel {
+  author: string; // author name, or "Uncommitted changes" for working-tree lines
+  age: string; // relative time (e.g. "3d"); '' when uncommitted
+  shortSha: string; // 7-char hash; '' when uncommitted
+  summary: string; // commit subject; '' when uncommitted
+  uncommitted: boolean;
+}
+
+/**
+ * Structured blame fields for the ruler label. Uncommitted lines collapse to a
+ * single phrase. `now` is unix seconds, injectable for deterministic tests.
+ */
+export function blameLabel(line: BlameLine, now: number): BlameLabel {
+  if (line.uncommitted) {
+    return { author: 'Uncommitted changes', age: '', shortSha: '', summary: '', uncommitted: true };
+  }
+  return {
+    author: line.author,
+    age: formatRelativeTime(line.authorTime, now),
+    shortSha: line.shortSha,
+    summary: line.summary,
+    uncommitted: false,
+  };
+}
+
+/**
+ * The maximal contiguous run of lines around `targetLine` that share the same
+ * commit — i.e. where that commit's changes start and end in the file. Returns
+ * 1-indexed inclusive bounds, or null if the line has no blame. Assumes `lines`
+ * is ascending and gap-free (full-file blame), so it walks outward in O(block).
+ */
+export function contiguousBlock(
+  lines: BlameLine[],
+  targetLine: number,
+): { start: number; end: number } | null {
+  const idx = targetLine - 1;
+  const cur = lines[idx];
+  if (!cur || cur.line !== targetLine) return null;
+  const { sha } = cur;
+  let start = idx;
+  let end = idx;
+  while (
+    start > 0 &&
+    lines[start - 1]!.sha === sha &&
+    lines[start - 1]!.line === lines[start]!.line - 1
+  )
+    start--;
+  while (
+    end < lines.length - 1 &&
+    lines[end + 1]!.sha === sha &&
+    lines[end + 1]!.line === lines[end]!.line + 1
+  )
+    end++;
+  return { start: lines[start]!.line, end: lines[end]!.line };
+}

--- a/src/renderer/components/diffEditor/blame/refForView.test.ts
+++ b/src/renderer/components/diffEditor/blame/refForView.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { refForView } from './refForView';
+
+describe('refForView', () => {
+  it('blames the working file (null ref) for working and branch views', () => {
+    expect(refForView({ kind: 'working', ref: 'HEAD' })).toBeNull();
+    expect(refForView({ kind: 'working', ref: 'index' })).toBeNull();
+    expect(refForView({ kind: 'branch', base: 'main' })).toBeNull();
+  });
+
+  it('blames at the commit hash for a commit view', () => {
+    expect(refForView({ kind: 'commit', hash: 'abc1234' })).toBe('abc1234');
+  });
+});

--- a/src/renderer/components/diffEditor/blame/refForView.ts
+++ b/src/renderer/components/diffEditor/blame/refForView.ts
@@ -1,0 +1,11 @@
+import type { EditorView } from '../types';
+
+/**
+ * The git ref to blame against for a view's *modified* side:
+ *  - `working` / `branch` → the working file on disk (no rev → `null`, which the
+ *    IPC turns into a plain `git blame` that includes uncommitted lines)
+ *  - `commit` → that commit's hash
+ */
+export function refForView(view: EditorView): string | null {
+  return view.kind === 'commit' ? view.hash : null;
+}

--- a/src/renderer/components/diffEditor/blame/useGitBlame.ts
+++ b/src/renderer/components/diffEditor/blame/useGitBlame.ts
@@ -1,0 +1,289 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { editor as monacoEditor } from 'monaco-editor';
+import type { BlameLine } from '@shared/types';
+import type { EditorView } from '../types';
+import { refForView } from './refForView';
+import { blameLabel, contiguousBlock, type BlameLabel } from './formatBlame';
+
+interface Args {
+  cwd: string;
+  filePath: string;
+  view: EditorView;
+  modifiedEditor: monacoEditor.ICodeEditor | null;
+  monaco: typeof import('monaco-editor') | null;
+  /** Master on/off (header toggle). When false, nothing is fetched or drawn. */
+  enabled: boolean;
+  /** True only for a loaded, non-binary, non-large file — otherwise no blame. */
+  canBlame: boolean;
+}
+
+/** Rest-on-a-line delay before blame first appears (ms). */
+const HOVER_DELAY_MS = 350;
+/** Editor block fade-out duration; keep in sync with the CSS animation. */
+const BLOCK_FADE_MS = 340;
+/** Grace period after the mouse leaves the editor before blame hides — lets the
+ *  pointer travel onto the (interactive) label without it vanishing first. */
+const LEAVE_GRACE_MS = 160;
+
+/** A pixel band on the right overview-ruler strip marking the hovered commit's
+ *  extent, plus a compact label. Positioned by EditorPane (top-relative). */
+export interface BlameRulerMark {
+  top: number;
+  height: number;
+  label: BlameLabel;
+}
+
+/**
+ * Inline git blame for the modified editor. Fetches per-line authorship for the
+ * current (cwd, filePath, view); then, on hover (after a short rest delay),
+ * highlights the contiguous run of lines belonging to the hovered line's commit
+ * in the editor body, and surfaces that run as a band + a compact info card on
+ * the right overview-ruler strip — returned as `rulerMark`/`rulerVisible`/
+ * `rulerHost` for EditorPane to position and render. The card is interactive
+ * (its × disables blame); `holdLabel`/`releaseLabel` keep it shown while the
+ * pointer is on it. Everything fades in/out. Blame is fetched once per view;
+ * hovering only re-applies decorations — no IPC.
+ */
+export function useGitBlame({
+  cwd,
+  filePath,
+  view,
+  modifiedEditor,
+  monaco,
+  enabled,
+  canBlame,
+}: Args): {
+  rulerMark: BlameRulerMark | null;
+  rulerVisible: boolean;
+  rulerHost: HTMLElement | null;
+  /** Keep blame shown while the pointer is over the label (cancels the hide). */
+  holdLabel: () => void;
+  /** Release the label — schedule the grace-period hide. */
+  releaseLabel: () => void;
+} {
+  const [lines, setLines] = useState<BlameLine[]>([]);
+  // `rulerMark` keeps the last geometry/label so the band + label can fade/slide
+  // OUT in place; `rulerVisible` drives the in/out transition.
+  const [rulerMark, setRulerMark] = useState<BlameRulerMark | null>(null);
+  const [rulerVisible, setRulerVisible] = useState(false);
+  // A div inserted as the first child of Monaco's `.diffOverview` so the band
+  // paints BEHIND the ruler's diff add/delete marks; null until located.
+  const [rulerHost, setRulerHost] = useState<HTMLElement | null>(null);
+  // Stable handles for the label's mouseenter/leave — delegate to the current
+  // render effect's hide scheduling (which lives in the effect closure).
+  const holdRef = useRef<() => void>(() => {});
+  const releaseRef = useRef<() => void>(() => {});
+  const holdLabel = useCallback(() => holdRef.current(), []);
+  const releaseLabel = useCallback(() => releaseRef.current(), []);
+
+  // Fetch blame for the current view. Keyed on the inputs that change the
+  // answer; cursor movement is deliberately not a dependency.
+  useEffect(() => {
+    if (!enabled || !canBlame || !filePath) {
+      setLines([]);
+      return;
+    }
+    let cancelled = false;
+    const ref = refForView(view);
+    void window.electronAPI
+      .editorBlame({ cwd, filePath, ref })
+      .then((resp) => {
+        if (cancelled) return;
+        setLines(resp.success && resp.data ? resp.data.lines : []);
+      })
+      .catch(() => {
+        if (!cancelled) setLines([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [cwd, filePath, view, enabled, canBlame]);
+
+  // Render: a block tint over the hovered commit's run, plus the ruler band +
+  // label carrying the blame text. Hidden — faded out — when the mouse leaves.
+  useEffect(() => {
+    if (!modifiedEditor || !monaco || !enabled || lines.length === 0) return;
+
+    const lineHeight = modifiedEditor.getOption(monaco.editor.EditorOption.lineHeight);
+    const block = modifiedEditor.createDecorationsCollection();
+
+    // Insert a host behind the ruler's diff marks for the band to portal into.
+    // If the overview strip can't be found, EditorPane falls back to the area.
+    const overview = modifiedEditor
+      .getDomNode()
+      ?.closest('.monaco-diff-editor')
+      ?.querySelector('.diffOverview') as HTMLElement | null;
+    let host: HTMLDivElement | null = null;
+    if (overview) {
+      host = document.createElement('div');
+      host.className = 'monaco-blame-ruler-host';
+      overview.insertBefore(host, overview.firstChild);
+    }
+    setRulerHost(host);
+
+    // The commit run currently displayed (1-indexed, inclusive), or null when
+    // hidden. Used to suppress re-renders while the mouse stays inside the run.
+    let shownRun: { start: number; end: number } | null = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let outTimer: ReturnType<typeof setTimeout> | null = null;
+    const clearTimer = () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+    const clearOutTimer = () => {
+      if (outTimer) {
+        clearTimeout(outTimer);
+        outTimer = null;
+      }
+    };
+    const paintBlock = (run: { start: number; end: number }, className: string) => {
+      block.set([
+        {
+          range: new monaco.Range(run.start, 1, run.end, 1),
+          options: { isWholeLine: true, className },
+        },
+      ]);
+    };
+
+    // Map a commit run to a band + label on the right overview-ruler strip. The
+    // strip shows the whole file scaled into the editor's height, so this is
+    // pure content→strip math (independent of scroll). Null until laid out.
+    const buildMark = (run: { start: number; end: number }): BlameRulerMark | null => {
+      const viewportHeight = modifiedEditor.getLayoutInfo().height;
+      const scrollHeight = modifiedEditor.getScrollHeight();
+      if (!scrollHeight || !viewportHeight) return null;
+      const scale = Math.min(1, viewportHeight / scrollHeight);
+      const top = modifiedEditor.getTopForLineNumber(run.start) * scale;
+      const bottom = (modifiedEditor.getTopForLineNumber(run.end) + lineHeight) * scale;
+      const blame = lines[run.start - 1];
+      if (!blame) return null;
+      return {
+        top,
+        height: Math.max(2, bottom - top),
+        label: blameLabel(blame, Date.now() / 1000),
+      };
+    };
+
+    const hide = () => {
+      clearTimer();
+      if (!shownRun) return;
+      const run = shownRun;
+      shownRun = null;
+      setRulerVisible(false); // band + label fade out, geometry retained
+      // Fade the editor block out (out-animation), then drop the decoration.
+      clearOutTimer();
+      paintBlock(run, 'monaco-blame-block-out');
+      outTimer = setTimeout(() => {
+        outTimer = null;
+        block.clear();
+      }, BLOCK_FADE_MS);
+    };
+
+    const show = (lineNumber: number) => {
+      const model = modifiedEditor.getModel();
+      const blame = model ? lines[lineNumber - 1] : undefined;
+      const run = blame ? contiguousBlock(lines, lineNumber) : null;
+      if (!model || !blame || !run) {
+        hide();
+        return;
+      }
+      clearOutTimer(); // cancel any pending fade-out clear
+      shownRun = run;
+      paintBlock(run, 'monaco-blame-block');
+      const mark = buildMark(run);
+      if (mark) {
+        setRulerMark(mark);
+        setRulerVisible(true);
+      }
+    };
+
+    // Hover-to-line with a rest delay. Moving *within* the shown commit run is a
+    // no-op (it's the same commit), so it neither re-renders nor re-delays.
+    // Pointing at a different line/run (re)starts the delay; the current blame,
+    // if any, stays put until the new one is ready.
+    const onLine = (lineNumber: number) => {
+      if (shownRun && lineNumber >= shownRun.start && lineNumber <= shownRun.end) {
+        clearTimer();
+        return;
+      }
+      clearTimer();
+      timer = setTimeout(() => {
+        timer = null;
+        show(lineNumber);
+      }, HOVER_DELAY_MS);
+    };
+
+    // Hiding on mouse-leave is deferred by a grace period so the pointer can
+    // travel from the code onto the interactive label without it vanishing.
+    // While the pointer is actually ON the label, `overLabel` makes hover
+    // authoritative — no editor event (even a late onMouseLeave) can hide it.
+    let leaveTimer: ReturnType<typeof setTimeout> | null = null;
+    let overLabel = false;
+    const cancelHide = () => {
+      if (leaveTimer) {
+        clearTimeout(leaveTimer);
+        leaveTimer = null;
+      }
+    };
+    const scheduleHide = () => {
+      if (overLabel) return; // card hover wins — never hide while on it
+      clearTimer(); // cancel a pending show
+      cancelHide();
+      leaveTimer = setTimeout(() => {
+        leaveTimer = null;
+        if (!overLabel) hide();
+      }, LEAVE_GRACE_MS);
+    };
+    // Pointer entered the label → pin the current commit: cancel the pending
+    // hide AND any pending show (armed while crossing other lines en route), so
+    // the block + band + card stay frozen to be clicked.
+    holdRef.current = () => {
+      overLabel = true;
+      clearTimer();
+      cancelHide();
+    };
+    // Pointer left the label → resume the normal grace-period hide.
+    releaseRef.current = () => {
+      overLabel = false;
+      scheduleHide();
+    };
+
+    const moveSub = modifiedEditor.onMouseMove((e) => {
+      const ln = e.target.position?.lineNumber;
+      if (ln) {
+        cancelHide();
+        onLine(ln);
+      } else {
+        scheduleHide();
+      }
+    });
+    const leaveSub = modifiedEditor.onMouseLeave(() => scheduleHide());
+    // Re-sync the ruler band when the strip's geometry changes (resize, wrap
+    // toggle, content height) — not on scroll, which doesn't move the band.
+    const resync = () => {
+      if (!shownRun) return;
+      const mark = buildMark(shownRun);
+      if (mark) setRulerMark(mark);
+    };
+    const layoutSub = modifiedEditor.onDidLayoutChange(resync);
+    const sizeSub = modifiedEditor.onDidContentSizeChange(resync);
+
+    return () => {
+      clearTimer();
+      clearOutTimer();
+      cancelHide();
+      moveSub.dispose();
+      leaveSub.dispose();
+      layoutSub.dispose();
+      sizeSub.dispose();
+      block.clear();
+      host?.remove();
+      setRulerHost(null);
+      setRulerVisible(false);
+    };
+  }, [modifiedEditor, monaco, lines, enabled]);
+
+  return { rulerMark, rulerVisible, rulerHost, holdLabel, releaseLabel };
+}

--- a/src/renderer/components/diffEditor/blame/useGitBlame.ts
+++ b/src/renderer/components/diffEditor/blame/useGitBlame.ts
@@ -55,6 +55,10 @@ export function useGitBlame({
 }: Args): {
   rulerMark: BlameRulerMark | null;
   rulerVisible: boolean;
+  /** True only when the card moves directly between two commits (visible→visible)
+   *  — drives the eased top/height slide. False on a fresh appear so the card
+   *  doesn't glide in from the previous commit's position. */
+  rulerSlide: boolean;
   rulerHost: HTMLElement | null;
   /** Keep blame shown while the pointer is over the label (cancels the hide). */
   holdLabel: () => void;
@@ -66,6 +70,7 @@ export function useGitBlame({
   // OUT in place; `rulerVisible` drives the in/out transition.
   const [rulerMark, setRulerMark] = useState<BlameRulerMark | null>(null);
   const [rulerVisible, setRulerVisible] = useState(false);
+  const [rulerSlide, setRulerSlide] = useState(false);
   // A div inserted as the first child of Monaco's `.diffOverview` so the band
   // paints BEHIND the ruler's diff add/delete marks; null until located.
   const [rulerHost, setRulerHost] = useState<HTMLElement | null>(null);
@@ -190,10 +195,14 @@ export function useGitBlame({
         return;
       }
       clearOutTimer(); // cancel any pending fade-out clear
+      // A move between two already-shown commits should slide; a fresh appear
+      // (was hidden) should snap to position, then fade in.
+      const moving = shownRun !== null;
       shownRun = run;
       paintBlock(run, 'monaco-blame-block');
       const mark = buildMark(run);
       if (mark) {
+        setRulerSlide(moving);
         setRulerMark(mark);
         setRulerVisible(true);
       }
@@ -285,5 +294,5 @@ export function useGitBlame({
     };
   }, [modifiedEditor, monaco, lines, enabled]);
 
-  return { rulerMark, rulerVisible, rulerHost, holdLabel, releaseLabel };
+  return { rulerMark, rulerVisible, rulerSlide, rulerHost, holdLabel, releaseLabel };
 }

--- a/src/renderer/components/diffEditor/comments/BubbleStack.tsx
+++ b/src/renderer/components/diffEditor/comments/BubbleStack.tsx
@@ -16,6 +16,9 @@ interface Props {
   onEdit(comment: LiveComment): void;
   /** Click the in-bubble × → delete this comment. */
   onDelete(id: string): void;
+  /** Origin tag for every bubble in this view (e.g. 'Commit abc1234'), or
+   *  undefined in the plain working view where no tag is needed. */
+  scopeLabel?: string;
   /** Id of the comment currently being edited — its persisted card fades
    *  out as the DraftBubble crossfades in beside it. Null when nothing is
    *  being edited. */
@@ -38,6 +41,7 @@ export function BubbleStack({
   onEdit,
   onDelete,
   editingId,
+  scopeLabel,
 }: Props) {
   const stacked = comments.length >= 2;
   return (
@@ -53,6 +57,8 @@ export function BubbleStack({
               stacked ? `${metaLabel(c)} — comment ${i + 1} of ${comments.length}` : metaLabel(c)
             }
             text={c.text}
+            sent={c.sent}
+            scopeLabel={scopeLabel}
             hasTail={isLast}
             isHighlighted={hoveredId === c.id}
             tailLeftPx={tailLeftPx}

--- a/src/renderer/components/diffEditor/comments/CommentBubble.tsx
+++ b/src/renderer/components/diffEditor/comments/CommentBubble.tsx
@@ -7,6 +7,12 @@ interface Props {
   /** Short label like 'L15-18' rendered above the body text. */
   meta: string;
   text: string;
+  /** Already pushed to the agent — the card dims to read as "done". */
+  sent: boolean;
+  /** Origin tag (e.g. 'Working tree', 'Commit abc1234') shown when the open
+   *  view isn't the plain working tree, so it's clear which diff this anchors
+   *  to. Undefined → no tag. */
+  scopeLabel?: string;
   /** Only the bottom-most bubble in a stack shows a tail. */
   hasTail: boolean;
   /** Bubble fill intensifies when the row OR this bubble is hovered. */
@@ -32,6 +38,8 @@ export function CommentBubble({
   shade,
   meta,
   text,
+  sent,
+  scopeLabel,
   hasTail,
   isHighlighted,
   tailLeftPx,
@@ -41,10 +49,14 @@ export function CommentBubble({
   onDelete,
   isFadingOut,
 }: Props) {
+  // A sent comment fades back so it reads as "already pushed" without
+  // disappearing (it stays editable/removable). A bubble mid-edit takes
+  // precedence and fades fully out as the draft crossfades in.
+  const opacity = isFadingOut ? 0 : sent ? 0.4 : 1;
   return (
     <div
       style={{
-        opacity: isFadingOut ? 0 : 1,
+        opacity,
         transition: 'opacity 240ms ease-out',
         pointerEvents: isFadingOut ? 'none' : 'auto',
       }}
@@ -71,8 +83,20 @@ export function CommentBubble({
           >
             <X size={13} strokeWidth={1.8} />
           </button>
-          <div className="font-mono text-[10px] text-muted-foreground/55 mb-[2px] tracking-normal">
-            {meta}
+          <div className="flex items-center gap-[6px] mb-[2px]">
+            <span className="font-mono text-[10px] text-muted-foreground/55 tracking-normal">
+              {meta}
+            </span>
+            {scopeLabel && (
+              <span className="rounded-[3px] bg-primary/12 px-[5px] py-[1px] text-[9px] font-medium text-primary/80">
+                {scopeLabel}
+              </span>
+            )}
+            {sent && (
+              <span className="rounded-[3px] bg-foreground/10 px-[5px] py-[1px] text-[9px] font-medium uppercase tracking-[0.04em] text-muted-foreground/75">
+                Sent
+              </span>
+            )}
           </div>
           <div className="whitespace-pre-wrap wrap-break-word">{text}</div>
         </div>

--- a/src/renderer/components/diffEditor/comments/CommentsMenu.tsx
+++ b/src/renderer/components/diffEditor/comments/CommentsMenu.tsx
@@ -11,32 +11,34 @@ import {
   X,
 } from 'lucide-react';
 import { Popover, PopoverArrow, PopoverContent, PopoverTrigger } from '../../ui/Popover';
+import { scopeLabel } from './commentScope';
 import type { DiffComment } from './types';
 
 const ACCORDION_TRANSITION = { duration: 0.18, ease: [0.16, 1, 0.3, 1] as const };
 const ROW_TRANSITION = { duration: 0.16, ease: [0.16, 1, 0.3, 1] as const };
 
 interface Props {
+  /** All comments across every view (scope). */
   commentsByFile: Record<string, DiffComment[]>;
   currentFilePath: string;
-  /** Returns the current model's live range for the given comment id, or
-   *  null if the comment isn't in the current file. Lets the dropdown show
-   *  up-to-the-second line numbers for the open file (which may have
-   *  shifted due to typing) while non-current files fall back to stored. */
+  /** Scope of the open view — its section sorts first and is highlighted. */
+  currentScope: string;
+  /** Live range for a comment in the OPEN view's current file (else null). */
   getLiveRangeForCurrent: (commentId: string) => { start: number; end: number } | null;
-  onNavigate: (filePath: string, commentId: string) => void;
+  /** Jump to a comment — switches to its view (scope) + file as needed. */
+  onNavigate: (scope: string, filePath: string, commentId: string) => void;
   onRemove: (filePath: string, commentId: string) => void;
   onUnsend: (commentId: string) => void;
-  /** Send every unsent comment. Closes the modal afterward. */
-  onSend: () => void;
-  /** Open the edit-before-send modal pre-filled with every unsent comment. */
+  /** Send all unsent comments of one view. */
+  onSendScope: (scope: string) => void;
+  /** Send every unsent comment across all views. Closes the menu. */
+  onSendAll: () => void;
+  /** Open the edit-before-send modal prefilled with every unsent comment. */
   onEditAndSend: () => void;
-  /** Send a single comment. Keeps the dropdown + modal open. */
+  /** Send a single comment. Keeps the dropdown open. */
   onSendOne: (commentId: string) => void;
 }
 
-/** Split a path into its directory prefix and base name so the directory
- *  can be dimmed and the filename emphasized in the file header. */
 function splitPath(p: string): { dir: string; base: string } {
   const i = p.lastIndexOf('/');
   if (i < 0) return { dir: '', base: p };
@@ -45,8 +47,7 @@ function splitPath(p: string): { dir: string; base: string } {
 
 type Group = [string, DiffComment[]];
 
-/** Bucket comments by file path, keep only non-empty buckets, and place the
- *  current file at the top. Pure for memoization. */
+/** Bucket comments by file (matching `predicate`), current file first. */
 function bucketByFile(
   source: Record<string, DiffComment[]>,
   predicate: (c: DiffComment) => boolean,
@@ -62,42 +63,78 @@ function bucketByFile(
     });
 }
 
+interface ScopeView {
+  scope: string;
+  label: string;
+  isCurrent: boolean;
+  groups: Group[];
+  count: number;
+}
+
 export function CommentsMenu({
   commentsByFile,
   currentFilePath,
+  currentScope,
   getLiveRangeForCurrent,
   onNavigate,
   onRemove,
   onUnsend,
-  onSend,
+  onSendScope,
+  onSendAll,
   onEditAndSend,
   onSendOne,
 }: Props) {
   const [open, setOpen] = useState(false);
 
-  // Parent re-renders on every keystroke / scroll — memoize the two buckets
-  // so this menu doesn't reshuffle on each pass.
-  const unsentGroups = useMemo(
-    () => bucketByFile(commentsByFile, (c) => !c.sent, currentFilePath),
-    [commentsByFile, currentFilePath],
-  );
-  const sentGroups = useMemo(
-    () => bucketByFile(commentsByFile, (c) => c.sent, currentFilePath),
-    [commentsByFile, currentFilePath],
-  );
-  const unsentCount = useMemo(
-    () => unsentGroups.reduce((n, [, l]) => n + l.length, 0),
-    [unsentGroups],
-  );
-  const sentCount = useMemo(() => sentGroups.reduce((n, [, l]) => n + l.length, 0), [sentGroups]);
-  const noUnsent = unsentCount === 0;
+  const { unsentViews, sentViews, totalUnsent, totalSent } = useMemo(() => {
+    const byScope = new Map<string, Record<string, DiffComment[]>>();
+    for (const [path, list] of Object.entries(commentsByFile)) {
+      for (const c of list) {
+        let rec = byScope.get(c.viewScope);
+        if (!rec) {
+          rec = {};
+          byScope.set(c.viewScope, rec);
+        }
+        (rec[path] ??= []).push(c);
+      }
+    }
+    const orderedScopes = Array.from(byScope.keys()).sort((a, b) => {
+      if (a === currentScope) return -1;
+      if (b === currentScope) return 1;
+      if (a === 'live') return -1;
+      if (b === 'live') return 1;
+      return a.localeCompare(b);
+    });
+    const view = (scope: string, predicate: (c: DiffComment) => boolean): ScopeView => {
+      const groups = bucketByFile(byScope.get(scope)!, predicate, currentFilePath);
+      return {
+        scope,
+        label: scopeLabel(scope),
+        isCurrent: scope === currentScope,
+        groups,
+        count: groups.reduce((n, [, l]) => n + l.length, 0),
+      };
+    };
+    const unsent = orderedScopes.map((s) => view(s, (c) => !c.sent)).filter((v) => v.count > 0);
+    const sent = orderedScopes.map((s) => view(s, (c) => c.sent)).filter((v) => v.count > 0);
+    return {
+      unsentViews: unsent,
+      sentViews: sent,
+      totalUnsent: unsent.reduce((n, v) => n + v.count, 0),
+      totalSent: sent.reduce((n, v) => n + v.count, 0),
+    };
+  }, [commentsByFile, currentScope, currentFilePath]);
 
-  // Accordion state — initialized lazily from the first render's counts so
-  // a freshly-opened menu lands on the meaningful section. The user can
-  // toggle freely after that; we don't override their choice on every
-  // count change.
-  const [unsentOpen, setUnsentOpen] = useState(() => unsentCount > 0);
-  const [sentOpen, setSentOpen] = useState(() => unsentCount === 0 && sentCount > 0);
+  const noUnsent = totalUnsent === 0;
+
+  const rowHandlers = {
+    getLiveRangeForCurrent,
+    onNavigate,
+    onRemove,
+    onSendOne,
+    onUnsend,
+    closeMenu: () => setOpen(false),
+  };
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -108,11 +145,7 @@ export function CommentsMenu({
               ? 'border-border/40 bg-foreground/2.5 text-muted-foreground/80 hover:bg-foreground/6 hover:border-border/55 hover:text-foreground/90'
               : 'border-primary/30 bg-primary/9 text-primary hover:bg-primary/[0.14] hover:border-primary/45'
           }`}
-          style={{
-            // Inner glass-lip highlight on the active pill — barely
-            // perceptible, but it lifts the capsule off the header bar.
-            boxShadow: noUnsent ? undefined : 'inset 0 1px 0 hsl(0 0% 100% / 0.06)',
-          }}
+          style={{ boxShadow: noUnsent ? undefined : 'inset 0 1px 0 hsl(0 0% 100% / 0.06)' }}
         >
           <MessageSquare
             size={12}
@@ -124,7 +157,7 @@ export function CommentsMenu({
               <>0 to send</>
             ) : (
               <>
-                <span className="font-semibold">{unsentCount}</span> to send
+                <span className="font-semibold">{totalUnsent}</span> to send
               </>
             )}
           </span>
@@ -141,67 +174,46 @@ export function CommentsMenu({
         sideOffset={8}
         className="glass-popover w-[460px] max-h-[520px] flex flex-col p-0 overflow-hidden"
       >
-        {/* Header. The hairline uses `foreground/0.06` so it reads in both
-            themes as a soft fold in the glass, not a hard division line. */}
-        <div className="flex items-baseline justify-between px-4 pt-3 pb-2.5 border-b border-foreground/6">
+        <div className="flex items-baseline justify-between px-4 pt-3 pb-2.5 border-b border-foreground/6 shrink-0">
           <h3 className="text-[12px] font-semibold tracking-tight text-foreground/90">Comments</h3>
           <span className="text-[10.5px] text-muted-foreground/60 tabular-nums tracking-tight">
-            {unsentCount + sentCount} total
+            {totalUnsent + totalSent} total
           </span>
         </div>
 
-        {/* Body */}
         <div className="flex-1 min-h-0 overflow-y-auto">
-          <AccordionSection
-            label="Unsent"
-            count={unsentCount}
-            accent="primary"
-            open={unsentOpen}
-            onToggle={() => setUnsentOpen((o) => !o)}
-            emptyState="No unsent comments — everything's been pushed."
-            groups={unsentGroups}
-            currentFilePath={currentFilePath}
-            getLiveRangeForCurrent={getLiveRangeForCurrent}
-            onNavigate={(path, id) => {
-              setOpen(false);
-              onNavigate(path, id);
-            }}
-            onRemove={onRemove}
-            onSendOne={onSendOne}
-            onUnsend={onUnsend}
-          />
-          {sentCount > 0 && (
-            <AccordionSection
-              label="Sent"
-              count={sentCount}
-              accent="muted"
-              open={sentOpen}
-              onToggle={() => setSentOpen((o) => !o)}
-              emptyState="Nothing sent yet."
-              groups={sentGroups}
+          {unsentViews.map((v) => (
+            <UnsentSection
+              key={v.scope}
+              view={v}
               currentFilePath={currentFilePath}
-              getLiveRangeForCurrent={getLiveRangeForCurrent}
-              onNavigate={(path, id) => {
-                setOpen(false);
-                onNavigate(path, id);
-              }}
-              onRemove={onRemove}
-              onSendOne={onSendOne}
-              onUnsend={onUnsend}
+              onSendScope={() => onSendScope(v.scope)}
+              {...rowHandlers}
             />
+          ))}
+          {totalSent > 0 && (
+            <SentSection
+              views={sentViews}
+              total={totalSent}
+              currentFilePath={currentFilePath}
+              {...rowHandlers}
+            />
+          )}
+          {noUnsent && totalSent === 0 && (
+            <div className="px-4 py-6 text-center text-[11px] italic text-muted-foreground/55">
+              No comments yet.
+            </div>
           )}
         </div>
 
-        {/* Footer. Mirror the header's soft hairline; subtle tinted ground
-            so the CTA still has its own visual lane. */}
-        <div className="flex items-center justify-between gap-3 px-3 py-2.5 border-t border-foreground/6 bg-foreground/2">
+        <div className="flex items-center justify-between gap-3 px-3 py-2.5 border-t border-foreground/6 bg-foreground/2 shrink-0">
           <span className="text-[10.5px] text-muted-foreground/65 leading-tight">
             {noUnsent ? (
               <>All caught up</>
             ) : (
               <>
-                <span className="font-medium text-foreground/85 tabular-nums">{unsentCount}</span>{' '}
-                ready for your next prompt
+                <span className="font-medium text-foreground/85 tabular-nums">{totalUnsent}</span>{' '}
+                across {unsentViews.length} view{unsentViews.length !== 1 ? 's' : ''}
               </>
             )}
           </span>
@@ -224,7 +236,7 @@ export function CommentsMenu({
               disabled={noUnsent}
               onClick={() => {
                 setOpen(false);
-                onSend();
+                onSendAll();
               }}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[11px] font-medium bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition disabled:opacity-40 disabled:cursor-not-allowed disabled:active:scale-100"
             >
@@ -239,129 +251,212 @@ export function CommentsMenu({
   );
 }
 
-interface AccordionProps {
-  label: string;
-  count: number;
-  /** Accent for the section header dot + comment-card left bars. */
-  accent: 'primary' | 'muted';
-  open: boolean;
-  onToggle: () => void;
-  emptyState: string;
-  groups: Group[];
-  currentFilePath: string;
+interface RowHandlers {
   getLiveRangeForCurrent: (commentId: string) => { start: number; end: number } | null;
-  onNavigate: (filePath: string, commentId: string) => void;
+  onNavigate: (scope: string, filePath: string, commentId: string) => void;
   onRemove: (filePath: string, commentId: string) => void;
   onSendOne: (commentId: string) => void;
   onUnsend: (commentId: string) => void;
+  closeMenu: () => void;
 }
 
-function AccordionSection({
-  label,
-  count,
-  accent,
-  open,
-  onToggle,
-  emptyState,
-  groups,
+/** Sticky header so it stays visible as the body scrolls — like the right
+ *  inspector's section bars. The glass background occludes scrolling rows. */
+function StickyHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="sticky top-0 z-10 bg-[hsl(var(--surface-1)/0.92)] backdrop-blur-md">
+      {children}
+    </div>
+  );
+}
+
+function UnsentSection({
+  view,
+  currentFilePath,
+  onSendScope,
+  getLiveRangeForCurrent,
+  onNavigate,
+  onRemove,
+  onSendOne,
+  onUnsend,
+  closeMenu,
+}: { view: ScopeView; currentFilePath: string; onSendScope: () => void } & RowHandlers) {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="border-b border-foreground/5 last:border-b-0">
+      <StickyHeader>
+        <div className="flex items-center gap-2 px-3 py-2 hover:bg-foreground/[0.035] transition-colors">
+          <button
+            type="button"
+            onClick={() => setOpen((o) => !o)}
+            className="flex items-center gap-2 flex-1 min-w-0 text-left"
+          >
+            {open ? (
+              <ChevronDown
+                size={12}
+                strokeWidth={2}
+                className="text-muted-foreground/70 shrink-0"
+              />
+            ) : (
+              <ChevronRight
+                size={12}
+                strokeWidth={2}
+                className="text-muted-foreground/70 shrink-0"
+              />
+            )}
+            <span
+              className={`w-1.5 h-1.5 rounded-full shrink-0 ${view.isCurrent ? 'bg-primary/80' : 'bg-primary/50'}`}
+              aria-hidden
+            />
+            <span className="text-[11px] font-semibold tracking-tight text-foreground/90 truncate">
+              {view.label}
+            </span>
+            {view.isCurrent && (
+              <span className="shrink-0 text-[9px] uppercase tracking-wider font-medium text-primary/75">
+                current
+              </span>
+            )}
+            <span className="text-[10.5px] text-muted-foreground/60 tabular-nums shrink-0">
+              {view.count} to send
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={onSendScope}
+            title={`Send ${view.count} comment${view.count !== 1 ? 's' : ''} in ${view.label}`}
+            className="shrink-0 flex items-center gap-1 px-2 py-1 rounded-md text-[10.5px] font-medium text-primary hover:bg-primary/12 active:scale-[0.98] transition"
+          >
+            <Send size={10} strokeWidth={2.2} />
+            Send
+          </button>
+        </div>
+      </StickyHeader>
+      <SectionBody open={open}>
+        {view.groups.map(([path, list], gi) => (
+          <FileGroup
+            key={path}
+            path={path}
+            scope={view.scope}
+            list={list}
+            isCurrent={path === currentFilePath}
+            marginTop={gi > 0}
+            getLiveRangeForCurrent={view.isCurrent ? getLiveRangeForCurrent : () => null}
+            onNavigate={onNavigate}
+            onRemove={onRemove}
+            onSendOne={onSendOne}
+            onUnsend={onUnsend}
+            closeMenu={closeMenu}
+          />
+        ))}
+      </SectionBody>
+    </div>
+  );
+}
+
+function SentSection({
+  views,
+  total,
   currentFilePath,
   getLiveRangeForCurrent,
   onNavigate,
   onRemove,
   onSendOne,
   onUnsend,
-}: AccordionProps) {
-  const isSent = accent === 'muted';
-  const dotClass = isSent ? 'bg-muted-foreground/40' : 'bg-primary/70';
+  closeMenu,
+}: { views: ScopeView[]; total: number; currentFilePath: string } & RowHandlers) {
+  const [open, setOpen] = useState(false);
   return (
     <div className="border-b border-foreground/5 last:border-b-0">
-      <button
-        type="button"
-        onClick={onToggle}
-        className="w-full flex items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-foreground/[0.035]"
-      >
-        {open ? (
-          <ChevronDown size={12} strokeWidth={2} className="text-muted-foreground/70" />
-        ) : (
-          <ChevronRight size={12} strokeWidth={2} className="text-muted-foreground/70" />
-        )}
-        <span className={`w-1.5 h-1.5 rounded-full ${dotClass}`} aria-hidden />
-        <span
-          className={`text-[11px] font-semibold tracking-tight ${
-            isSent ? 'text-muted-foreground/85' : 'text-foreground/90'
-          }`}
+      <StickyHeader>
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-foreground/[0.035] transition-colors"
         >
-          {label}
-        </span>
-        <span className="text-[10.5px] text-muted-foreground/60 tabular-nums">{count}</span>
-      </button>
-      <AnimatePresence initial={false}>
-        {open && (
-          <motion.div
-            key="body"
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={ACCORDION_TRANSITION}
-            style={{ overflow: 'hidden' }}
-          >
-            <div className="px-2 pb-2">
-              {count === 0 ? (
-                <div className="px-3 py-3 text-[11px] italic text-muted-foreground/55">
-                  {emptyState}
-                </div>
-              ) : (
-                groups.map(([path, list], gi) => (
-                  <FileGroup
-                    key={path}
-                    path={path}
-                    list={list}
-                    isCurrent={path === currentFilePath}
-                    marginTop={gi > 0}
-                    accent={accent}
-                    getLiveRangeForCurrent={getLiveRangeForCurrent}
-                    onNavigate={onNavigate}
-                    onRemove={onRemove}
-                    onSendOne={onSendOne}
-                    onUnsend={onUnsend}
-                  />
-                ))
-              )}
+          {open ? (
+            <ChevronDown size={12} strokeWidth={2} className="text-muted-foreground/70 shrink-0" />
+          ) : (
+            <ChevronRight size={12} strokeWidth={2} className="text-muted-foreground/70 shrink-0" />
+          )}
+          <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/40 shrink-0" aria-hidden />
+          <span className="text-[11px] font-semibold tracking-tight text-muted-foreground/85">
+            Sent
+          </span>
+          <span className="text-[10.5px] text-muted-foreground/60 tabular-nums">{total}</span>
+        </button>
+      </StickyHeader>
+      <SectionBody open={open}>
+        {views.map((v) => (
+          <div key={v.scope} className="mt-1 first:mt-0">
+            <div className="flex items-center gap-1.5 px-2 pt-1.5 pb-0.5">
+              <span className="text-[9px] uppercase tracking-wider font-medium text-muted-foreground/50">
+                {v.label}
+              </span>
             </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+            {v.groups.map(([path, list], gi) => (
+              <FileGroup
+                key={`${v.scope}-${path}`}
+                path={path}
+                scope={v.scope}
+                list={list}
+                isCurrent={v.isCurrent && path === currentFilePath}
+                marginTop={gi > 0}
+                getLiveRangeForCurrent={v.isCurrent ? getLiveRangeForCurrent : () => null}
+                onNavigate={onNavigate}
+                onRemove={onRemove}
+                onSendOne={onSendOne}
+                onUnsend={onUnsend}
+                closeMenu={closeMenu}
+              />
+            ))}
+          </div>
+        ))}
+      </SectionBody>
     </div>
   );
 }
 
-interface FileGroupProps {
+function SectionBody({ open, children }: { open: boolean; children: React.ReactNode }) {
+  return (
+    <AnimatePresence initial={false}>
+      {open && (
+        <motion.div
+          key="body"
+          initial={{ height: 0, opacity: 0 }}
+          animate={{ height: 'auto', opacity: 1 }}
+          exit={{ height: 0, opacity: 0 }}
+          transition={ACCORDION_TRANSITION}
+          style={{ overflow: 'hidden' }}
+        >
+          <div className="px-2 pb-2">{children}</div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+interface FileGroupProps extends RowHandlers {
   path: string;
+  scope: string;
   list: DiffComment[];
   isCurrent: boolean;
   marginTop: boolean;
-  accent: 'primary' | 'muted';
-  getLiveRangeForCurrent: (commentId: string) => { start: number; end: number } | null;
-  onNavigate: (filePath: string, commentId: string) => void;
-  onRemove: (filePath: string, commentId: string) => void;
-  onSendOne: (commentId: string) => void;
-  onUnsend: (commentId: string) => void;
 }
 
 function FileGroup({
   path,
+  scope,
   list,
   isCurrent,
   marginTop,
-  accent,
   getLiveRangeForCurrent,
   onNavigate,
   onRemove,
   onSendOne,
   onUnsend,
+  closeMenu,
 }: FileGroupProps) {
   const { dir, base } = splitPath(path);
-  const isSent = accent === 'muted';
   return (
     <div className={marginTop ? 'mt-2' : ''}>
       <div className="flex items-baseline gap-2 px-2 py-1">
@@ -395,12 +490,15 @@ function FileGroup({
                 <span
                   aria-hidden
                   className={`shrink-0 w-[3px] rounded-full my-1 transition-colors ${
-                    isSent ? 'bg-muted-foreground/25' : 'bg-primary/70'
+                    c.sent ? 'bg-muted-foreground/25' : 'bg-primary/70'
                   }`}
                 />
                 <button
                   type="button"
-                  onClick={() => onNavigate(path, c.id)}
+                  onClick={() => {
+                    closeMenu();
+                    onNavigate(scope, path, c.id);
+                  }}
                   title="Jump to this comment"
                   className="flex-1 min-w-0 flex flex-col gap-1 px-2.5 py-1.5 pr-14 text-left rounded-md"
                 >
@@ -409,17 +507,14 @@ function FileGroup({
                   </span>
                   <span
                     className={`text-[12.5px] leading-snug whitespace-pre-wrap wrap-break-word ${
-                      isSent ? 'text-foreground/55' : 'text-foreground/90'
+                      c.sent ? 'text-foreground/55' : 'text-foreground/90'
                     }`}
                   >
                     {c.text}
                   </span>
                 </button>
-                {/* Hover-only action cluster. Either Send (unsent) or Undo
-                  (sent), plus Remove. Consistent rule across all states:
-                  no action ever shows at rest. */}
                 <div className="absolute top-1.5 right-1.5 flex items-center gap-0.5 opacity-0 group-hover/item:opacity-100 transition-opacity">
-                  {isSent ? (
+                  {c.sent ? (
                     <ActionButton
                       label="Include in next prompt"
                       onClick={() => onUnsend(c.id)}

--- a/src/renderer/components/diffEditor/comments/__tests__/commentPrompt.test.ts
+++ b/src/renderer/components/diffEditor/comments/__tests__/commentPrompt.test.ts
@@ -7,12 +7,15 @@ const pc = (over: Partial<PromptComment>): PromptComment => ({
   startLine: over.startLine ?? 1,
   endLine: over.endLine ?? 1,
   text: over.text ?? 'note',
+  viewScope: over.viewScope ?? 'live',
   ...over,
 });
 
 describe('buildCommentPrompt', () => {
   it('returns null when no ids selected', () => {
-    expect(buildCommentPrompt({ ids: [], byFile: {}, currentFilePath: 'a.ts' })).toBeNull();
+    expect(
+      buildCommentPrompt({ ids: [], byFile: {}, currentFilePath: 'a.ts', currentScope: 'live' }),
+    ).toBeNull();
   });
 
   it('formats a single comment with path:line header', () => {
@@ -20,6 +23,7 @@ describe('buildCommentPrompt', () => {
       ids: ['c'],
       byFile: { 'a.ts': [pc({ id: 'c', startLine: 3, endLine: 3, text: 'fix this' })] },
       currentFilePath: 'a.ts',
+      currentScope: 'live',
     });
     expect(out).toBe('Comments:\n\na.ts:3:\nfix this');
   });
@@ -32,6 +36,7 @@ describe('buildCommentPrompt', () => {
         'a.ts': [pc({ id: 'x', filePath: 'a.ts', startLine: 5, endLine: 7, text: 'current' })],
       },
       currentFilePath: 'a.ts',
+      currentScope: 'live',
     });
     expect(out).toBe('Comments:\n\na.ts:5-7:\ncurrent\n\nz.ts:1-2:\nother');
   });
@@ -41,8 +46,30 @@ describe('buildCommentPrompt', () => {
       ids: ['x'],
       byFile: { 'a.ts': [pc({ id: 'x', startLine: 2, endLine: 2, text: 'see code' })] },
       currentFilePath: 'a.ts',
+      currentScope: 'live',
       currentFile: { language: 'typescript', codeForId: () => 'const a = 1;' },
     });
     expect(out).toBe('Comments:\n\na.ts:2:\n```typescript\nconst a = 1;\n```\nsee code');
+  });
+
+  it('labels a commit-scoped comment and skips code enrichment when scope differs', () => {
+    const out = buildCommentPrompt({
+      ids: ['x'],
+      byFile: {
+        'a.ts': [
+          pc({ id: 'x', startLine: 4, endLine: 4, text: 'old', viewScope: 'commit:abcdef123' }),
+        ],
+      },
+      currentFilePath: 'a.ts',
+      currentScope: 'live',
+      // codeForId would throw if called — proves enrichment is skipped on scope mismatch.
+      currentFile: {
+        language: 'typescript',
+        codeForId: () => {
+          throw new Error('should not enrich a different scope');
+        },
+      },
+    });
+    expect(out).toBe('Comments:\n\na.ts:4: (commit abcdef1)\nold');
   });
 });

--- a/src/renderer/components/diffEditor/comments/__tests__/commentScope.test.ts
+++ b/src/renderer/components/diffEditor/comments/__tests__/commentScope.test.ts
@@ -68,4 +68,19 @@ describe('commentCountsByScope', () => {
     expect(counts.get('live')).toBe(3);
     expect(counts.get('commit:abc')).toBe(1);
   });
+
+  it('excludes already-sent comments from the per-scope tallies', () => {
+    const byFile = {
+      'a.ts': [
+        { id: '1', viewScope: 'live', sent: false },
+        { id: '2', viewScope: 'live', sent: true },
+        { id: '3', viewScope: 'commit:abc', sent: true },
+      ],
+      'b.ts': [{ id: '4', viewScope: 'live', sent: false }],
+    };
+    const counts = commentCountsByScope(byFile);
+    expect(counts.get('live')).toBe(2);
+    // Every commit-scoped comment was sent → scope drops out of the map.
+    expect(counts.get('commit:abc')).toBeUndefined();
+  });
 });

--- a/src/renderer/components/diffEditor/comments/__tests__/commentScope.test.ts
+++ b/src/renderer/components/diffEditor/comments/__tests__/commentScope.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  commentCountsByScope,
+  commentScope,
+  commitShortHash,
+  filterCommentsByScope,
+  scopeLabel,
+} from '../commentScope';
+
+describe('commentScope', () => {
+  it('maps working and branch views to the shared "live" scope', () => {
+    expect(commentScope({ kind: 'working', ref: 'HEAD' })).toBe('live');
+    expect(commentScope({ kind: 'working', ref: 'index' })).toBe('live');
+    expect(commentScope({ kind: 'branch', base: 'main' })).toBe('live');
+    expect(commentScope({ kind: 'branch', base: 'origin/main' })).toBe('live');
+  });
+
+  it('scopes a commit view to its hash', () => {
+    expect(commentScope({ kind: 'commit', hash: 'abc123' })).toBe('commit:abc123');
+  });
+});
+
+describe('filterCommentsByScope', () => {
+  const c = (id: string, viewScope: string) => ({ id, viewScope });
+
+  it('keeps only matching-scope comments and drops emptied files', () => {
+    const byFile = {
+      'a.ts': [c('1', 'live'), c('2', 'commit:abc')],
+      'b.ts': [c('3', 'commit:abc')],
+      'c.ts': [c('4', 'live')],
+    };
+    expect(filterCommentsByScope(byFile, 'live')).toEqual({
+      'a.ts': [c('1', 'live')],
+      'c.ts': [c('4', 'live')],
+    });
+  });
+
+  it('returns an empty map when nothing matches', () => {
+    expect(filterCommentsByScope({ 'a.ts': [c('1', 'live')] }, 'commit:xyz')).toEqual({});
+  });
+});
+
+describe('scopeLabel + commitShortHash', () => {
+  it('labels the live scope as Working tree', () => {
+    expect(scopeLabel('live')).toBe('Working tree');
+    expect(commitShortHash('live')).toBeNull();
+  });
+
+  it('labels a commit scope with its short hash', () => {
+    expect(scopeLabel('commit:abcdef1234567890')).toBe('Commit abcdef1');
+    expect(commitShortHash('commit:abcdef1234567890')).toBe('abcdef1');
+  });
+});
+
+describe('commentCountsByScope', () => {
+  it('tallies comments per scope across files', () => {
+    const byFile = {
+      'a.ts': [
+        { id: '1', viewScope: 'live' },
+        { id: '2', viewScope: 'commit:abc' },
+      ],
+      'b.ts': [
+        { id: '3', viewScope: 'live' },
+        { id: '4', viewScope: 'live' },
+      ],
+    };
+    const counts = commentCountsByScope(byFile);
+    expect(counts.get('live')).toBe(3);
+    expect(counts.get('commit:abc')).toBe(1);
+  });
+});

--- a/src/renderer/components/diffEditor/comments/__tests__/liveProjection.test.ts
+++ b/src/renderer/components/diffEditor/comments/__tests__/liveProjection.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { projectRanges, rangesEqual, type RangeReader } from '../liveProjection';
+import {
+  isFullModelReplace,
+  projectRanges,
+  rangesEqual,
+  type RangeReader,
+} from '../liveProjection';
 import type { LiveComment } from '../types';
 
 const live = (id: string, startLine: number, endLine: number): LiveComment => ({
@@ -10,6 +15,7 @@ const live = (id: string, startLine: number, endLine: number): LiveComment => ({
   endLine,
   text: 't',
   sent: false,
+  viewScope: 'live',
   createdAt: '',
   updatedAt: '',
   decorationId: `dec-${id}`,
@@ -35,5 +41,46 @@ describe('rangesEqual', () => {
   });
   it('false when membership differs', () => {
     expect(rangesEqual([live('a', 1, 2)], [live('a', 1, 2), live('b', 4, 4)])).toBe(false);
+  });
+});
+
+describe('isFullModelReplace', () => {
+  const newDoc = 'line1\nline2\nline3';
+
+  it('true for a flush (setValue in commit view)', () => {
+    expect(isFullModelReplace({ isFlush: true, changes: [] }, newDoc)).toBe(true);
+  });
+
+  it('true for the lib full-range edit: one change at offset 0 whose text is the whole new doc', () => {
+    expect(
+      isFullModelReplace({ isFlush: false, changes: [{ rangeOffset: 0, text: newDoc }] }, newDoc),
+    ).toBe(true);
+  });
+
+  it('false for an incremental edit (typing a char mid-document)', () => {
+    expect(
+      isFullModelReplace({ isFlush: false, changes: [{ rangeOffset: 12, text: 'x' }] }, newDoc),
+    ).toBe(false);
+  });
+
+  it('false for an edit at offset 0 that only replaces part of the doc', () => {
+    expect(
+      isFullModelReplace({ isFlush: false, changes: [{ rangeOffset: 0, text: 'line1' }] }, newDoc),
+    ).toBe(false);
+  });
+
+  it('false for a multi-change edit (e.g. multi-cursor)', () => {
+    expect(
+      isFullModelReplace(
+        {
+          isFlush: false,
+          changes: [
+            { rangeOffset: 0, text: 'a' },
+            { rangeOffset: 5, text: 'b' },
+          ],
+        },
+        newDoc,
+      ),
+    ).toBe(false);
   });
 });

--- a/src/renderer/components/diffEditor/comments/__tests__/rowShades.test.ts
+++ b/src/renderer/components/diffEditor/comments/__tests__/rowShades.test.ts
@@ -11,6 +11,7 @@ function c(over: Partial<DiffComment>): DiffComment {
     endLine: 1,
     text: '',
     sent: false,
+    viewScope: 'live',
     createdAt: '2026-06-05T00:00:00Z',
     updatedAt: '2026-06-05T00:00:00Z',
     ...over,

--- a/src/renderer/components/diffEditor/comments/__tests__/shadeAssignment.test.ts
+++ b/src/renderer/components/diffEditor/comments/__tests__/shadeAssignment.test.ts
@@ -11,6 +11,7 @@ function c(over: Partial<DiffComment>): DiffComment {
     endLine: 1,
     text: '',
     sent: false,
+    viewScope: 'live',
     createdAt: '2026-06-05T00:00:00Z',
     updatedAt: '2026-06-05T00:00:00Z',
     ...over,

--- a/src/renderer/components/diffEditor/comments/commentPrompt.ts
+++ b/src/renderer/components/diffEditor/comments/commentPrompt.ts
@@ -4,12 +4,17 @@ export interface PromptComment {
   startLine: number;
   endLine: number;
   text: string;
+  /** Diff state the comment is anchored to ('live' or 'commit:<hash>'). */
+  viewScope: string;
 }
 
 export interface BuildPromptArgs {
   ids: ReadonlyArray<string>;
   byFile: Record<string, PromptComment[]>;
   currentFilePath: string;
+  /** Scope of the open view. Code enrichment is only valid for current-file
+   *  comments whose scope matches it (the live model holds that content). */
+  currentScope: string;
   /** Optional current-file enrichment: language + a per-id code excerpt
    *  (already resolved against the live model by the caller). */
   currentFile?: {
@@ -18,10 +23,16 @@ export interface BuildPromptArgs {
   };
 }
 
+/** ` (commit <short>)` suffix for a commit-scoped comment so the agent knows
+ *  the line ref is from that commit, not the working tree. Empty for live. */
+function scopeSuffix(viewScope: string): string {
+  return viewScope.startsWith('commit:') ? ` (commit ${viewScope.slice(7, 14)})` : '';
+}
+
 /** Pure: turn a set of comment ids into the `path:line:` prompt body. Current
  *  file sorts first; current-file comments may carry a fenced code excerpt. */
 export function buildCommentPrompt(args: BuildPromptArgs): string | null {
-  const { ids, byFile, currentFilePath, currentFile } = args;
+  const { ids, byFile, currentFilePath, currentScope, currentFile } = args;
   if (ids.length === 0) return null;
   const idSet = new Set(ids);
 
@@ -40,8 +51,11 @@ export function buildCommentPrompt(args: BuildPromptArgs): string | null {
     const isCurrent = path === currentFilePath;
     for (const c of list) {
       const lineRef = c.startLine === c.endLine ? `${c.startLine}` : `${c.startLine}-${c.endLine}`;
-      const header = `${path}:${lineRef}:`;
-      const code = isCurrent && currentFile ? currentFile.codeForId(c) : '';
+      const header = `${path}:${lineRef}:${scopeSuffix(c.viewScope)}`;
+      // Only the open view's content lives in the model, so a code excerpt is
+      // trustworthy only for current-file comments of the current scope.
+      const canEnrich = isCurrent && !!currentFile && c.viewScope === currentScope;
+      const code = canEnrich ? currentFile!.codeForId(c) : '';
       const lang = currentFile?.language ?? '';
       sections.push(
         code ? `${header}\n\`\`\`${lang}\n${code}\n\`\`\`\n${c.text}` : `${header}\n${c.text}`,

--- a/src/renderer/components/diffEditor/comments/commentScope.ts
+++ b/src/renderer/components/diffEditor/comments/commentScope.ts
@@ -24,14 +24,18 @@ export function scopeLabel(scope: string): string {
   return short ? `Commit ${short}` : 'Working tree';
 }
 
-/** Total comments per scope across all files — feeds the commits-drawer
- *  per-view count badges. */
-export function commentCountsByScope<T extends { viewScope: string }>(
+/** Total *unsent* comments per scope across all files — feeds the commits-drawer
+ *  per-view count badges. Sent comments no longer need attention, so they drop
+ *  out of the counters. */
+export function commentCountsByScope<T extends { viewScope: string; sent?: boolean }>(
   byFile: Record<string, T[]>,
 ): Map<string, number> {
   const counts = new Map<string, number>();
   for (const list of Object.values(byFile)) {
-    for (const c of list) counts.set(c.viewScope, (counts.get(c.viewScope) ?? 0) + 1);
+    for (const c of list) {
+      if (c.sent) continue;
+      counts.set(c.viewScope, (counts.get(c.viewScope) ?? 0) + 1);
+    }
   }
   return counts;
 }

--- a/src/renderer/components/diffEditor/comments/commentScope.ts
+++ b/src/renderer/components/diffEditor/comments/commentScope.ts
@@ -1,0 +1,51 @@
+import type { EditorView } from '../types';
+
+/** The content-identity a comment is anchored to.
+ *
+ *  `working` and `branch` views both render the live working file as the
+ *  modified side (only the base/original side differs), so a comment sits on
+ *  the same line in both — they share the `'live'` scope and their comments are
+ *  shown (and live-tracked) interchangeably. A `commit` view renders frozen
+ *  content where that line means something else, so its comments are scoped to
+ *  the commit hash and stay there. */
+export function commentScope(view: EditorView): string {
+  return view.kind === 'commit' ? `commit:${view.hash}` : 'live';
+}
+
+/** The 7-char short hash for a `commit:<hash>` scope, else null. */
+export function commitShortHash(scope: string): string | null {
+  return scope.startsWith('commit:') ? scope.slice(7, 14) : null;
+}
+
+/** Human label for a scope: 'Working tree' for the shared live diff, or
+ *  'Commit <short>' for a frozen commit. */
+export function scopeLabel(scope: string): string {
+  const short = commitShortHash(scope);
+  return short ? `Commit ${short}` : 'Working tree';
+}
+
+/** Total comments per scope across all files — feeds the commits-drawer
+ *  per-view count badges. */
+export function commentCountsByScope<T extends { viewScope: string }>(
+  byFile: Record<string, T[]>,
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const list of Object.values(byFile)) {
+    for (const c of list) counts.set(c.viewScope, (counts.get(c.viewScope) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/** Keep only the comments belonging to `scope`, dropping now-empty files.
+ *  Used to scope the comments menu / prompt to the view currently open. */
+export function filterCommentsByScope<T extends { viewScope: string }>(
+  byFile: Record<string, T[]>,
+  scope: string,
+): Record<string, T[]> {
+  const out: Record<string, T[]> = {};
+  for (const [path, list] of Object.entries(byFile)) {
+    const kept = list.filter((c) => c.viewScope === scope);
+    if (kept.length > 0) out[path] = kept;
+  }
+  return out;
+}

--- a/src/renderer/components/diffEditor/comments/liveProjection.ts
+++ b/src/renderer/components/diffEditor/comments/liveProjection.ts
@@ -19,6 +19,30 @@ export function projectRanges(
   });
 }
 
+/** The shape of a Monaco content-change event we care about (subset of
+ *  IModelContentChangedEvent), kept minimal so it's unit-testable. */
+export interface ContentChangeLite {
+  isFlush: boolean;
+  changes: ReadonlyArray<{ rangeOffset: number; text: string }>;
+}
+
+/** True when an edit replaced the model's ENTIRE text in one operation — i.e.
+ *  a file (re)load. `@monaco-editor/react` pushes new `modified` content with
+ *  `executeEdits(fullRange, { forceMoveMarkers: true })`, which collapses every
+ *  comment decoration onto the last line; `setValue` (commit view) fires a
+ *  flush. Either way the decoration ranges are now garbage and the caller must
+ *  re-anchor comments from the store rather than read them back. An incremental
+ *  edit (typing, paste) is never a full replace, so live tracking is preserved.
+ *
+ *  Signature of the lib's edit: a single change at offset 0 whose inserted text
+ *  IS the whole post-edit document. */
+export function isFullModelReplace(e: ContentChangeLite, currentValue: string): boolean {
+  if (e.isFlush) return true;
+  if (e.changes.length !== 1) return false;
+  const only = e.changes[0]!;
+  return only.rangeOffset === 0 && only.text === currentValue;
+}
+
 /** True when both arrays have the same ids in the same order with identical
  *  ranges. Used to avoid publishing a new reference when nothing moved. */
 export function rangesEqual(a: ReadonlyArray<LiveComment>, b: ReadonlyArray<LiveComment>): boolean {

--- a/src/renderer/components/diffEditor/comments/overlay/CommentOverlay.tsx
+++ b/src/renderer/components/diffEditor/comments/overlay/CommentOverlay.tsx
@@ -34,6 +34,9 @@ interface Props {
   editingId: string | null;
   onSubmitDraft(text: string): void;
   onCancelDraft(): void;
+  /** Origin tag for every bubble (e.g. 'Commit abc1234') when the open view
+   *  isn't the plain working tree; undefined otherwise. */
+  scopeLabel?: string;
   /** Bubble width as a fraction of the editor's content width. */
   bubbleWidthFraction?: number;
 }
@@ -61,6 +64,7 @@ export function CommentOverlay({
   editingId,
   onSubmitDraft,
   onCancelDraft,
+  scopeLabel,
   bubbleWidthFraction = DEFAULT_BUBBLE_FRACTION,
 }: Props) {
   const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(() => new Set());
@@ -246,6 +250,7 @@ export function CommentOverlay({
                 onEdit={onEditComment}
                 onDelete={onDeleteComment}
                 editingId={editingId}
+                scopeLabel={scopeLabel}
               />
             </div>
             {editingComment && pendingRange && (

--- a/src/renderer/components/diffEditor/comments/useCommentBands.ts
+++ b/src/renderer/components/diffEditor/comments/useCommentBands.ts
@@ -70,7 +70,9 @@ export function useCommentBands({
           isWholeLine: true,
           className: cls,
           lineNumberClassName: `monaco-comment-ln-shade-${r.signature}`,
-          minimap: { color: commentMarker, position: monaco.editor.MinimapPosition.Inline },
+          // Gutter (not Inline) so the marker is a crisp tick in the minimap's
+          // dedicated lane rather than a faint line tint that's easy to miss.
+          minimap: { color: commentMarker, position: monaco.editor.MinimapPosition.Gutter },
           overviewRuler: {
             color: commentMarker,
             position: monaco.editor.OverviewRulerLane.Right,

--- a/src/renderer/components/diffEditor/comments/useCommentPrompt.ts
+++ b/src/renderer/components/diffEditor/comments/useCommentPrompt.ts
@@ -11,14 +11,19 @@ interface Args {
   monaco: typeof import('monaco-editor') | null;
   liveComments: LiveComment[];
   language: string;
+  /** Scope of the open view — used for code enrichment (only current-scope,
+   *  current-file comments can be enriched from the live model). */
+  scope: string;
   onClose: () => void;
 }
 
 export interface CommentPrompt {
   /** Non-null while the edit-before-send modal is open. */
   editTarget: { ids: string[]; text: string } | null;
-  /** Send every unsent comment, then close the modal. */
+  /** Send every unsent comment across all views, then close the modal. */
   sendAllUnsent: () => void;
+  /** Send the unsent comments of one view (scope). Keeps the menu open. */
+  sendScope: (scope: string) => void;
   /** Send one comment; keeps the modal open (the user is triaging). */
   sendOne: (id: string) => void;
   /** Open the edit-before-send modal prefilled with every unsent comment. */
@@ -38,8 +43,10 @@ export function useCommentPrompt({
   monaco,
   liveComments,
   language,
+  scope,
   onClose,
 }: Args): CommentPrompt {
+  // All comments across every view — the menu manages and sends across scopes.
   const byFile = useCommentsStore((s) => s.byFile);
   const [editTarget, setEditTarget] = useState<{ ids: string[]; text: string } | null>(null);
 
@@ -54,12 +61,14 @@ export function useCommentPrompt({
           startLine: c.startLine,
           endLine: c.endLine,
           text: c.text,
+          viewScope: c.viewScope,
         }));
       }
       return buildCommentPrompt({
         ids,
         byFile: promptByFile,
         currentFilePath: filePath,
+        currentScope: scope,
         currentFile:
           model && monaco
             ? {
@@ -76,14 +85,20 @@ export function useCommentPrompt({
             : undefined,
       });
     },
-    [byFile, filePath, modifiedEditor, monaco, liveComments, language],
+    [byFile, filePath, scope, modifiedEditor, monaco, liveComments, language],
   );
 
-  const collectUnsentIds = useCallback((): string[] => {
-    const ids: string[] = [];
-    for (const list of Object.values(byFile)) for (const c of list) if (!c.sent) ids.push(c.id);
-    return ids;
-  }, [byFile]);
+  // Unsent ids, optionally limited to one view (scope).
+  const collectUnsentIds = useCallback(
+    (onlyScope?: string): string[] => {
+      const ids: string[] = [];
+      for (const list of Object.values(byFile))
+        for (const c of list)
+          if (!c.sent && (onlyScope === undefined || c.viewScope === onlyScope)) ids.push(c.id);
+      return ids;
+    },
+    [byFile],
+  );
 
   const writeToTui = useCallback(
     (text: string, idsToMarkSent: ReadonlyArray<string>) => {
@@ -105,6 +120,17 @@ export function useCommentPrompt({
     writeToTui(text, ids);
     onClose();
   }, [activeTaskId, collectUnsentIds, build, writeToTui, onClose]);
+
+  const sendScope = useCallback(
+    (scopeToSend: string) => {
+      if (!activeTaskId) return;
+      const ids = collectUnsentIds(scopeToSend);
+      const text = build(ids);
+      if (text === null) return;
+      writeToTui(text, ids);
+    },
+    [activeTaskId, collectUnsentIds, build, writeToTui],
+  );
 
   const sendOne = useCallback(
     (id: string) => {
@@ -139,6 +165,7 @@ export function useCommentPrompt({
   return {
     editTarget,
     sendAllUnsent,
+    sendScope,
     sendOne,
     openEditAndSend,
     confirmEditAndSend,

--- a/src/renderer/components/diffEditor/comments/useFileComments.ts
+++ b/src/renderer/components/diffEditor/comments/useFileComments.ts
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { editor as monacoEditor } from 'monaco-editor';
 import { useCommentsStore } from '../../../stores/commentsStore';
-import { projectRanges, rangesEqual, type RangeReader } from './liveProjection';
+import { isFullModelReplace, projectRanges, rangesEqual, type RangeReader } from './liveProjection';
 import type { DiffComment, LineRange, LiveComment } from './types';
 
 // Frozen empty default so `?? EMPTY_STORED` doesn't allocate a fresh array
@@ -16,6 +16,9 @@ interface Args {
   /** Diff editor instance (state, not ref) — null until mount. */
   editor: monacoEditor.IStandaloneDiffEditor | null;
   monaco: typeof import('monaco-editor') | null;
+  /** Content-state the current view anchors to ('live' or 'commit:<hash>').
+   *  Only comments of this scope are hydrated/shown for the file. */
+  scope: string;
 }
 
 export interface FileCommentsBinding {
@@ -42,9 +45,18 @@ export function useFileComments({
   isFileLoaded,
   editor,
   monaco,
+  scope,
 }: Args): FileCommentsBinding {
   const storeReady = useCommentsStore((s) => s.isReady);
-  const stored = useCommentsStore((s) => s.byFile[filePath]) ?? EMPTY_STORED;
+  const allStored = useCommentsStore((s) => s.byFile[filePath]) ?? EMPTY_STORED;
+  // Only comments anchored to the view's current diff state belong here. Memo
+  // keeps the reference stable (it feeds effect dep arrays) unless the file's
+  // comments or the scope actually change.
+  const stored = useMemo(() => allStored.filter((c) => c.viewScope === scope), [allStored, scope]);
+  // Latest stored comments, readable from callbacks (hydrate/re-anchor) without
+  // making `stored` an effect/callback dependency.
+  const storedRef = useRef<readonly DiffComment[]>(stored);
+  storedRef.current = stored;
 
   const [liveComments, setLiveComments] = useState<LiveComment[]>([]);
   const liveCommentsRef = useRef<LiveComment[]>([]);
@@ -67,27 +79,23 @@ export function useFileComments({
     if (!rangesEqual(liveCommentsRef.current, next)) setLiveComments(next);
   }, [makeReader]);
 
-  // ── Hydrate (file loaded + store ready) ──
-  useEffect(() => {
-    if (!isFileLoaded || !storeReady) {
-      // File is loading OR store hasn't resolved yet. Drop live state but DO
-      // NOT snapshot — there are no valid decorations against the (still-old)
-      // model.
-      setLiveComments([]);
-      hydratedKeyRef.current = '';
-      return;
-    }
-    const key = `${filePath}::loaded`;
-    if (hydratedKeyRef.current === key) return;
-    hydratedKeyRef.current = key;
-
+  // (Re)create decorations from the STORE — the source of truth — discarding
+  // whatever the current decorations say. Used for the initial hydrate and to
+  // re-anchor after a wholesale content replacement (which collapses every
+  // decoration onto the last line; see the content-change effect). Reads the
+  // latest stored comments via the ref so it isn't recreated per store mutation.
+  const hydrate = useCallback((): boolean => {
     const model = modifiedEditor?.getModel();
-    if (!modifiedEditor || !monaco || !model || stored.length === 0) {
+    if (!modifiedEditor || !monaco || !model) return false;
+    const prevIds = liveCommentsRef.current.map((c) => c.decorationId);
+    if (prevIds.length > 0) model.deltaDecorations(prevIds, []);
+    const src = storedRef.current;
+    if (src.length === 0) {
       setLiveComments([]);
-      return;
+      return true;
     }
     const lineCount = model.getLineCount();
-    const hydrated: LiveComment[] = stored.map((sc) => {
+    const hydrated: LiveComment[] = src.map((sc) => {
       const start = Math.min(Math.max(1, sc.startLine), lineCount);
       const end = Math.min(Math.max(start, sc.endLine), lineCount);
       const ids = model.deltaDecorations(
@@ -102,21 +110,55 @@ export function useFileComments({
       return { ...sc, startLine: start, endLine: end, decorationId: ids[0]! };
     });
     setLiveComments(hydrated);
-    // `stored` is intentionally excluded: store mutations should NOT trigger
-    // re-hydration. Reconciliation lives in the effects below.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filePath, isFileLoaded, storeReady, editor, monaco]);
+    return true;
+  }, [modifiedEditor, monaco]);
 
-  // ── Reactive projection on edits ──
+  // ── Hydrate (file loaded + store ready) ──
+  useEffect(() => {
+    if (!isFileLoaded || !storeReady) {
+      // File is loading OR store hasn't resolved yet. Drop live state but DO
+      // NOT snapshot — there are no valid decorations against the (still-old)
+      // model.
+      const model = modifiedEditor?.getModel();
+      const prevIds = liveCommentsRef.current.map((c) => c.decorationId);
+      if (model && prevIds.length > 0) model.deltaDecorations(prevIds, []);
+      setLiveComments([]);
+      hydratedKeyRef.current = '';
+      return;
+    }
+    // Keyed by file AND scope so switching to a different diff state
+    // (e.g. working → a specific commit) re-anchors from that scope's comments.
+    const key = `${filePath}::${scope}::loaded`;
+    if (hydratedKeyRef.current === key) return;
+    // Mark the key done ONLY if hydration actually ran — on first open the
+    // effect can fire before the diff editor finishes mounting (modifiedEditor
+    // still null), and marking it prematurely would skip the retry once the
+    // editor is ready (the bug where comments showed only after navigating
+    // away and back). Store mutations do NOT trigger re-hydration (hydrate
+    // reads storedRef); reconciliation lives in the effects below.
+    if (hydrate()) hydratedKeyRef.current = key;
+  }, [filePath, scope, isFileLoaded, storeReady, modifiedEditor, hydrate]);
+
+  // ── React to content changes ──
+  // A wholesale content swap (file (re)load) reaches the modified model via the
+  // editor lib's `executeEdits(fullRange, { forceMoveMarkers: true })`, which
+  // shoves every comment decoration onto the last line. Detect that and
+  // re-anchor from the store instead of reading back the collapsed ranges.
+  // Incremental edits (typing) fall through to a normal live re-projection so
+  // comments still track the lines they're attached to.
   useEffect(() => {
     if (!modifiedEditor) return;
-    const sub = modifiedEditor.onDidChangeModelContent(() => republish());
+    const sub = modifiedEditor.onDidChangeModelContent((e) => {
+      const model = modifiedEditor.getModel();
+      if (model && isFullModelReplace(e, model.getValue())) hydrate();
+      else republish();
+    });
     return () => sub.dispose();
-  }, [modifiedEditor, republish]);
+  }, [modifiedEditor, hydrate, republish]);
 
   // ── Reconcile store removals → drop decorations ──
   useEffect(() => {
-    if (hydratedKeyRef.current !== `${filePath}::loaded`) return;
+    if (hydratedKeyRef.current !== `${filePath}::${scope}::loaded`) return;
     const storedIds = new Set(stored.map((s) => s.id));
     const removed = liveCommentsRef.current.filter((c) => !storedIds.has(c.id));
     if (removed.length === 0) return;
@@ -127,11 +169,11 @@ export function useFileComments({
         [],
       );
     setLiveComments(liveCommentsRef.current.filter((c) => storedIds.has(c.id)));
-  }, [stored, filePath, modifiedEditor]);
+  }, [stored, filePath, scope, modifiedEditor]);
 
   // ── Mirror text/sent edits from store (not ranges) ──
   useEffect(() => {
-    if (hydratedKeyRef.current !== `${filePath}::loaded`) return;
+    if (hydratedKeyRef.current !== `${filePath}::${scope}::loaded`) return;
     let changed = false;
     const next = liveCommentsRef.current.map((live) => {
       const fresh = stored.find((s) => s.id === live.id);
@@ -140,7 +182,7 @@ export function useFileComments({
       return { ...live, text: fresh.text, sent: fresh.sent };
     });
     if (changed) setLiveComments(next);
-  }, [stored, filePath]);
+  }, [stored, filePath, scope]);
 
   // ── Snapshot on unmount / file switch (closure-captured path) ──
   useEffect(() => {
@@ -163,7 +205,13 @@ export function useFileComments({
       if (!modifiedEditor || !monaco || !model) return null;
       const created = useCommentsStore
         .getState()
-        .addComment({ filePath, startLine: range.start, endLine: range.end, text });
+        .addComment({
+          filePath,
+          startLine: range.start,
+          endLine: range.end,
+          text,
+          viewScope: scope,
+        });
       if (!created) return null;
       const ids = model.deltaDecorations(
         [],
@@ -178,7 +226,7 @@ export function useFileComments({
       setLiveComments((prev) => [...prev, liveC]);
       return liveC;
     },
-    [filePath, modifiedEditor, monaco],
+    [filePath, scope, modifiedEditor, monaco],
   );
 
   const updateText = useCallback((id: string, text: string) => {

--- a/src/renderer/components/diffEditor/editor/EditorHeader.tsx
+++ b/src/renderer/components/diffEditor/editor/EditorHeader.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
-import { Code2, Eye, GitCompare, WrapText, X } from 'lucide-react';
+import { Code2, Eye, GitCommit, GitCompare, MessageSquare, WrapText, X } from 'lucide-react';
 import type { EditorView } from '../types';
 import { Popover, PopoverAnchor, PopoverContent } from '../../ui/Popover';
+import { Tooltip } from '../../ui/Tooltip';
 import { BranchPicker } from '../BranchPicker';
 
 interface Props {
@@ -24,6 +25,8 @@ interface Props {
    *  in non-branch view. Null when neither origin/HEAD nor main/master is
    *  available — clicking the chip then just opens the picker. */
   defaultBase: string | null;
+  /** Comments anchored to the open view — shown after the "Showing …" label. */
+  commentCount: number;
   backgroundColor: string;
 }
 
@@ -40,10 +43,26 @@ export function EditorHeader({
   onSelectBase,
   onExitBranchView,
   defaultBase,
+  commentCount,
   backgroundColor,
 }: Props) {
-  const isCommit = view.kind === 'commit';
   const isBranch = view.kind === 'branch';
+  // "Showing …" pill — only for non-working views (the working tree is the
+  // default and needs no callout). Tooltip carries the full ref.
+  const viewMeta =
+    view.kind === 'branch'
+      ? {
+          label: `Showing vs ${view.base}`,
+          tooltip: `Comparing against ${view.base}`,
+          Icon: GitCompare,
+        }
+      : view.kind === 'commit'
+        ? {
+            label: `Showing commit ${view.hash.slice(0, 7)}`,
+            tooltip: `Commit ${view.hash}`,
+            Icon: GitCommit,
+          }
+        : null;
   const [pickerOpen, setPickerOpen] = useState(false);
 
   // Close the picker when the host switches view (e.g. user clicks a commit
@@ -76,12 +95,30 @@ export function EditorHeader({
       style={{ background: backgroundColor }}
     >
       <div className="flex items-center gap-3 min-w-0">
-        <span className="text-[13px] font-medium text-foreground truncate">{filePath}</span>
-        {isCommit && (
-          <span className="text-[11px] tabular-nums text-muted-foreground/50 font-mono">
-            {view.hash.slice(0, 7)}
-          </span>
+        {viewMeta && (
+          <Tooltip
+            content={
+              commentCount > 0
+                ? `${viewMeta.tooltip} · ${commentCount} comment${commentCount !== 1 ? 's' : ''}`
+                : viewMeta.tooltip
+            }
+          >
+            <span className="inline-flex items-center gap-1.5 px-2 h-6 rounded-md text-[11px] font-medium shrink-0 bg-primary/15 text-primary">
+              <viewMeta.Icon size={12} strokeWidth={1.8} className="shrink-0" />
+              <span className="font-mono whitespace-nowrap max-w-[260px] truncate">
+                {viewMeta.label}
+              </span>
+              {commentCount > 0 && (
+                <>
+                  <span className="opacity-40">·</span>
+                  <MessageSquare size={11} strokeWidth={2} className="opacity-80 shrink-0" />
+                  <span className="tabular-nums">{commentCount}</span>
+                </>
+              )}
+            </span>
+          </Tooltip>
         )}
+        <span className="text-[13px] font-medium text-foreground truncate">{filePath}</span>
       </div>
       <div className="flex items-center gap-2">
         {canPreview && (

--- a/src/renderer/components/diffEditor/editor/EditorHeader.tsx
+++ b/src/renderer/components/diffEditor/editor/EditorHeader.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useState } from 'react';
-import { Code2, Eye, GitCommit, GitCompare, MessageSquare, WrapText, X } from 'lucide-react';
+import {
+  Code2,
+  Eye,
+  GitCommit,
+  GitCompare,
+  History,
+  MessageSquare,
+  WrapText,
+  X,
+} from 'lucide-react';
 import type { EditorView } from '../types';
 import { Popover, PopoverAnchor, PopoverContent } from '../../ui/Popover';
 import { Tooltip } from '../../ui/Tooltip';
@@ -11,6 +20,9 @@ interface Props {
   view: EditorView;
   wordWrap: boolean;
   onToggleWordWrap(): void;
+  /** Inline git-blame toggle (default on, persisted). */
+  blameEnabled: boolean;
+  onToggleBlame(): void;
   /** Show the Code | Preview toggle (HTML files only). */
   canPreview: boolean;
   /** True when the rendered preview is showing instead of the editor. */
@@ -36,6 +48,8 @@ export function EditorHeader({
   view,
   wordWrap,
   onToggleWordWrap,
+  blameEnabled,
+  onToggleBlame,
   canPreview,
   previewing,
   onTogglePreview,
@@ -191,6 +205,17 @@ export function EditorHeader({
             />
           </PopoverContent>
         </Popover>
+        <button
+          onClick={onToggleBlame}
+          title={blameEnabled ? 'Hide git blame' : 'Show git blame'}
+          className={`p-1.5 rounded-md transition-colors ${
+            blameEnabled
+              ? 'bg-primary/15 text-primary'
+              : 'text-muted-foreground/60 hover:text-foreground hover:bg-accent/60'
+          }`}
+        >
+          <History size={14} strokeWidth={1.8} />
+        </button>
         <button
           onClick={onToggleWordWrap}
           title={wordWrap ? 'Disable word wrap' : 'Enable word wrap'}

--- a/src/renderer/components/rightInspector/RightInspector.tsx
+++ b/src/renderer/components/rightInspector/RightInspector.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { ArrowDown, ArrowUp, GitBranch, Maximize2, Minus, Plus } from 'lucide-react';
+import { ArrowDown, ArrowUp, GitBranch, MessageSquareCode, Minus, Plus } from 'lucide-react';
 import { FileChangesPanel } from '../changes/FileChangesPanel';
 import { Tooltip } from '../ui/Tooltip';
 import { UsageStrip } from './UsageStrip';
@@ -125,7 +125,7 @@ export function RightInspector({
             onClick={onOpenEditor}
             className="p-[3px] rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors shrink-0"
           >
-            <Maximize2 size={11} strokeWidth={2} />
+            <MessageSquareCode size={11} strokeWidth={2} />
           </button>
         </Tooltip>
       </div>

--- a/src/renderer/components/settings/SettingsModal.tsx
+++ b/src/renderer/components/settings/SettingsModal.tsx
@@ -24,7 +24,6 @@ import {
   Info,
   ChevronDown,
   PanelLeft,
-  GitCompare,
   Terminal as TerminalIcon,
   GitCommit,
   Shield,
@@ -65,7 +64,6 @@ type SettingsTab =
   | 'sidebar'
   | 'appearance'
   | 'notifications'
-  | 'diff'
   | 'terminal'
   | 'ide'
   | 'attribution'
@@ -79,7 +77,7 @@ type SettingsTab =
 
 const NAV_GROUPS: Array<{ label: string; ids: SettingsTab[] }> = [
   { label: 'Interface', ids: ['sidebar', 'appearance', 'notifications'] },
-  { label: 'Editor', ids: ['diff', 'terminal', 'ide'] },
+  { label: 'Editor', ids: ['terminal', 'ide'] },
   { label: 'Workflow', ids: ['attribution', 'claude-code', 'keybindings', 'usage'] },
   { label: 'System', ids: ['add-ons', 'updates', 'privacy', 'about'] },
 ];
@@ -107,12 +105,6 @@ const NAV_ITEMS: Array<{
     label: 'Notifications',
     description: 'Sound and desktop alerts when tasks need attention.',
     Icon: Bell,
-  },
-  {
-    id: 'diff',
-    label: 'Diff',
-    description: 'How file diffs are displayed.',
-    Icon: GitCompare,
   },
   {
     id: 'terminal',
@@ -735,8 +727,6 @@ export function SettingsModal({
   const onRtkDownload = useRuntime((s) => s.downloadRtk);
   const theme = useSettings((s) => s.theme);
   const onThemeChange = useSettings((s) => s.setTheme);
-  const diffContextLines = useSettings((s) => s.diffContextLines);
-  const onDiffContextLinesChange = useSettings((s) => s.setDiffContextLines);
   const notificationSound = useSettings((s) => s.notificationSound);
   const setNotificationSound = useSettings((s) => s.setNotificationSound);
   const onNotificationSoundChange = (v: NotificationSound) => {
@@ -1048,34 +1038,6 @@ export function SettingsModal({
                         }`}
                       />
                     </SettingsBlock>
-                  </SettingsCard>
-                </SettingsPane>
-              )}
-
-              {tab === 'diff' && (
-                <SettingsPane key={`pane-${tab}`}>
-                  <SettingsCard title="Context">
-                    <SettingsRow
-                      label="Context lines"
-                      description="Unchanged lines shown around each change."
-                      align="start"
-                      control={
-                        <Segmented
-                          fullWidth={false}
-                          size="sm"
-                          value={diffContextLines === null ? 'full' : String(diffContextLines)}
-                          options={[
-                            { value: 'full', label: 'Full' },
-                            { value: '3', label: '3' },
-                            { value: '10', label: '10' },
-                            { value: '50', label: '50' },
-                          ]}
-                          onChange={(v) =>
-                            onDiffContextLinesChange(v === 'full' ? null : Number(v))
-                          }
-                        />
-                      }
-                    />
                   </SettingsCard>
                 </SettingsPane>
               )}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1003,23 +1003,19 @@
 }
 
 /* Inline git blame — the contiguous run of lines from the hovered line's commit.
- * Faint enough to read under the comment shade bands. Fades in on appear; the
- * hook swaps to the -out class to fade it back out before dropping the
- * decoration. The blame text itself lives in the ruler label below. */
+ * Faint enough to read under the comment shade bands. The blame text itself lives
+ * in the ruler label below.
+ *
+ * The steady tint is a STATIC background (no keyframe): Monaco recreates a line
+ * decoration's DOM node on every cursor/selection change, which would replay any
+ * keyframe on that node — so an in-animation here flickered the whole block on a
+ * click inside it. Only the deliberate fade-OUT (set once, on hide, when nobody
+ * is clicking) keeps a keyframe. */
 .monaco-blame-block {
   background-color: hsl(var(--primary) / 0.07);
-  animation: blame-block-in 340ms ease;
 }
 .monaco-blame-block-out {
   animation: blame-block-out 340ms ease forwards;
-}
-@keyframes blame-block-in {
-  from {
-    background-color: hsl(var(--primary) / 0);
-  }
-  to {
-    background-color: hsl(var(--primary) / 0.07);
-  }
 }
 @keyframes blame-block-out {
   from {
@@ -1061,6 +1057,14 @@
 .monaco-blame-ruler-band[data-visible='true'] {
   opacity: 1;
 }
+/* Slide between commits (visible→visible) — gated on data-slide so a fresh
+ * appear snaps to position instead of gliding in from the previous commit. */
+.monaco-blame-ruler-band[data-slide='true'] {
+  transition:
+    opacity 340ms ease,
+    top 260ms cubic-bezier(0.4, 0, 0.2, 1),
+    height 260ms cubic-bezier(0.4, 0, 0.2, 1);
+}
 
 /* Commit card butted against the band's left edge (square inner corner, primary
  * right border tying it to the band). Narrow + stacked: author, then sha · age,
@@ -1091,6 +1095,17 @@
 }
 .monaco-blame-ruler-label[data-visible='true'] {
   opacity: 1;
+}
+/* Slide the card to the new commit (visible→visible). The top is set
+ * imperatively (clamped) in EditorPane, so this transition eases that change;
+ * a fresh appear (data-slide='false') snaps, then fades in. */
+.monaco-blame-ruler-label[data-slide='true'] {
+  transition:
+    opacity 340ms ease,
+    top 260ms cubic-bezier(0.4, 0, 0.2, 1),
+    background-color 140ms ease,
+    border-color 140ms ease,
+    box-shadow 140ms ease;
 }
 /* Hover feedback — the card lifts slightly and firms up its surface/border. */
 .monaco-blame-ruler-label:hover {

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1002,6 +1002,151 @@
   background-color: hsl(var(--primary) / 0.32);
 }
 
+/* Inline git blame — the contiguous run of lines from the hovered line's commit.
+ * Faint enough to read under the comment shade bands. Fades in on appear; the
+ * hook swaps to the -out class to fade it back out before dropping the
+ * decoration. The blame text itself lives in the ruler label below. */
+.monaco-blame-block {
+  background-color: hsl(var(--primary) / 0.07);
+  animation: blame-block-in 340ms ease;
+}
+.monaco-blame-block-out {
+  animation: blame-block-out 340ms ease forwards;
+}
+@keyframes blame-block-in {
+  from {
+    background-color: hsl(var(--primary) / 0);
+  }
+  to {
+    background-color: hsl(var(--primary) / 0.07);
+  }
+}
+@keyframes blame-block-out {
+  from {
+    background-color: hsl(var(--primary) / 0.07);
+  }
+  to {
+    background-color: hsl(var(--primary) / 0);
+  }
+}
+
+/* Host injected as the first child of Monaco's `.diffOverview` so the blame band
+ * paints BEHIND the ruler's diff add/delete marks and the viewport box. */
+.monaco-blame-ruler-host {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+/* Make the diff scroll-viewport indicator more opaque (Monaco's scrollbar-slider
+ * default is very faint) so it stays clearly legible against the blame band that
+ * now shares this overview strip. */
+.monaco-diff-editor .diffOverview .diffViewport {
+  background: hsl(var(--primary) / 0.3) !important;
+}
+
+/* The hovered commit's extent on the overview-ruler strip — subtle, behind the
+ * diff marks, fades in/out. Narrow slice on the modified lane (rightmost). */
+.monaco-blame-ruler-band {
+  position: absolute;
+  right: 0;
+  width: 9px;
+  /* Desaturated neutral (muted-foreground) — reads distinct from the primary
+   * viewport indicator and the green/red diff marks without being vibrant. */
+  background-color: hsl(var(--muted-foreground) / 0.2);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 340ms ease;
+}
+.monaco-blame-ruler-band[data-visible='true'] {
+  opacity: 1;
+}
+
+/* Commit card butted against the band's left edge (square inner corner, primary
+ * right border tying it to the band). Narrow + stacked: author, then sha · age,
+ * then the wrapped subject. Fades with the band. */
+.monaco-blame-ruler-label {
+  position: absolute;
+  right: 14px;
+  z-index: 7;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 162px;
+  padding: 6px 9px;
+  border-radius: 5px 0 0 5px;
+  border: 1px solid hsl(var(--border) / 0.5);
+  background-color: hsl(var(--surface-3) / 0.45);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 4px 14px hsl(0 0% 0% / 0.18);
+  /* Interactive so the × is clickable; the hook's grace period keeps it shown
+   * while the pointer travels here from the code. */
+  pointer-events: auto;
+  opacity: 0;
+  transition:
+    opacity 340ms ease,
+    background-color 140ms ease,
+    border-color 140ms ease,
+    box-shadow 140ms ease;
+}
+.monaco-blame-ruler-label[data-visible='true'] {
+  opacity: 1;
+}
+/* Hover feedback — the card lifts slightly and firms up its surface/border. */
+.monaco-blame-ruler-label:hover {
+  background-color: hsl(var(--surface-3) / 0.72);
+  border-color: hsl(var(--border) / 0.9);
+  box-shadow: 0 6px 18px hsl(0 0% 0% / 0.26);
+}
+.blame-label-close {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  color: hsl(var(--muted-foreground) / 0.55);
+  cursor: pointer;
+  transition:
+    color 120ms ease,
+    background-color 120ms ease;
+}
+.blame-label-close:hover {
+  color: hsl(var(--foreground));
+  background-color: hsl(var(--surface-2));
+}
+.blame-label-author {
+  font-size: 11px;
+  font-weight: 500;
+  color: hsl(var(--muted-foreground));
+  padding-right: 16px; /* clear the × button */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.blame-label-meta {
+  display: flex;
+  gap: 7px;
+  font-size: 10px;
+  color: hsl(var(--muted-foreground));
+}
+.blame-label-sha {
+  font-family: 'SF Mono', ui-monospace, Menlo, monospace;
+  color: hsl(var(--primary));
+}
+.blame-label-summary {
+  font-size: 10px;
+  line-height: 1.4;
+  color: hsl(var(--muted-foreground));
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* Only render the *active* indent guide — the column for the block the
  * cursor is currently inside. Inactive guides get hidden. Monaco tags the
  * active one with `.indent-active` (indentGuides.js); we suppress the

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws://localhost:*">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws://localhost:*">
     <title>Dash</title>
   </head>
   <body class="bg-background text-foreground">

--- a/src/renderer/stores/__tests__/commentsStore.test.ts
+++ b/src/renderer/stores/__tests__/commentsStore.test.ts
@@ -10,6 +10,7 @@ const cmt = (over: Partial<DiffComment> = {}): DiffComment => ({
   endLine: over.endLine ?? 2,
   text: over.text ?? 'hello',
   sent: over.sent ?? false,
+  viewScope: over.viewScope ?? 'live',
   createdAt: over.createdAt ?? '2026-01-01T00:00:00Z',
   updatedAt: over.updatedAt ?? '2026-01-01T00:00:00Z',
 });
@@ -48,7 +49,7 @@ describe('commentsStore', () => {
     await useCommentsStore.getState().loadForTask('t1');
     const created = useCommentsStore
       .getState()
-      .addComment({ filePath: 'a.ts', startLine: 3, endLine: 3, text: 'x' });
+      .addComment({ filePath: 'a.ts', startLine: 3, endLine: 3, text: 'x', viewScope: 'live' });
     expect(created).not.toBeNull();
     expect(useCommentsStore.getState().byFile['a.ts']).toHaveLength(1);
     expect(api.diffCommentsUpsert).toHaveBeenCalledTimes(1);
@@ -59,7 +60,7 @@ describe('commentsStore', () => {
     // never loadForTask → taskId null
     const created = useCommentsStore
       .getState()
-      .addComment({ filePath: 'a.ts', startLine: 1, endLine: 1, text: 'x' });
+      .addComment({ filePath: 'a.ts', startLine: 1, endLine: 1, text: 'x', viewScope: 'live' });
     expect(created).toBeNull();
     expect(useCommentsStore.getState().disabled).toBe(true);
     expect(api.diffCommentsUpsert).not.toHaveBeenCalled();

--- a/src/renderer/stores/__tests__/settingsKeys.test.ts
+++ b/src/renderer/stores/__tests__/settingsKeys.test.ts
@@ -74,8 +74,6 @@ describe('settings registry', () => {
 
   it('registers the phase-1f special settings', () => {
     const byField = Object.fromEntries(SETTINGS_REGISTRY.map((r) => [r.field, r]));
-    expect(byField.diffContextLines!.codec.decode(null)).toBeNull();
-    expect(byField.diffContextLines!.codec.decode('5')).toBe(5);
     expect(byField.commitAttribution!.codec.decode(null)).toBeUndefined();
     expect(byField.commitAttribution!.codec.decode('')).toBe('');
   });

--- a/src/renderer/stores/commentsStore.ts
+++ b/src/renderer/stores/commentsStore.ts
@@ -6,6 +6,7 @@ interface AddInput {
   startLine: number;
   endLine: number;
   text: string;
+  viewScope: string;
 }
 export interface RangeSnapshot {
   id: string;
@@ -85,6 +86,7 @@ function persist(c: DiffComment, patch: Partial<DiffComment> = {}): void {
     endLine: c.endLine,
     text: c.text,
     sent: c.sent,
+    viewScope: c.viewScope,
     ...patch,
   });
 }
@@ -124,6 +126,7 @@ export const useCommentsStore = create<CommentsStore>((set, get) => ({
       endLine: input.endLine,
       text: input.text,
       sent: false,
+      viewScope: input.viewScope,
       createdAt: now,
       updatedAt: now,
     };

--- a/src/renderer/stores/settingsKeys.ts
+++ b/src/renderer/stores/settingsKeys.ts
@@ -7,7 +7,6 @@ import {
   strEnum,
   json,
   stringSet,
-  nullableInt,
   strOrUndefined,
 } from './settingsCodecs';
 import type { NotificationSound } from '../sounds';
@@ -38,7 +37,6 @@ export interface SettingsState {
   rotationOrder: string[];
   rotationExclusions: Set<string>;
   unseenTaskIds: Set<string>;
-  diffContextLines: number | null;
   commitAttribution: string | undefined;
   preferredIDE: string;
   keybindings: KeyBindingMap;
@@ -116,7 +114,6 @@ export const SETTINGS_REGISTRY: RegistryEntry[] = [
   entry('rotationOrder', 'rotationOrder', json<string[]>([])),
   entry('rotationExclusions', 'rotationExclusions', stringSet()),
   entry('unseenTaskIds', 'unseenTaskIds', stringSet()),
-  entry('diffContextLines', 'diffContextLines', nullableInt(3)),
   entry('commitAttribution', 'commitAttribution', strOrUndefined()),
   entry('preferredIDE', 'preferredIDE', str('auto')),
   entry('keybindings', 'keybindings', keybindingsCodec()),

--- a/src/shared/__tests__/relativeTime.test.ts
+++ b/src/shared/__tests__/relativeTime.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { formatRelativeTime } from '../relativeTime';
+
+const NOW = 1_700_000_000;
+
+describe('formatRelativeTime', () => {
+  it('returns empty string for a falsy timestamp', () => {
+    expect(formatRelativeTime(0, NOW)).toBe('');
+  });
+
+  it('formats each magnitude bucket', () => {
+    expect(formatRelativeTime(NOW - 45, NOW)).toBe('45s');
+    expect(formatRelativeTime(NOW - 12 * 60, NOW)).toBe('12m');
+    expect(formatRelativeTime(NOW - 3 * 3600, NOW)).toBe('3h');
+    expect(formatRelativeTime(NOW - 5 * 86400, NOW)).toBe('5d');
+    expect(formatRelativeTime(NOW - 8 * 30 * 86400, NOW)).toBe('8mo');
+    expect(formatRelativeTime(NOW - 2 * 365 * 86400, NOW)).toBe('2y');
+  });
+
+  it('clamps future timestamps to 0s', () => {
+    expect(formatRelativeTime(NOW + 100, NOW)).toBe('0s');
+  });
+});

--- a/src/shared/relativeTime.ts
+++ b/src/shared/relativeTime.ts
@@ -1,0 +1,17 @@
+/**
+ * Compact "time ago" label — e.g. `45s`, `12m`, `3h`, `5d`, `8mo`, `2y`.
+ *
+ * `now` is taken as an argument (unix seconds) so callers can pass
+ * `Date.now() / 1000` while tests stay deterministic. Returns '' for a falsy
+ * timestamp; future times clamp to `0s`.
+ */
+export function formatRelativeTime(unixSeconds: number, now: number): string {
+  if (!unixSeconds) return '';
+  const s = Math.max(0, Math.floor(now - unixSeconds));
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.floor(s / 60)}m`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h`;
+  if (s < 86400 * 30) return `${Math.floor(s / 86400)}d`;
+  if (s < 86400 * 365) return `${Math.floor(s / (86400 * 30))}mo`;
+  return `${Math.floor(s / (86400 * 365))}y`;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -739,6 +739,24 @@ export type EditorWriteResult =
   | { ok: true; mtimeMs: number; sizeBytes: number }
   | { ok: false; stale: true; currentMtimeMs: number; currentSizeBytes: number };
 
+/** One git-blame record per final line of a file (line is 1-indexed). Faithful
+ *  to `git blame --incremental`; presentation decisions live in the renderer. */
+export interface BlameLine {
+  line: number; // 1-indexed final line number
+  sha: string; // 40-char commit hash; all-zeros when uncommitted
+  shortSha: string; // 7-char abbreviation (of sha, so '0000000' when uncommitted)
+  author: string; // author name as reported by git
+  authorEmail: string; // author email, angle brackets stripped
+  authorTime: number; // author time, unix seconds (0 when absent)
+  summary: string; // commit subject line
+  uncommitted: boolean; // true → not-yet-committed working-tree line
+}
+
+/** Result of editor:blame — one entry per line, in ascending line order. */
+export interface EditorBlameResult {
+  lines: BlameLine[];
+}
+
 /** Commit summary for the diff editor's commit drawer. Includes the body so
  *  hover popovers can render the full message without a second IPC. */
 export interface EditorCommitListItem {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -819,6 +819,9 @@ export interface DiffComment {
   endLine: number;
   text: string;
   sent: boolean;
+  /** Diff state the anchor is meaningful against: 'live' (working/branch
+   *  views share the working file) or 'commit:<hash>' for a frozen commit. */
+  viewScope: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -833,6 +836,7 @@ export interface DiffCommentInput {
   endLine: number;
   text: string;
   sent: boolean;
+  viewScope: string;
 }
 
 /* ── Unified Extensions model (Skills + Plugins across scopes) ──────────────

--- a/src/types/electron-api/editor.ts
+++ b/src/types/electron-api/editor.ts
@@ -5,6 +5,7 @@ import type {
   EditorReadBranchResult,
   EditorWriteResult,
   EditorCommitListItem,
+  EditorBlameResult,
   FileChange,
   DiffComment,
   DiffCommentInput,
@@ -52,6 +53,11 @@ export interface EditorApi {
     filePath: string;
     base: string;
   }) => Promise<IpcResponse<EditorReadBranchResult>>;
+  editorBlame: (args: {
+    cwd: string;
+    filePath: string;
+    ref: string | null;
+  }) => Promise<IpcResponse<EditorBlameResult>>;
 
   // Diff review comments
   diffCommentsList: (args: { taskId: string }) => Promise<IpcResponse<DiffComment[]>>;


### PR DESCRIPTION
## Summary

Two diff-editor features on this branch:

1. **Diff comments — robust anchoring, view scoping & review UI**
2. **Inline git blame**

## Diff comments (view scoping + review UI)

- **CSP fix** — allow the Monaco editor worker via `worker-src` (it was blocked by `script-src 'self'`).
- **Robust anchoring** — re-anchor comment decorations from source on a wholesale model-content replace (Monaco collapses decorations to the last line on every file (re)load), vs. live-tracking on incremental edits.
- **View scoping** — comments are tagged with the view they were authored in (`working` / `commit:<hash>`): DB `view_scope` column + migration, comments menu grouped by view, a "Showing …" header pill, minimap markers, and sent-dimming.

## Inline git blame

Hover a line to highlight its commit's contiguous run in the editor body and surface that run on the right overview-ruler strip as a faint band plus a compact card (author · age · sha · subject). Toggle off via the header **History** button or the card's **×** — on by default, persisted to `localStorage`.

- **Main** — `editor:blame` IPC running `git blame --incremental`, with a pure porcelain parser (`blameParser`) that dedups commit metadata per SHA and flags uncommitted lines; exposed through preload + `electron-api` / shared types (`BlameLine` / `EditorBlameResult`).
- **Renderer** — `useGitBlame` hook: fetch per view, same-commit block decoration (fades in/out), ruler band + info card portaled *behind* the diff marks, hover rest-delay, and a grace-period hold so the card stays put to be clicked. Pure helpers `refForView` / `blameLabel` / `contiguousBlock`, and the `History` header toggle.
- **Shared** — extracted `formatRelativeTime` (now reused by `EditorSidebar`).
- **Fixes** — clamp the blame card and reveal a fresh comment draft so neither is clipped at the editor's bottom on last-line content.

## Testing

- `pnpm test` (full suite green), `pnpm type-check`, ESLint — all clean.
- Pure-logic unit tests added: porcelain parser (multi-line + uncommitted groups), `refForView` (all view kinds), `blameLabel`, `contiguousBlock`, `formatRelativeTime`.
- Monaco rendering verified by manual smoke (can't be driven headlessly).

## Notes

- Version bumped `0.13.1 → 0.13.2` (CI version gate).
- macOS arm64; no native-module changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)