### PR TITLE
Fix TUI flicker from per-chunk terminal.clear() under memory pressure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -15,7 +15,17 @@ import { isPromptOnlySnapshot } from './snapshotFilter';
 import { FitScheduler } from './FitScheduler';
 import { TUI_COLS, TUI_ROWS } from '../../shared/tuiProtocol';
 
-const MEMORY_LIMIT_BYTES = 128 * 1024 * 1024; // 128MB soft limit
+// Heap mark above which a terminal trims its own scrollback to relieve pressure.
+// `performance.memory.usedJSHeapSize` is the WHOLE renderer heap (React, Monaco,
+// every terminal), so the mark must clear normal baseline usage (Monaco alone
+// puts a working app at 130–160MB) — otherwise the trim fires constantly. Only
+// genuine pressure should trip it.
+const MEMORY_LIMIT_BYTES = 600 * 1024 * 1024; // 600MB
+// Don't re-check more often than this; the trim is sticky so one pass per window
+// is plenty and it must never run per output chunk (that was the flicker bug).
+const MEMORY_CHECK_INTERVAL_MS = 5_000;
+// Floor the scrollback never drops below when trimming under pressure.
+const MIN_SCROLLBACK = 10_000;
 
 export class TerminalSessionManager {
   readonly id: string;
@@ -47,6 +57,7 @@ export class TerminalSessionManager {
   private fitScheduler = new FitScheduler(() => this.fit(), 250);
   private lastPtyCols = 0;
   private lastPtyRows = 0;
+  private lastMemoryCheckAt = 0;
   private savedViewportY: number | null = null;
   // Shell-only sessions use xterm 6's DOM renderer (WebGL paints their
   // transparent background black). The DOM renderer lays each row's glyphs at
@@ -1189,14 +1200,31 @@ export class TerminalSessionManager {
     this.terminal.scrollToLine(line);
   }
 
+  /**
+   * Relieve renderer memory pressure by trimming THIS terminal's scrollback when
+   * the heap runs genuinely high. Throttled (never per output chunk) and
+   * non-destructive: lowering the scrollback cap drops the oldest off-screen
+   * lines WITHOUT clearing the visible viewport, so it frees memory with no
+   * repaint, and the reduced cap is sticky so it doesn't re-fire on the next
+   * chunk.
+   *
+   * The previous version called `terminal.clear()` on every chunk once over a
+   * 128MB limit and immediately restored scrollback to 100k — so with a normal
+   * (Monaco-loaded) heap parked above 128MB it wiped + repainted the TUI on
+   * every output chunk, flickering "like crazy" while output streamed (e.g. the
+   * repaints Claude Code emits while scrolling in NO_FLICKER mode).
+   */
   private checkMemory() {
-    if (typeof performance !== 'undefined' && 'memory' in performance) {
-      const mem = (performance as unknown as { memory: { usedJSHeapSize: number } }).memory;
-      if (mem.usedJSHeapSize > MEMORY_LIMIT_BYTES) {
-        this.terminal.options.scrollback = 10_000;
-        this.terminal.clear();
-        this.terminal.options.scrollback = 100_000;
-      }
-    }
+    if (typeof performance === 'undefined' || !('memory' in performance)) return;
+    const now = Date.now();
+    if (now - this.lastMemoryCheckAt < MEMORY_CHECK_INTERVAL_MS) return;
+    this.lastMemoryCheckAt = now;
+    const mem = (performance as unknown as { memory: { usedJSHeapSize: number } }).memory;
+    if (mem.usedJSHeapSize <= MEMORY_LIMIT_BYTES) return;
+    const current = this.terminal.options.scrollback ?? MIN_SCROLLBACK;
+    if (current <= MIN_SCROLLBACK) return; // already at the floor
+    // Halve toward the floor; lowering the cap trims the oldest scrollback lines
+    // in place — no clear(), no viewport repaint.
+    this.terminal.options.scrollback = Math.max(MIN_SCROLLBACK, Math.floor(current / 2));
   }
 }


### PR DESCRIPTION
## Problem

In longer sessions, the Claude Code TUI flickers heavily — it repaints imperfectly and oscillates, especially while scrolling. Reproduced and confirmed in-app.

## Root cause

`TerminalSessionManager.checkMemory()` ran after **every** PTY data chunk (`onPtyData`). Once the renderer heap crossed a **128 MB** soft limit it called `terminal.clear()` (wiping the buffer + forcing a full repaint) and immediately restored scrollback to 100k.

Three compounding defects:
1. **Wrong metric/threshold** — `performance.memory.usedJSHeapSize` is the whole renderer heap (React + Monaco + every terminal). A normal Monaco-loaded app baselines at 130–160 MB, so 128 MB was *permanently* tripped.
2. **Per-chunk** — once over the limit, every output chunk cleared the terminal.
3. **Self-perpetuating** — scrollback was restored to 100k immediately, so the heap never dropped back under the limit.

Net effect: while output streamed (e.g. the repaints Claude Code emits when scrolling in `CLAUDE_CODE_NO_FLICKER` mode), the TUI was cleared on every chunk → "flicker like crazy". Confirmed with a temporary log: `terminal.clear()` fired in bursts that lined up exactly with the visible flicker, heap parked at 130–160 MB vs the 128 MB limit.

## Fix

Make the memory guard **throttled, non-destructive, sticky, and correctly calibrated**:
- **Throttled** — runs at most once per 5 s, never per chunk.
- **Non-destructive** — lowers the scrollback cap (which trims oldest off-screen lines in place) instead of `terminal.clear()`; no viewport wipe, no repaint.
- **Sticky** — halves toward a 10k floor instead of bouncing back to 100k, so it doesn't re-fire on the next chunk.
- **Calibrated** — trips at 600 MB, clear of the normal Monaco baseline, so only genuine pressure triggers it.

## Verification

Renderer-only (hot-reloads). Reproduced the flicker, applied the fix, confirmed the flicker is gone with the same repro (long session + scroll). Type-check and lint clean.

Claude goes brr.. via Dash

🤖 Generated with [Claude Code](https://claude.com/claude-code)