### PR TITLE
Diff editor enhancement sweep + Node 24 baseline (0.13.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,4 +62,4 @@ Main process `entry.ts` rewrites at runtime: `@shared/*` → `dist/main/shared/*
 
 ## Requirements
 
-Node.js 22+ (`.nvmrc`), pnpm (`shamefully-hoist` in `.npmrc`), Claude Code CLI, Git. macOS arm64 or Linux x64.
+Node.js 24 (`.nvmrc`), pnpm (`shamefully-hoist` in `.npmrc`), Claude Code CLI, Git. macOS arm64 or Linux x64.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/main/ipc/__tests__/editorIpcCommitStats.test.ts
+++ b/src/main/ipc/__tests__/editorIpcCommitStats.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { parseCommitNumstatLog } from '../editorIpc';
+
+// `git log --numstat --format=%x1f%H` emits a \x1f-prefixed hash line per
+// commit, followed by `<adds>\t<dels>\t<path>` numstat rows.
+const U = '\x1f';
+
+describe('parseCommitNumstatLog', () => {
+  it('sums additions/deletions per commit across its files', () => {
+    const out = [`${U}abc123`, '5\t2\tsrc/a.ts', '3\t0\tsrc/b.ts', `${U}def456`, '1\t1\tx.ts'].join(
+      '\n',
+    );
+    const map = parseCommitNumstatLog(out);
+    expect(map.get('abc123')).toEqual({ additions: 8, deletions: 2 });
+    expect(map.get('def456')).toEqual({ additions: 1, deletions: 1 });
+  });
+
+  it('treats binary files (- / -) as zero', () => {
+    const out = [`${U}abc123`, '-\t-\timg.png', '4\t1\tsrc/a.ts'].join('\n');
+    expect(parseCommitNumstatLog(out)).toEqual(
+      new Map([['abc123', { additions: 4, deletions: 1 }]]),
+    );
+  });
+
+  it('records a commit with no numstat (e.g. merge) as 0/0', () => {
+    const out = [`${U}merge1`, `${U}abc123`, '2\t0\ta.ts'].join('\n');
+    const map = parseCommitNumstatLog(out);
+    expect(map.get('merge1')).toEqual({ additions: 0, deletions: 0 });
+    expect(map.get('abc123')).toEqual({ additions: 2, deletions: 0 });
+  });
+
+  it('tolerates blank lines between commit blocks', () => {
+    const out = [`${U}abc123`, '', '5\t2\ta.ts', ''].join('\n');
+    expect(parseCommitNumstatLog(out).get('abc123')).toEqual({ additions: 5, deletions: 2 });
+  });
+
+  it('returns an empty map for empty output', () => {
+    expect(parseCommitNumstatLog('')).toEqual(new Map());
+  });
+
+  it('ignores numstat rows with no preceding commit header', () => {
+    expect(parseCommitNumstatLog('5\t2\ta.ts')).toEqual(new Map());
+  });
+});

--- a/src/main/ipc/editorIpc.ts
+++ b/src/main/ipc/editorIpc.ts
@@ -272,6 +272,40 @@ export function parseDiffNumstatZ(
   return map;
 }
 
+/** Parse `git log --numstat --format=%x1f%H` into a commit-hash → {adds, dels}
+ *  map, summing per-file numstat across each commit. A line beginning with the
+ *  unit-separator (\x1f) starts a new commit; numstat rows are `<adds>\t<dels>
+ *  \t<path>` (binary files use '-'). Locale-independent (numbers only); merge
+ *  commits emit no numstat and stay at 0/0. */
+export function parseCommitNumstatLog(
+  stdout: string,
+): Map<string, { additions: number; deletions: number }> {
+  const map = new Map<string, { additions: number; deletions: number }>();
+  let current: { additions: number; deletions: number } | null = null;
+  for (const line of stdout.split('\n')) {
+    if (line.startsWith('\x1f')) {
+      const hash = line.slice(1).trim();
+      if (!hash) {
+        current = null;
+        continue;
+      }
+      current = { additions: 0, deletions: 0 };
+      map.set(hash, current);
+      continue;
+    }
+    if (!current || !line) continue;
+    const t1 = line.indexOf('\t');
+    if (t1 < 0) continue;
+    const t2 = line.indexOf('\t', t1 + 1);
+    if (t2 < 0) continue;
+    const addsStr = line.slice(0, t1);
+    const delsStr = line.slice(t1 + 1, t2);
+    current.additions += addsStr === '-' ? 0 : parseInt(addsStr, 10) || 0;
+    current.deletions += delsStr === '-' ? 0 : parseInt(delsStr, 10) || 0;
+  }
+  return map;
+}
+
 export function registerEditorIpc(): void {
   // ── editor:readWorking ────────────────────────────────────────
   ipcMain.handle(
@@ -546,18 +580,36 @@ export function registerEditorIpc(): void {
           ['log', '-z', `--max-count=${limit}`, `--format=${format}`, 'HEAD'],
           { cwd: args.cwd, maxBuffer: 5 * 1024 * 1024, timeout: 15000 },
         );
+        // Second single pass over the same range for per-commit line stats —
+        // O(1) git calls, not one numstat call per commit. The \x1f-prefixed
+        // hash line delimits each commit's numstat block.
+        let lineStats = new Map<string, { additions: number; deletions: number }>();
+        try {
+          const { stdout: numstatOut } = await execFileAsync(
+            'git',
+            ['log', '--numstat', `--max-count=${limit}`, '--format=%x1f%H', 'HEAD'],
+            { cwd: args.cwd, maxBuffer: 5 * 1024 * 1024, timeout: 15000 },
+          );
+          lineStats = parseCommitNumstatLog(numstatOut);
+        } catch {
+          // Stats are best-effort; fall back to 0/0 if the numstat pass fails.
+        }
         const commits: EditorCommitListItem[] = [];
         for (const record of stdout.split('\0')) {
           if (!record) continue;
           const parts = record.split('\x1f');
           if (parts.length < 6) continue;
+          const hash = parts[0]!;
+          const stat = lineStats.get(hash);
           commits.push({
-            hash: parts[0]!,
+            hash,
             shortHash: parts[1]!,
             authorName: parts[2] || '',
             authorDate: parseInt(parts[3]!, 10) || 0,
             subject: parts[4] || '',
             body: (parts[5] || '').trim(),
+            additions: stat?.additions ?? 0,
+            deletions: stat?.deletions ?? 0,
           });
         }
         return { success: true, data: commits };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -331,6 +331,8 @@ export function App() {
   const setDiffFile = useGit((s) => s.setDiffFile);
   const showCommitGraph = useGit((s) => s.showCommitGraph);
   const setShowCommitGraph = useGit((s) => s.setShowCommitGraph);
+  const commitGraphFocusHash = useGit((s) => s.commitGraphFocusHash);
+  const setCommitGraphFocusHash = useGit((s) => s.setCommitGraphFocusHash);
 
   const sidebarCollapsed = useSettings((s) => s.sidebarCollapsed);
   const setSidebarCollapsed = useSettings((s) => s.setSidebarCollapsed);
@@ -1012,8 +1014,15 @@ export function App() {
   function handleViewDiff(filePath: string, staged: boolean) {
     if (!activeTask) return;
     // Monaco loads HEAD/index + working copy itself via files:readForEdit;
-    // App.tsx just opens the modal with the file identity.
-    setDiffFile({ cwd: activeTask.path, filePath, staged });
+    // App.tsx just opens the modal with the file identity. Pin the working view
+    // explicitly so clicking a specific file always shows its working diff
+    // rather than restoring the editor's last (possibly commit/branch) view.
+    setDiffFile({
+      cwd: activeTask.path,
+      filePath,
+      staged,
+      initialView: { kind: 'working', ref: staged ? 'index' : 'HEAD' },
+    });
   }
 
   return (
@@ -1446,10 +1455,16 @@ export function App() {
                 .map((t) => [t.branch, { id: t.id, name: t.name, useWorktree: t.useWorktree }]),
             )
           }
-          onClose={() => setShowCommitGraph(false)}
+          focusHash={commitGraphFocusHash}
+          elevated={!!diffFile}
+          onClose={() => {
+            setShowCommitGraph(false);
+            setCommitGraphFocusHash(null);
+          }}
           onSelectTask={(taskId) => {
             setActiveTaskId(taskId);
             setShowCommitGraph(false);
+            setCommitGraphFocusHash(null);
           }}
         />
       )}

--- a/src/renderer/components/CommitGraph/CommitGraphModal.tsx
+++ b/src/renderer/components/CommitGraph/CommitGraphModal.tsx
@@ -16,17 +16,22 @@ interface CommitGraphModalProps {
   taskBranches: Map<string, TaskBranchInfo>;
   onClose: () => void;
   onSelectTask: (taskId: string) => void;
+  /** Select + scroll to this commit on open (e.g. from the blame card). */
+  focusHash?: string | null;
+  /** Stack above another open modal (the diff editor). */
+  elevated?: boolean;
 }
 
 export function CommitGraphModal(props: CommitGraphModalProps) {
   return (
-    <Modal onClose={props.onClose} size="w-[94vw] max-w-6xl h-[88vh]">
+    <Modal onClose={props.onClose} size="w-[94vw] max-w-6xl h-[88vh]" elevated={props.elevated}>
       <CommitGraphBody
         projectPath={props.projectPath}
         projectName={props.projectName}
         gitRemote={props.gitRemote}
         taskBranches={props.taskBranches}
         onSelectTask={props.onSelectTask}
+        focusHash={props.focusHash}
       />
     </Modal>
   );
@@ -38,6 +43,7 @@ interface CommitGraphBodyProps {
   gitRemote: string | null;
   taskBranches: Map<string, TaskBranchInfo>;
   onSelectTask: (taskId: string) => void;
+  focusHash?: string | null;
 }
 
 function CommitGraphBody({
@@ -46,6 +52,7 @@ function CommitGraphBody({
   gitRemote,
   taskBranches,
   onSelectTask,
+  focusHash,
 }: CommitGraphBodyProps) {
   const close = useModalClose();
 
@@ -73,6 +80,7 @@ function CommitGraphBody({
         gitRemote={gitRemote}
         taskBranches={taskBranches}
         onSelectTask={onSelectTask}
+        focusHash={focusHash}
       />
     </>
   );

--- a/src/renderer/components/CommitGraph/CommitGraphView.tsx
+++ b/src/renderer/components/CommitGraph/CommitGraphView.tsx
@@ -13,6 +13,9 @@ interface CommitGraphViewProps {
   gitRemote: string | null;
   taskBranches: Map<string, TaskBranchInfo>;
   onSelectTask: (taskId: string) => void;
+  /** Select + scroll to the commit whose hash starts with this prefix, once,
+   *  after the graph loads. Null/no-match leaves the graph at the top. */
+  focusHash?: string | null;
 }
 
 const PAGE_SIZE = 150;
@@ -22,6 +25,7 @@ export function CommitGraphView({
   gitRemote,
   taskBranches,
   onSelectTask,
+  focusHash,
 }: CommitGraphViewProps) {
   const [graphData, setGraphData] = useState<CommitGraphData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -31,6 +35,9 @@ export function CommitGraphView({
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailClosing, setDetailClosing] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  // Guards the one-shot focus effect so it doesn't re-fire on subsequent loads
+  // (e.g. "load more") or steal a selection the user has since made.
+  const focusedHashRef = useRef<string | null>(null);
 
   // taskBranches is already a Map, no need to transform
   const githubSlug = useMemo(() => parseGithubSlug(gitRemote), [gitRemote]);
@@ -85,6 +92,26 @@ export function CommitGraphView({
     }
     return map;
   }, [graphData]);
+
+  // One-shot: once the graph has loaded, select + scroll to the focused commit.
+  useEffect(() => {
+    if (!graphData || !focusHash || focusedHashRef.current === focusHash) return;
+    const row = graphData.commits.findIndex((gc) => gc.commit.hash.startsWith(focusHash));
+    if (row < 0) return; // not in the loaded page — leave the graph at the top
+    focusedHashRef.current = focusHash;
+    setDetailClosing(false);
+    setSelectedRow(row);
+    setDetailLoading(true);
+    const hash = graphData.commits[row]!.commit.hash;
+    void window.electronAPI.gitGetCommitDetail({ cwd: projectPath, hash }).then((res) => {
+      if (res.success && res.data) setDetail(res.data);
+      setDetailLoading(false);
+    });
+    const el = scrollRef.current;
+    if (el) {
+      el.scrollTo({ top: Math.max(0, row * ROW_HEIGHT - el.clientHeight / 2), behavior: 'smooth' });
+    }
+  }, [graphData, focusHash, projectPath]);
 
   function handleCloseDetail() {
     setDetailClosing(true);

--- a/src/renderer/components/diffEditor/BranchPicker.tsx
+++ b/src/renderer/components/diffEditor/BranchPicker.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Search } from 'lucide-react';
+import { GitCompare, Search, X } from 'lucide-react';
 import type { BranchInfo } from '@shared/types';
 
 interface BranchPickerProps {
@@ -8,11 +8,14 @@ interface BranchPickerProps {
   selectedRef: string | null;
   /** Picker has no internal "close" — the host owns that lifecycle. */
   onSelect: (ref: string) => void;
+  /** When in branch view, leave the comparison (back to working tree). Shown as
+   *  a row at the top of the picker. Omitted outside branch view. */
+  onExit?: () => void;
 }
 
 /** Compact branch list with a search input. Uses the existing
  *  gitListBranches IPC, so it reflects fetched-remote branches. */
-export function BranchPicker({ cwd, selectedRef, onSelect }: BranchPickerProps) {
+export function BranchPicker({ cwd, selectedRef, onSelect, onExit }: BranchPickerProps) {
   const [branches, setBranches] = useState<BranchInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -54,6 +57,17 @@ export function BranchPicker({ cwd, selectedRef, onSelect }: BranchPickerProps) 
           className="flex-1 bg-transparent outline-hidden text-[12px] placeholder:text-muted-foreground/40"
         />
       </div>
+      {onExit && (
+        <button
+          type="button"
+          onClick={onExit}
+          className="w-full flex items-center gap-2 px-3 py-1.5 text-left text-[12px] border-b border-border/40 text-muted-foreground/80 hover:text-foreground hover:bg-[hsl(var(--surface-2)/0.6)] transition-colors"
+        >
+          <X size={12} strokeWidth={1.8} className="shrink-0" />
+          <span className="flex-1">Exit comparison</span>
+          <GitCompare size={11} strokeWidth={1.8} className="shrink-0 opacity-50" />
+        </button>
+      )}
       <div className="flex-1 min-h-0 overflow-y-auto py-1">
         {loading && <div className="px-3 py-2 text-[11px] text-muted-foreground/40">Loading…</div>}
         {error && <div className="px-3 py-2 text-[11px] text-destructive">{error}</div>}

--- a/src/renderer/components/diffEditor/DiffEditor.tsx
+++ b/src/renderer/components/diffEditor/DiffEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import type { FileChange } from '../../../shared/types';
 import { useGit } from '../../stores/gitStore';
@@ -8,6 +8,7 @@ import type { EditorView } from './types';
 import type { DiffEditorModalProps } from './DiffEditorModal';
 import { useEditorViewData } from './data/useEditorViewData';
 import { resolveHeadSentinel, pickFirstChangedFile } from './data/viewData';
+import { readStoredView, writeStoredView } from './data/viewPersistence';
 import { useCommentsStore } from '../../stores/commentsStore';
 import { commentScope, commentCountsByScope } from './comments/commentScope';
 
@@ -24,10 +25,18 @@ export function DiffEditor({
   onClose,
 }: DiffEditorModalProps) {
   const gitStatus = useGit((s) => s.gitStatus);
-  const [view, setView] = useState<EditorView>(
-    () => initialView ?? { kind: 'working', ref: initialStaged ? 'index' : 'HEAD' },
-  );
+  // View precedence: an explicit caller intent (initialView) wins, so clicking
+  // a specific file always shows its working diff and "open at HEAD" is honored.
+  // Otherwise restore the last view for this repo, falling back to working.
+  const [view, setView] = useState<EditorView>(() => {
+    if (initialView) return initialView;
+    return readStoredView(cwd) ?? { kind: 'working', ref: initialStaged ? 'index' : 'HEAD' };
+  });
   const [selectedPath, setSelectedPath] = useState<string>(initialFilePath);
+  // One-shot guard: a restored commit/branch ref may no longer exist (branch
+  // deleted, history rewritten). Validate the *initial* view once and fall back
+  // to working if it's stale — without ejecting the user from later choices.
+  const validatedInitialView = useRef(false);
 
   // ── View-dependent git data (changed files, repo tree, commits, base) ──
   const workingFiles: FileChange[] = useMemo(() => gitStatus?.files ?? [], [gitStatus]);
@@ -47,6 +56,36 @@ export function DiffEditor({
   useEffect(() => {
     setView((current) => resolveHeadSentinel(current, commits));
   }, [commits]);
+
+  // Persist the active view per-repo so reopening lands back here. The 'HEAD'
+  // sentinel is skipped inside writeStoredView until it resolves to a sha.
+  useEffect(() => {
+    writeStoredView(cwd, view);
+  }, [cwd, view]);
+
+  // Validate the restored initial view exactly once. A commit lists every file
+  // in its tree, so an empty repoPaths after load means the sha is gone; a
+  // branch base is checked against the live branch list. Either miss → working.
+  useEffect(() => {
+    if (validatedInitialView.current) return;
+    if (view.kind === 'working') {
+      validatedInitialView.current = true;
+      return;
+    }
+    if (view.kind === 'commit') {
+      if (repoPathsLoading) return; // wait for the tree listing to settle
+      validatedInitialView.current = true;
+      if (repoPaths.length === 0) changeView({ kind: 'working', ref: 'HEAD' });
+      return;
+    }
+    // branch
+    validatedInitialView.current = true;
+    const base = view.base;
+    void window.electronAPI.gitListBranches(cwd).then((resp) => {
+      const exists = resp.success && !!resp.data?.some((b) => b.ref === base);
+      if (!exists) changeView({ kind: 'working', ref: 'HEAD' });
+    });
+  }, [view, repoPaths, repoPathsLoading, cwd]);
 
   // Auto-pick the first changed file ONLY when nothing is selected. User
   // clicks must stay sticky — even on an unchanged file. Resetting on every

--- a/src/renderer/components/diffEditor/EditorPane.tsx
+++ b/src/renderer/components/diffEditor/EditorPane.tsx
@@ -6,6 +6,7 @@ import type { ITheme as XtermTheme } from '@xterm/xterm';
 import type { EditorView } from './types';
 import type { LiveComment } from './comments/types';
 import { useCommentsStore } from '../../stores/commentsStore';
+import { useGit } from '../../stores/gitStore';
 import { useGutterSelection } from './comments/useGutterSelection';
 import { useFileComments } from './comments/useFileComments';
 import { commentScope, scopeLabel } from './comments/commentScope';
@@ -443,6 +444,7 @@ export function EditorPane({
                 onNavigate={onNavigateToComment}
                 onRemove={(_path, id) => useCommentsStore.getState().remove(id)}
                 onUnsend={(id) => useCommentsStore.getState().markUnsent(id)}
+                onClearSent={(scope) => useCommentsStore.getState().clearSent(scope)}
                 onSendScope={promptApi.sendScope}
                 onSendAll={promptApi.sendAllUnsent}
                 onEditAndSend={promptApi.openEditAndSend}
@@ -453,6 +455,10 @@ export function EditorPane({
           {state.kind === 'loading' && displayed.kind === 'loaded' && <LoadingPill />}
           {rulerMark &&
             (() => {
+              const lineRange =
+                rulerMark.lineStart === rulerMark.lineEnd
+                  ? `L${rulerMark.lineStart}`
+                  : `L${rulerMark.lineStart}–${rulerMark.lineEnd}`;
               const band = (
                 <div
                   className="monaco-blame-ruler-band"
@@ -482,16 +488,28 @@ export function EditorPane({
                       <X size={11} strokeWidth={2} />
                     </button>
                     <span className="blame-label-author">{rulerMark.label.author}</span>
-                    {!rulerMark.label.uncommitted && (
-                      <>
-                        <span className="blame-label-meta">
-                          <span className="blame-label-sha">{rulerMark.label.shortSha}</span>
-                          {rulerMark.label.age && <span>{rulerMark.label.age} ago</span>}
-                        </span>
-                        {rulerMark.label.summary && (
-                          <span className="blame-label-summary">{rulerMark.label.summary}</span>
-                        )}
-                      </>
+                    <span className="blame-label-meta">
+                      {!rulerMark.label.uncommitted && (
+                        <>
+                          <button
+                            type="button"
+                            className="blame-label-sha"
+                            title="Open this commit in the graph"
+                            onClick={() =>
+                              useGit.getState().openCommitGraphAtCommit(rulerMark.label.shortSha)
+                            }
+                          >
+                            {rulerMark.label.shortSha}
+                          </button>
+                          {rulerMark.label.age && (
+                            <span className="blame-label-age">{rulerMark.label.age} ago</span>
+                          )}
+                        </>
+                      )}
+                      <span className="blame-label-lines">{lineRange}</span>
+                    </span>
+                    {!rulerMark.label.uncommitted && rulerMark.label.summary && (
+                      <span className="blame-label-summary">{rulerMark.label.summary}</span>
                     )}
                   </div>
                 </>
@@ -508,6 +526,7 @@ export function EditorPane({
             onHoveredIdChange={setHoveredCommentId}
             onEditComment={draftApi.beginEdit}
             onDeleteComment={binding.remove}
+            onReopenComment={(id) => useCommentsStore.getState().markUnsent(id)}
             pendingRange={dragging ? null : pendingRange}
             pendingText={draftApi.pendingText}
             editingId={draftApi.editingId}

--- a/src/renderer/components/diffEditor/EditorSidebar.tsx
+++ b/src/renderer/components/diffEditor/EditorSidebar.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState, useEffect } from 'react';
 import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
-import { ChevronDown, ChevronRight, GitCommit, History } from 'lucide-react';
+import { ChevronDown, ChevronRight, GitCommit, History, ListFilter } from 'lucide-react';
 import type { FileChange, FileChangeStatus } from '../../../shared/types';
 import { formatRelativeTime } from '@shared/relativeTime';
 import type { CommitSummary, EditorView } from './types';
@@ -30,6 +30,7 @@ interface EditorSidebarProps {
 }
 
 const COMMITS_DRAWER_KEY = 'diffEditor.commitsDrawerSize';
+const CHANGED_ONLY_KEY = 'diffEditor.changedOnly';
 
 export function EditorSidebar(props: EditorSidebarProps) {
   const initialDrawerSize = parseInitial(localStorage.getItem(COMMITS_DRAWER_KEY), 35);
@@ -213,20 +214,72 @@ function FileTreePanel({
   onSelectFile,
   commentCounts,
 }: FileTreePanelProps) {
-  const tree = useMemo(() => buildRepoTree(paths, changedFiles), [paths, changedFiles]);
+  const [changedOnly, setChangedOnly] = useState<boolean>(
+    () => localStorage.getItem(CHANGED_ONLY_KEY) === 'true',
+  );
+  const toggleChangedOnly = () =>
+    setChangedOnly((v) => {
+      const next = !v;
+      localStorage.setItem(CHANGED_ONLY_KEY, String(next));
+      return next;
+    });
+  // In changed-only mode, seed the tree from an empty repo-path set so
+  // buildRepoTree's union reduces to just the changed files and their parent
+  // folders (unchanged siblings never enter the tree).
+  const tree = useMemo(
+    () => buildRepoTree(changedOnly ? [] : paths, changedFiles),
+    [changedOnly, paths, changedFiles],
+  );
+  const totals = useMemo(() => {
+    let additions = 0;
+    let deletions = 0;
+    for (const f of changedFiles) {
+      additions += f.additions;
+      deletions += f.deletions;
+    }
+    return { additions, deletions };
+  }, [changedFiles]);
   return (
     <div className="h-full min-h-0 flex flex-col">
       <div className="px-3 py-2 text-[10px] uppercase tracking-wider text-muted-foreground/70 font-mono flex items-center justify-between shrink-0">
-        <span>
-          Files{' '}
-          {tree.changedCount > 0 && (
-            <span className="tabular-nums">· {tree.changedCount} changed</span>
+        <span className="flex items-center gap-2">
+          <span>
+            Files{' '}
+            {tree.changedCount > 0 && (
+              <span className="tabular-nums">· {tree.changedCount} changed</span>
+            )}
+          </span>
+          {(totals.additions > 0 || totals.deletions > 0) && (
+            <span className="flex gap-1.5 tabular-nums normal-case tracking-normal">
+              {totals.additions > 0 && (
+                <span className="text-[hsl(var(--git-added))]">+{totals.additions}</span>
+              )}
+              {totals.deletions > 0 && (
+                <span className="text-[hsl(var(--git-deleted))]">−{totals.deletions}</span>
+              )}
+            </span>
           )}
         </span>
+        <Tooltip content={changedOnly ? 'Show all files' : 'Show changed files only'}>
+          <button
+            type="button"
+            onClick={toggleChangedOnly}
+            aria-pressed={changedOnly}
+            className={`shrink-0 p-1 -mr-1 rounded transition-colors ${
+              changedOnly
+                ? 'text-primary'
+                : 'text-muted-foreground/50 hover:text-foreground hover:bg-[hsl(var(--surface-2)/0.6)]'
+            }`}
+          >
+            <ListFilter size={13} strokeWidth={1.8} />
+          </button>
+        </Tooltip>
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto scrollbar-gutter-stable scrollbar-thin-hover pb-2 px-1">
         {loading && paths.length === 0 ? (
           <div className="px-3 py-2 text-[11px] text-muted-foreground/40">Loading…</div>
+        ) : changedOnly && tree.changedCount === 0 ? (
+          <div className="px-3 py-2 text-[11px] text-muted-foreground/40">No changed files</div>
         ) : (
           <FolderContents
             node={tree}
@@ -590,6 +643,16 @@ function CommitRow({ commit, active, commentCount, onSelect }: CommitRowProps) {
             {commit.subject || '(no subject)'}
           </span>
           {commentCount > 0 && <CommentBadge count={commentCount} />}
+          {(commit.additions > 0 || commit.deletions > 0) && (
+            <span className="font-mono text-[10px] flex gap-1 shrink-0 tabular-nums">
+              {commit.additions > 0 && (
+                <span className="text-[hsl(var(--git-added))]">+{commit.additions}</span>
+              )}
+              {commit.deletions > 0 && (
+                <span className="text-[hsl(var(--git-deleted))]">−{commit.deletions}</span>
+              )}
+            </span>
+          )}
           <span className="text-[10px] text-muted-foreground/40 shrink-0 tabular-nums">
             {formatRelativeTime(commit.authorDate, Date.now() / 1000)}
           </span>

--- a/src/renderer/components/diffEditor/blame/useGitBlame.ts
+++ b/src/renderer/components/diffEditor/blame/useGitBlame.ts
@@ -31,6 +31,9 @@ export interface BlameRulerMark {
   top: number;
   height: number;
   label: BlameLabel;
+  /** 1-indexed inclusive line run of the hovered commit, surfaced on the card. */
+  lineStart: number;
+  lineEnd: number;
 }
 
 /**
@@ -168,6 +171,8 @@ export function useGitBlame({
         top,
         height: Math.max(2, bottom - top),
         label: blameLabel(blame, Date.now() / 1000),
+        lineStart: run.start,
+        lineEnd: run.end,
       };
     };
 

--- a/src/renderer/components/diffEditor/comments/BubbleStack.tsx
+++ b/src/renderer/components/diffEditor/comments/BubbleStack.tsx
@@ -16,6 +16,8 @@ interface Props {
   onEdit(comment: LiveComment): void;
   /** Click the in-bubble × → delete this comment. */
   onDelete(id: string): void;
+  /** Click the in-bubble reopen control on a sent comment → mark it unsent. */
+  onReopen(id: string): void;
   /** Origin tag for every bubble in this view (e.g. 'Commit abc1234'), or
    *  undefined in the plain working view where no tag is needed. */
   scopeLabel?: string;
@@ -40,6 +42,7 @@ export function BubbleStack({
   onBubbleHover,
   onEdit,
   onDelete,
+  onReopen,
   editingId,
   scopeLabel,
 }: Props) {
@@ -66,6 +69,7 @@ export function BubbleStack({
             onMouseLeave={() => onBubbleHover(null)}
             onDoubleClick={() => onEdit(c)}
             onDelete={() => onDelete(c.id)}
+            onReopen={() => onReopen(c.id)}
             isFadingOut={c.id === editingId}
           />
         );

--- a/src/renderer/components/diffEditor/comments/CommentBubble.tsx
+++ b/src/renderer/components/diffEditor/comments/CommentBubble.tsx
@@ -1,4 +1,4 @@
-import { X } from 'lucide-react';
+import { Undo2, X } from 'lucide-react';
 import type { Shade } from './types';
 import { BubbleShell } from './BubbleShell';
 
@@ -25,6 +25,9 @@ interface Props {
   /** Click the in-bubble × → delete this comment. ESC is taken by the
    *  surrounding Modal, so a button is the keyboard-free path. */
   onDelete(): void;
+  /** Click the in-bubble reopen control on a SENT comment → mark it unsent so
+   *  it rejoins the next prompt. Only rendered when `sent`. */
+  onReopen(): void;
   /** True when this comment is currently being edited — the persisted
    *  card fades to opacity 0 while the DraftBubble crossfades in beside
    *  it, so the read-only → editable transition reads as a single morph
@@ -47,6 +50,7 @@ export function CommentBubble({
   onMouseLeave,
   onDoubleClick,
   onDelete,
+  onReopen,
   isFadingOut,
 }: Props) {
   // A sent comment fades back so it reads as "already pushed" without
@@ -71,18 +75,34 @@ export function CommentBubble({
         onDoubleClick={onDoubleClick}
       >
         <div className="group/bubble">
-          <button
-            type="button"
-            aria-label="Delete comment"
-            title="Delete comment"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete();
-            }}
-            className="absolute top-[6px] right-[6px] flex h-[20px] w-[20px] items-center justify-center rounded-[4px] text-muted-foreground/60 opacity-40 hover:opacity-100 hover:text-foreground hover:bg-foreground/10 transition-opacity z-10"
-          >
-            <X size={13} strokeWidth={1.8} />
-          </button>
+          <div className="absolute top-[6px] right-[6px] flex items-center gap-[2px] z-10">
+            {sent && (
+              <button
+                type="button"
+                aria-label="Reopen comment"
+                title="Reopen — include in next prompt"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onReopen();
+                }}
+                className="flex h-[20px] w-[20px] items-center justify-center rounded-[4px] text-muted-foreground/60 opacity-40 hover:opacity-100 hover:text-primary hover:bg-primary/10 transition-opacity"
+              >
+                <Undo2 size={12} strokeWidth={1.8} />
+              </button>
+            )}
+            <button
+              type="button"
+              aria-label="Delete comment"
+              title="Delete comment"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
+              className="flex h-[20px] w-[20px] items-center justify-center rounded-[4px] text-muted-foreground/60 opacity-40 hover:opacity-100 hover:text-foreground hover:bg-foreground/10 transition-opacity"
+            >
+              <X size={13} strokeWidth={1.8} />
+            </button>
+          </div>
           <div className="flex items-center gap-[6px] mb-[2px]">
             <span className="font-mono text-[10px] text-muted-foreground/55 tracking-normal">
               {meta}

--- a/src/renderer/components/diffEditor/comments/CommentsMenu.tsx
+++ b/src/renderer/components/diffEditor/comments/CommentsMenu.tsx
@@ -7,6 +7,7 @@ import {
   MessageSquare,
   Pencil,
   Send,
+  Trash2,
   Undo2,
   X,
 } from 'lucide-react';
@@ -29,6 +30,8 @@ interface Props {
   onNavigate: (scope: string, filePath: string, commentId: string) => void;
   onRemove: (filePath: string, commentId: string) => void;
   onUnsend: (commentId: string) => void;
+  /** Remove sent comments — all of them, or just one scope's when given. */
+  onClearSent: (scope?: string) => void;
   /** Send all unsent comments of one view. */
   onSendScope: (scope: string) => void;
   /** Send every unsent comment across all views. Closes the menu. */
@@ -79,6 +82,7 @@ export function CommentsMenu({
   onNavigate,
   onRemove,
   onUnsend,
+  onClearSent,
   onSendScope,
   onSendAll,
   onEditAndSend,
@@ -196,6 +200,7 @@ export function CommentsMenu({
               views={sentViews}
               total={totalSent}
               currentFilePath={currentFilePath}
+              onClearSent={onClearSent}
               {...rowHandlers}
             />
           )}
@@ -357,33 +362,61 @@ function SentSection({
   views,
   total,
   currentFilePath,
+  onClearSent,
   getLiveRangeForCurrent,
   onNavigate,
   onRemove,
   onSendOne,
   onUnsend,
   closeMenu,
-}: { views: ScopeView[]; total: number; currentFilePath: string } & RowHandlers) {
+}: {
+  views: ScopeView[];
+  total: number;
+  currentFilePath: string;
+  onClearSent: (scope?: string) => void;
+} & RowHandlers) {
   const [open, setOpen] = useState(false);
   return (
     <div className="border-b border-foreground/5 last:border-b-0">
       <StickyHeader>
-        <button
-          type="button"
-          onClick={() => setOpen((o) => !o)}
-          className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-foreground/[0.035] transition-colors"
-        >
-          {open ? (
-            <ChevronDown size={12} strokeWidth={2} className="text-muted-foreground/70 shrink-0" />
-          ) : (
-            <ChevronRight size={12} strokeWidth={2} className="text-muted-foreground/70 shrink-0" />
-          )}
-          <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/40 shrink-0" aria-hidden />
-          <span className="text-[11px] font-semibold tracking-tight text-muted-foreground/85">
-            Sent
-          </span>
-          <span className="text-[10.5px] text-muted-foreground/60 tabular-nums">{total}</span>
-        </button>
+        <div className="flex items-center gap-2 px-3 py-2 hover:bg-foreground/[0.035] transition-colors">
+          <button
+            type="button"
+            onClick={() => setOpen((o) => !o)}
+            className="flex items-center gap-2 flex-1 min-w-0 text-left"
+          >
+            {open ? (
+              <ChevronDown
+                size={12}
+                strokeWidth={2}
+                className="text-muted-foreground/70 shrink-0"
+              />
+            ) : (
+              <ChevronRight
+                size={12}
+                strokeWidth={2}
+                className="text-muted-foreground/70 shrink-0"
+              />
+            )}
+            <span
+              className="w-1.5 h-1.5 rounded-full bg-muted-foreground/40 shrink-0"
+              aria-hidden
+            />
+            <span className="text-[11px] font-semibold tracking-tight text-muted-foreground/85">
+              Sent
+            </span>
+            <span className="text-[10.5px] text-muted-foreground/60 tabular-nums">{total}</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => onClearSent()}
+            title={`Clear ${total} sent comment${total !== 1 ? 's' : ''}`}
+            className="shrink-0 flex items-center gap-1 px-2 py-1 rounded-md text-[10.5px] font-medium text-muted-foreground/65 hover:text-destructive hover:bg-destructive/10 active:scale-[0.98] transition"
+          >
+            <Trash2 size={10} strokeWidth={2.2} />
+            Clear
+          </button>
+        </div>
       </StickyHeader>
       <SectionBody open={open}>
         {views.map((v) => (
@@ -392,6 +425,18 @@ function SentSection({
               <span className="text-[9px] uppercase tracking-wider font-medium text-muted-foreground/50">
                 {v.label}
               </span>
+              <span className="text-[9px] text-muted-foreground/40 tabular-nums">{v.count}</span>
+              {views.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() => onClearSent(v.scope)}
+                  title={`Clear ${v.count} sent comment${v.count !== 1 ? 's' : ''} in ${v.label}`}
+                  className="ml-auto shrink-0 flex items-center gap-1 px-1.5 py-0.5 rounded text-[9.5px] font-medium text-muted-foreground/55 hover:text-destructive hover:bg-destructive/10 transition"
+                >
+                  <Trash2 size={9} strokeWidth={2.2} />
+                  Clear
+                </button>
+              )}
             </div>
             {v.groups.map(([path, list], gi) => (
               <FileGroup

--- a/src/renderer/components/diffEditor/comments/__tests__/liveProjection.test.ts
+++ b/src/renderer/components/diffEditor/comments/__tests__/liveProjection.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
   isFullModelReplace,
+  isWholeBlockDeleted,
+  commentsDeletedByEdit,
   projectRanges,
   rangesEqual,
+  type EditChange,
   type RangeReader,
 } from '../liveProjection';
 import type { LiveComment } from '../types';
@@ -41,6 +44,68 @@ describe('rangesEqual', () => {
   });
   it('false when membership differs', () => {
     expect(rangesEqual([live('a', 1, 2)], [live('a', 1, 2), live('b', 4, 4)])).toBe(false);
+  });
+});
+
+describe('isWholeBlockDeleted', () => {
+  // A whole-line comment spanning lines [start, end]; the deletion is a pure
+  // removal (text: '') of the range (sl,sc)-(el, *).
+  const del = (startLine: number, startColumn: number, endLine: number): EditChange => ({
+    startLine,
+    startColumn,
+    endLine,
+    text: '',
+  });
+
+  it('removes a mid-file block deleted from its first col through past its last line', () => {
+    // comment 5-8, delete (5,1)-(9,1)
+    expect(isWholeBlockDeleted(5, 8, del(5, 1, 9))).toBe(true);
+  });
+
+  it('removes a single-line comment whose line is deleted', () => {
+    expect(isWholeBlockDeleted(5, 5, del(5, 1, 6))).toBe(true);
+  });
+
+  it('removes when the deletion starts on an earlier line', () => {
+    // delete the trailing newline of line 4 through line 9 → lines 5-8 gone
+    expect(isWholeBlockDeleted(5, 8, del(4, 20, 9))).toBe(true);
+  });
+
+  it('keeps the comment when replacement text is non-empty (edit to one line)', () => {
+    expect(isWholeBlockDeleted(5, 8, { startLine: 5, startColumn: 1, endLine: 9, text: 'x' })).toBe(
+      false,
+    );
+  });
+
+  it('keeps the comment when its first line survives (deletion starts mid-line)', () => {
+    expect(isWholeBlockDeleted(5, 8, del(5, 4, 9))).toBe(false);
+  });
+
+  it('keeps the comment when its last line survives (deletion ends on it)', () => {
+    // delete (5,1)-(8,1) removes lines 5-7, line 8 remains as a valid anchor
+    expect(isWholeBlockDeleted(5, 8, del(5, 1, 8))).toBe(false);
+  });
+
+  it('keeps the comment when only a leading subset of lines is deleted', () => {
+    // delete (6,1)-(9,1): line 5 survives
+    expect(isWholeBlockDeleted(5, 8, del(6, 1, 9))).toBe(false);
+  });
+});
+
+describe('commentsDeletedByEdit', () => {
+  it('collects ids whose whole block any change deletes', () => {
+    const comments = [
+      { id: 'a', startLine: 5, endLine: 8 },
+      { id: 'b', startLine: 20, endLine: 20 },
+    ];
+    const changes: EditChange[] = [{ startLine: 5, startColumn: 1, endLine: 9, text: '' }];
+    expect(commentsDeletedByEdit(comments, changes)).toEqual(['a']);
+  });
+
+  it('returns empty when no block is fully deleted', () => {
+    const comments = [{ id: 'a', startLine: 5, endLine: 8 }];
+    const changes: EditChange[] = [{ startLine: 6, startColumn: 1, endLine: 7, text: '' }];
+    expect(commentsDeletedByEdit(comments, changes)).toEqual([]);
   });
 });
 

--- a/src/renderer/components/diffEditor/comments/liveProjection.ts
+++ b/src/renderer/components/diffEditor/comments/liveProjection.ts
@@ -43,6 +43,50 @@ export function isFullModelReplace(e: ContentChangeLite, currentValue: string): 
   return only.rangeOffset === 0 && only.text === currentValue;
 }
 
+/** A single content edit, reduced to the fields needed to decide whether it
+ *  deleted a comment's anchor block. Mirrors Monaco's IModelContentChange
+ *  (range + replacement text). */
+export interface EditChange {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  text: string;
+}
+
+/** True when an incremental edit deletes EVERY line a whole-line comment is
+ *  anchored to, leaving no line to re-anchor on. Only a *pure deletion* (empty
+ *  replacement) whose removed range starts at/before the comment's first line
+ *  (at column 1) and extends past its last line qualifies: replacing the block
+ *  with new text is an edit (the comment keeps that line as a single anchor),
+ *  and any surviving boundary line keeps the comment. A deletion ending exactly
+ *  on the comment's last line (e.g. an end-of-file block) is conservatively
+ *  kept — far better to leave a stale comment than to drop a valid one. */
+export function isWholeBlockDeleted(
+  commentStart: number,
+  commentEnd: number,
+  change: EditChange,
+): boolean {
+  if (change.text.length > 0) return false;
+  const coversStart =
+    change.startLine < commentStart ||
+    (change.startLine === commentStart && change.startColumn === 1);
+  const coversEnd = change.endLine > commentEnd;
+  return coversStart && coversEnd;
+}
+
+/** Ids of the comments whose whole anchor block was deleted by `changes`.
+ *  Comment ranges and change ranges are both in pre-edit model coordinates. */
+export function commentsDeletedByEdit(
+  comments: ReadonlyArray<{ id: string; startLine: number; endLine: number }>,
+  changes: ReadonlyArray<EditChange>,
+): string[] {
+  const ids: string[] = [];
+  for (const c of comments) {
+    if (changes.some((ch) => isWholeBlockDeleted(c.startLine, c.endLine, ch))) ids.push(c.id);
+  }
+  return ids;
+}
+
 /** True when both arrays have the same ids in the same order with identical
  *  ranges. Used to avoid publishing a new reference when nothing moved. */
 export function rangesEqual(a: ReadonlyArray<LiveComment>, b: ReadonlyArray<LiveComment>): boolean {

--- a/src/renderer/components/diffEditor/comments/overlay/CommentOverlay.tsx
+++ b/src/renderer/components/diffEditor/comments/overlay/CommentOverlay.tsx
@@ -24,6 +24,8 @@ interface Props {
   onEditComment(comment: LiveComment): void;
   /** Click the × on a bubble → permanently delete that comment. */
   onDeleteComment(id: string): void;
+  /** Click the reopen control on a sent bubble → mark that comment unsent. */
+  onReopenComment(id: string): void;
   /** When non-null, the overlay renders a DraftBubble at the range's
    *  start line — for both fresh creation and editing. */
   pendingRange: LineRange | null;
@@ -59,6 +61,7 @@ export function CommentOverlay({
   onHoveredIdChange,
   onEditComment,
   onDeleteComment,
+  onReopenComment,
   pendingRange,
   pendingText,
   editingId,
@@ -249,6 +252,7 @@ export function CommentOverlay({
                 onBubbleHover={onHoveredIdChange}
                 onEdit={onEditComment}
                 onDelete={onDeleteComment}
+                onReopen={onReopenComment}
                 editingId={editingId}
                 scopeLabel={scopeLabel}
               />

--- a/src/renderer/components/diffEditor/comments/useFileComments.ts
+++ b/src/renderer/components/diffEditor/comments/useFileComments.ts
@@ -1,7 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { editor as monacoEditor } from 'monaco-editor';
 import { useCommentsStore } from '../../../stores/commentsStore';
-import { isFullModelReplace, projectRanges, rangesEqual, type RangeReader } from './liveProjection';
+import {
+  commentsDeletedByEdit,
+  isFullModelReplace,
+  projectRanges,
+  rangesEqual,
+  type RangeReader,
+} from './liveProjection';
 import type { DiffComment, LineRange, LiveComment } from './types';
 
 // Frozen empty default so `?? EMPTY_STORED` doesn't allocate a fresh array
@@ -150,11 +156,41 @@ export function useFileComments({
     if (!modifiedEditor) return;
     const sub = modifiedEditor.onDidChangeModelContent((e) => {
       const model = modifiedEditor.getModel();
-      if (model && isFullModelReplace(e, model.getValue())) hydrate();
-      else republish();
+      if (model && isFullModelReplace(e, model.getValue())) {
+        hydrate();
+        return;
+      }
+      // Incremental edit. If it deleted a comment's entire anchor block, drop
+      // that comment (store + decoration); otherwise just re-project ranges.
+      // Both comment ranges (liveCommentsRef) and the change ranges are in the
+      // pre-edit coordinate space, so they're directly comparable.
+      const editChanges = e.changes.map((ch) => ({
+        startLine: ch.range.startLineNumber,
+        startColumn: ch.range.startColumn,
+        endLine: ch.range.endLineNumber,
+        text: ch.text,
+      }));
+      const removedIds = commentsDeletedByEdit(liveCommentsRef.current, editChanges);
+      if (removedIds.length === 0) {
+        republish();
+        return;
+      }
+      const removeSet = new Set(removedIds);
+      const removedDecos = liveCommentsRef.current
+        .filter((c) => removeSet.has(c.id))
+        .map((c) => c.decorationId);
+      for (const id of removedIds) useCommentsStore.getState().remove(id);
+      if (model && removedDecos.length > 0) model.deltaDecorations(removedDecos, []);
+      // Project the survivors to their post-edit ranges in the same pass so the
+      // re-add bug (republish reading the stale ref) can't resurrect a removal.
+      const survivors = projectRanges(
+        liveCommentsRef.current.filter((c) => !removeSet.has(c.id)),
+        makeReader(),
+      );
+      setLiveComments(survivors);
     });
     return () => sub.dispose();
-  }, [modifiedEditor, hydrate, republish]);
+  }, [modifiedEditor, hydrate, republish, makeReader]);
 
   // ── Reconcile store removals → drop decorations ──
   useEffect(() => {
@@ -203,15 +239,13 @@ export function useFileComments({
     (range: LineRange, text: string): LiveComment | null => {
       const model = modifiedEditor?.getModel();
       if (!modifiedEditor || !monaco || !model) return null;
-      const created = useCommentsStore
-        .getState()
-        .addComment({
-          filePath,
-          startLine: range.start,
-          endLine: range.end,
-          text,
-          viewScope: scope,
-        });
+      const created = useCommentsStore.getState().addComment({
+        filePath,
+        startLine: range.start,
+        endLine: range.end,
+        text,
+        viewScope: scope,
+      });
       if (!created) return null;
       const ids = model.deltaDecorations(
         [],

--- a/src/renderer/components/diffEditor/data/__tests__/viewData.test.ts
+++ b/src/renderer/components/diffEditor/data/__tests__/viewData.test.ts
@@ -10,6 +10,8 @@ const commit = (hash: string): CommitSummary => ({
   body: '',
   authorName: 'a',
   authorDate: 0,
+  additions: 0,
+  deletions: 0,
 });
 const fc = (path: string): FileChange => ({
   path,

--- a/src/renderer/components/diffEditor/data/__tests__/viewPersistence.test.ts
+++ b/src/renderer/components/diffEditor/data/__tests__/viewPersistence.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { parseStoredView } from '../viewPersistence';
+import type { EditorView } from '../../types';
+
+describe('parseStoredView', () => {
+  it('round-trips a working view (HEAD)', () => {
+    const v: EditorView = { kind: 'working', ref: 'HEAD' };
+    expect(parseStoredView(JSON.stringify(v))).toEqual(v);
+  });
+
+  it('round-trips a working view (index)', () => {
+    const v: EditorView = { kind: 'working', ref: 'index' };
+    expect(parseStoredView(JSON.stringify(v))).toEqual(v);
+  });
+
+  it('round-trips a concrete commit view', () => {
+    const v: EditorView = { kind: 'commit', hash: 'abc1234' };
+    expect(parseStoredView(JSON.stringify(v))).toEqual(v);
+  });
+
+  it('round-trips a branch view', () => {
+    const v: EditorView = { kind: 'branch', base: 'origin/main' };
+    expect(parseStoredView(JSON.stringify(v))).toEqual(v);
+  });
+
+  it('rejects the unresolved HEAD commit sentinel', () => {
+    expect(parseStoredView(JSON.stringify({ kind: 'commit', hash: 'HEAD' }))).toBeNull();
+  });
+
+  it('returns null for null / empty input', () => {
+    expect(parseStoredView(null)).toBeNull();
+    expect(parseStoredView('')).toBeNull();
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(parseStoredView('{not json')).toBeNull();
+  });
+
+  it('rejects an unknown kind', () => {
+    expect(parseStoredView(JSON.stringify({ kind: 'tag', name: 'v1' }))).toBeNull();
+  });
+
+  it('rejects a working view with a bad ref', () => {
+    expect(parseStoredView(JSON.stringify({ kind: 'working', ref: 'STAGE' }))).toBeNull();
+  });
+
+  it('rejects a commit view with an empty/missing hash', () => {
+    expect(parseStoredView(JSON.stringify({ kind: 'commit', hash: '' }))).toBeNull();
+    expect(parseStoredView(JSON.stringify({ kind: 'commit' }))).toBeNull();
+  });
+
+  it('rejects a branch view with an empty/missing base', () => {
+    expect(parseStoredView(JSON.stringify({ kind: 'branch', base: '' }))).toBeNull();
+    expect(parseStoredView(JSON.stringify({ kind: 'branch' }))).toBeNull();
+  });
+
+  it('rejects non-object JSON', () => {
+    expect(parseStoredView('42')).toBeNull();
+    expect(parseStoredView('"working"')).toBeNull();
+    expect(parseStoredView('null')).toBeNull();
+  });
+});

--- a/src/renderer/components/diffEditor/data/useEditorViewData.ts
+++ b/src/renderer/components/diffEditor/data/useEditorViewData.ts
@@ -74,6 +74,8 @@ export function useEditorViewData(
               body: c.body,
               authorName: c.authorName,
               authorDate: c.authorDate,
+              additions: c.additions,
+              deletions: c.deletions,
             }))
           : NO_COMMITS,
       ),

--- a/src/renderer/components/diffEditor/data/viewPersistence.ts
+++ b/src/renderer/components/diffEditor/data/viewPersistence.ts
@@ -1,0 +1,52 @@
+import type { EditorView } from '../types';
+
+// Per-repo last-open view, so reopening the editor lands back where the user
+// left off (a commit, a branch comparison, or the working tree) instead of
+// always resetting to working. Keyed by cwd because each task worktree has its
+// own history. Renderer-only, like the other diff-editor UI prefs.
+const keyFor = (cwd: string) => `diffEditor.view:${cwd}`;
+
+/** Validate an unknown value into an EditorView, or null if it doesn't match
+ *  the discriminated-union shape. Pure so it can be unit-tested directly. */
+export function parseStoredView(raw: string | null): EditorView | null {
+  if (!raw) return null;
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!value || typeof value !== 'object') return null;
+  const o = value as Record<string, unknown>;
+  if (o.kind === 'working' && (o.ref === 'HEAD' || o.ref === 'index')) {
+    return { kind: 'working', ref: o.ref };
+  }
+  if (o.kind === 'commit' && typeof o.hash === 'string' && o.hash) {
+    // Never restore the unresolved 'HEAD' sentinel as a pinned commit — the
+    // working tree is the right default for "latest".
+    if (o.hash === 'HEAD') return null;
+    return { kind: 'commit', hash: o.hash };
+  }
+  if (o.kind === 'branch' && typeof o.base === 'string' && o.base) {
+    return { kind: 'branch', base: o.base };
+  }
+  return null;
+}
+
+export function readStoredView(cwd: string): EditorView | null {
+  try {
+    return parseStoredView(localStorage.getItem(keyFor(cwd)));
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredView(cwd: string, view: EditorView): void {
+  // Don't persist the unresolved 'HEAD' sentinel; wait for the concrete sha.
+  if (view.kind === 'commit' && view.hash === 'HEAD') return;
+  try {
+    localStorage.setItem(keyFor(cwd), JSON.stringify(view));
+  } catch {
+    // Storage full / unavailable — persistence is best-effort.
+  }
+}

--- a/src/renderer/components/diffEditor/editor/EditorHeader.tsx
+++ b/src/renderer/components/diffEditor/editor/EditorHeader.tsx
@@ -1,14 +1,5 @@
 import { useEffect, useState } from 'react';
-import {
-  Code2,
-  Eye,
-  GitCommit,
-  GitCompare,
-  History,
-  MessageSquare,
-  WrapText,
-  X,
-} from 'lucide-react';
+import { Eye, GitCommit, GitCompare, History, MessageSquare, WrapText, X } from 'lucide-react';
 import type { EditorView } from '../types';
 import { Popover, PopoverAnchor, PopoverContent } from '../../ui/Popover';
 import { Tooltip } from '../../ui/Tooltip';
@@ -90,6 +81,18 @@ export function EditorHeader({
     setPickerOpen(false);
   }
 
+  function handleExit() {
+    onExitBranchView();
+    setPickerOpen(false);
+  }
+
+  // Plain icon button: no persistent fill — an active toggle just tints the
+  // icon primary; hover gives a subtle surface for affordance.
+  const iconBtn = (active: boolean) =>
+    `p-1.5 rounded-md transition-colors hover:bg-accent/60 ${
+      active ? 'text-primary' : 'text-muted-foreground/60 hover:text-foreground'
+    }`;
+
   function handleChipClick() {
     if (isBranch) {
       setPickerOpen((v) => !v);
@@ -117,7 +120,7 @@ export function EditorHeader({
                 : viewMeta.tooltip
             }
           >
-            <span className="inline-flex items-center gap-1.5 px-2 h-6 rounded-md text-[11px] font-medium shrink-0 bg-primary/15 text-primary">
+            <span className="inline-flex items-center gap-1.5 h-6 text-[11px] font-medium shrink-0 text-primary">
               <viewMeta.Icon size={12} strokeWidth={1.8} className="shrink-0" />
               <span className="font-mono whitespace-nowrap max-w-[260px] truncate">
                 {viewMeta.label}
@@ -134,67 +137,37 @@ export function EditorHeader({
         )}
         <span className="text-[13px] font-medium text-foreground truncate">{filePath}</span>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1">
         {canPreview && (
-          <div className="flex items-center gap-0.5 rounded-md bg-[hsl(var(--surface-3))] p-0.5">
+          <Tooltip content={previewing ? 'Show source' : 'Show rendered preview'}>
             <button
               type="button"
-              onClick={() => onTogglePreview(false)}
-              title="Show source"
-              className={`flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors ${
-                previewing
-                  ? 'text-muted-foreground/60 hover:text-foreground'
-                  : 'bg-primary/15 text-primary'
-              }`}
+              onClick={() => onTogglePreview(!previewing)}
+              className={iconBtn(previewing)}
             >
-              <Code2 size={12} strokeWidth={1.8} />
-              Code
+              <Eye size={14} strokeWidth={1.8} />
             </button>
-            <button
-              type="button"
-              onClick={() => onTogglePreview(true)}
-              title="Show rendered preview"
-              className={`flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-medium transition-colors ${
-                previewing
-                  ? 'bg-primary/15 text-primary'
-                  : 'text-muted-foreground/60 hover:text-foreground'
-              }`}
-            >
-              <Eye size={12} strokeWidth={1.8} />
-              Preview
-            </button>
-          </div>
+          </Tooltip>
         )}
         <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
           <PopoverAnchor asChild>
             <div className="inline-flex items-center">
-              <button
-                type="button"
-                onClick={handleChipClick}
-                title={isBranch ? 'Change base branch' : 'Compare with another branch'}
-                className={`inline-flex items-center gap-1.5 px-2 h-6 rounded-md text-[11px] font-mono transition-colors ${
-                  isBranch
-                    ? 'bg-primary/15 text-primary'
-                    : 'text-muted-foreground/60 hover:text-foreground hover:bg-accent/60'
-                }`}
-              >
-                <GitCompare size={12} strokeWidth={1.8} className="shrink-0" />
-                {isBranch ? (
-                  <span className="truncate max-w-[420px]">base: {view.base}</span>
-                ) : (
-                  <span className="whitespace-nowrap">Compare with branch…</span>
-                )}
-              </button>
-              {isBranch && (
+              <Tooltip content={isBranch ? 'Change base branch' : 'Compare with another branch'}>
                 <button
                   type="button"
-                  onClick={onExitBranchView}
-                  title="Exit branch comparison"
-                  className="ml-0.5 p-0.5 rounded-md text-muted-foreground/50 hover:text-foreground hover:bg-accent/60 transition-colors"
+                  onClick={handleChipClick}
+                  className={`inline-flex items-center gap-1.5 px-2 h-6 rounded-md text-[11px] font-mono transition-colors hover:bg-accent/60 ${
+                    isBranch ? 'text-primary' : 'text-muted-foreground/60 hover:text-foreground'
+                  }`}
                 >
-                  <X size={12} strokeWidth={2} />
+                  <GitCompare size={12} strokeWidth={1.8} className="shrink-0" />
+                  {isBranch ? (
+                    <span className="truncate max-w-[420px]">base: {view.base}</span>
+                  ) : (
+                    <span className="whitespace-nowrap">Compare with branch…</span>
+                  )}
                 </button>
-              )}
+              </Tooltip>
             </div>
           </PopoverAnchor>
           <PopoverContent side="bottom" align="end" sideOffset={6} className="p-0">
@@ -202,37 +175,28 @@ export function EditorHeader({
               cwd={cwd}
               selectedRef={isBranch ? view.base : null}
               onSelect={handleSelect}
+              onExit={isBranch ? handleExit : undefined}
             />
           </PopoverContent>
         </Popover>
-        <button
-          onClick={onToggleBlame}
-          title={blameEnabled ? 'Hide git blame' : 'Show git blame'}
-          className={`p-1.5 rounded-md transition-colors ${
-            blameEnabled
-              ? 'bg-primary/15 text-primary'
-              : 'text-muted-foreground/60 hover:text-foreground hover:bg-accent/60'
-          }`}
-        >
-          <History size={14} strokeWidth={1.8} />
-        </button>
-        <button
-          onClick={onToggleWordWrap}
-          title={wordWrap ? 'Disable word wrap' : 'Enable word wrap'}
-          className={`p-1.5 rounded-md transition-colors ${
-            wordWrap
-              ? 'bg-primary/15 text-primary'
-              : 'text-muted-foreground/60 hover:text-foreground hover:bg-accent/60'
-          }`}
-        >
-          <WrapText size={14} strokeWidth={1.8} />
-        </button>
-        <button
-          onClick={onClose}
-          className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground/50 hover:text-foreground transition-all duration-150"
-        >
-          <X size={14} strokeWidth={2} />
-        </button>
+        <Tooltip content={blameEnabled ? 'Hide git blame' : 'Show git blame'}>
+          <button onClick={onToggleBlame} className={iconBtn(blameEnabled)}>
+            <History size={14} strokeWidth={1.8} />
+          </button>
+        </Tooltip>
+        <Tooltip content={wordWrap ? 'Disable word wrap' : 'Enable word wrap'}>
+          <button onClick={onToggleWordWrap} className={iconBtn(wordWrap)}>
+            <WrapText size={14} strokeWidth={1.8} />
+          </button>
+        </Tooltip>
+        <Tooltip content="Close">
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-accent/60 transition-colors"
+          >
+            <X size={14} strokeWidth={2} />
+          </button>
+        </Tooltip>
       </div>
     </div>
   );

--- a/src/renderer/components/diffEditor/monacoTheme.ts
+++ b/src/renderer/components/diffEditor/monacoTheme.ts
@@ -4,8 +4,8 @@ import type { ITheme as XtermTheme } from '@xterm/xterm';
 // changes — Monaco caches themes by name, and the EditorPane's theme effect
 // only re-applies when `themeName` actually changes, so renaming forces a
 // fresh defineTheme + setTheme on already-open editors.
-export const MONACO_THEME_DARK = 'dash-terminal-dark-v5';
-export const MONACO_THEME_LIGHT = 'dash-terminal-light-v5';
+export const MONACO_THEME_DARK = 'dash-terminal-dark-v6';
+export const MONACO_THEME_LIGHT = 'dash-terminal-light-v6';
 
 /** Define a Monaco theme that mirrors the xterm.js terminal palette. Keeps
  *  the diff editor visually consistent with whichever palette the user
@@ -53,14 +53,14 @@ export function defineMonacoThemeFromTerminal(
       // borders so the diff editor doesn't sprout its own backdrop.
       'diffEditor.diagonalFill': '#00000000',
       'diffEditor.border': '#00000000',
-      // Subtle insert/remove backgrounds. Monaco's defaults are ~20% alpha
-      // (#9ccc2c33 / #ff000033) which reads as loud highlighter; we dial
-      // text down to ~5% and line down to ~3% so syntax colors stay legible
-      // while still marking the region.
-      'diffEditor.insertedTextBackground': isDark ? '#3fb9501f' : '#2da14424',
-      'diffEditor.removedTextBackground': isDark ? '#f850491f' : '#cf222e24',
-      'diffEditor.insertedLineBackground': isDark ? '#3fb95014' : '#2da14418',
-      'diffEditor.removedLineBackground': isDark ? '#f8504914' : '#cf222e18',
+      // Insert/remove backgrounds. Monaco's defaults are ~20% alpha
+      // (#9ccc2c33 / #ff000033) which reads as a loud highlighter; we keep the
+      // changed *text* a touch stronger (~18–20%) than the full *line* wash
+      // (~12–14%) so syntax colors stay legible while the region reads clearly.
+      'diffEditor.insertedTextBackground': isDark ? '#3fb9502e' : '#2da14433',
+      'diffEditor.removedTextBackground': isDark ? '#f850492e' : '#cf222e33',
+      'diffEditor.insertedLineBackground': isDark ? '#3fb95020' : '#2da14424',
+      'diffEditor.removedLineBackground': isDark ? '#f8504920' : '#cf222e24',
       'diffEditorOverview.insertedForeground': isDark ? '#3fb95080' : '#2da14480',
       'diffEditorOverview.removedForeground': isDark ? '#f8504980' : '#cf222e80',
     },

--- a/src/renderer/components/diffEditor/types.ts
+++ b/src/renderer/components/diffEditor/types.ts
@@ -14,6 +14,9 @@ export interface CommitSummary {
   body: string;
   authorName: string;
   authorDate: number;
+  /** Lines added/removed by this commit (0 for merges). */
+  additions: number;
+  deletions: number;
 }
 
 /** A file in the current view's tree. Reuses the project's FileChange shape. */

--- a/src/renderer/components/ui/Modal.tsx
+++ b/src/renderer/components/ui/Modal.tsx
@@ -36,6 +36,10 @@ interface ModalProps {
   /** Inline style merged onto the card div. Use for one-off overrides (e.g.
    *  a more transparent background) — beats class-based bg utilities. */
   cardStyle?: React.CSSProperties;
+  /** Raise the backdrop above the default z-50 so this modal stacks over
+   *  another already-open modal (e.g. the commit graph opened from the diff
+   *  editor's blame card). */
+  elevated?: boolean;
   children: React.ReactNode;
 }
 
@@ -43,7 +47,14 @@ interface ModalProps {
 // pushes onto this stack so the outer's keydown handler bows out for Esc.
 const modalCloseStack: Array<() => void> = [];
 
-export function Modal({ onClose, size, overflow = 'hidden', cardStyle, children }: ModalProps) {
+export function Modal({
+  onClose,
+  size,
+  overflow = 'hidden',
+  cardStyle,
+  elevated = false,
+  children,
+}: ModalProps) {
   const [closing, setClosing] = useState(false);
   const requestClose = useCallback(() => setClosing(true), []);
   // Backdrop click should ONLY close when both mousedown and mouseup land on
@@ -94,7 +105,7 @@ export function Modal({ onClose, size, overflow = 'hidden', cardStyle, children 
           softer dim + blur lets the underlying app peek through the translucent
           card without dominating it. */}
       <div
-        className={`fixed inset-0 z-50 flex items-center justify-center bg-[hsl(0_0%_0%/0.55)] backdrop-blur-md ${closing ? 'animate-fade-out' : 'animate-fade-in'}`}
+        className={`fixed inset-0 ${elevated ? 'z-[60]' : 'z-50'} flex items-center justify-center bg-[hsl(0_0%_0%/0.55)] backdrop-blur-md ${closing ? 'animate-fade-out' : 'animate-fade-in'}`}
         onMouseDown={(e) => {
           mouseDownOnBackdrop.current = e.target === e.currentTarget;
         }}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1075,9 +1075,9 @@
   z-index: 7;
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  width: 162px;
-  padding: 6px 9px;
+  gap: 3px;
+  width: 172px;
+  padding: 8px 10px;
   border-radius: 5px 0 0 5px;
   border: 1px solid hsl(var(--border) / 0.5);
   background-color: hsl(var(--surface-3) / 0.45);
@@ -1135,8 +1135,8 @@
 }
 .blame-label-author {
   font-size: 11px;
-  font-weight: 500;
-  color: hsl(var(--muted-foreground));
+  font-weight: 600;
+  color: hsl(var(--foreground) / 0.9); /* the card's title line */
   padding-right: 16px; /* clear the × button */
   white-space: nowrap;
   overflow: hidden;
@@ -1144,13 +1144,36 @@
 }
 .blame-label-meta {
   display: flex;
-  gap: 7px;
+  align-items: center;
+  gap: 6px;
   font-size: 10px;
   color: hsl(var(--muted-foreground));
 }
 .blame-label-sha {
   font-family: 'SF Mono', ui-monospace, Menlo, monospace;
+  font-size: 10px;
   color: hsl(var(--primary));
+  /* Rendered as a <button> (opens the commit in the graph) — strip the native
+   * chrome and read as an inline link. */
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+.blame-label-sha:hover {
+  text-decoration: underline;
+}
+.blame-label-age {
+  white-space: nowrap;
+}
+.blame-label-lines {
+  /* Quiet, right-aligned annotation — secondary to the sha · age metadata. */
+  margin-left: auto;
+  padding-left: 6px;
+  font-family: 'SF Mono', ui-monospace, Menlo, monospace;
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+  color: hsl(var(--muted-foreground) / 0.5);
 }
 .blame-label-summary {
   font-size: 10px;

--- a/src/renderer/stores/__tests__/commentsStore.test.ts
+++ b/src/renderer/stores/__tests__/commentsStore.test.ts
@@ -90,6 +90,46 @@ describe('commentsStore', () => {
     expect(api.diffCommentsDelete).toHaveBeenCalledWith({ id: 'a' });
   });
 
+  it('clearSent removes only sent comments and deletes each via IPC', async () => {
+    api.diffCommentsList = vi.fn(() =>
+      Promise.resolve({
+        success: true,
+        data: [
+          cmt({ id: 'a', sent: true }),
+          cmt({ id: 'b', sent: false }),
+          cmt({ id: 'c', filePath: 'b.ts', sent: true }),
+        ],
+      }),
+    );
+    const useCommentsStore = await freshStore();
+    await useCommentsStore.getState().loadForTask('t1');
+    useCommentsStore.getState().clearSent();
+    const byFile = useCommentsStore.getState().byFile;
+    expect(byFile['a.ts']!.map((c) => c.id)).toEqual(['b']);
+    expect(byFile['b.ts']).toBeUndefined();
+    expect(api.diffCommentsDelete).toHaveBeenCalledWith({ id: 'a' });
+    expect(api.diffCommentsDelete).toHaveBeenCalledWith({ id: 'c' });
+    expect(api.diffCommentsDelete).toHaveBeenCalledTimes(2);
+  });
+
+  it('clearSent(scope) only clears sent comments in that scope', async () => {
+    api.diffCommentsList = vi.fn(() =>
+      Promise.resolve({
+        success: true,
+        data: [
+          cmt({ id: 'a', sent: true, viewScope: 'live' }),
+          cmt({ id: 'b', sent: true, viewScope: 'commit:abc' }),
+        ],
+      }),
+    );
+    const useCommentsStore = await freshStore();
+    await useCommentsStore.getState().loadForTask('t1');
+    useCommentsStore.getState().clearSent('commit:abc');
+    expect(useCommentsStore.getState().byFile['a.ts']!.map((c) => c.id)).toEqual(['a']);
+    expect(api.diffCommentsDelete).toHaveBeenCalledWith({ id: 'b' });
+    expect(api.diffCommentsDelete).toHaveBeenCalledTimes(1);
+  });
+
   it('snapshotRanges patches start/end and persists', async () => {
     api.diffCommentsList = vi.fn(() =>
       Promise.resolve({ success: true, data: [cmt({ id: 'a', startLine: 1, endLine: 1 })] }),

--- a/src/renderer/stores/commentsStore.ts
+++ b/src/renderer/stores/commentsStore.ts
@@ -28,6 +28,8 @@ export interface CommentsActions {
   remove: (id: string) => void;
   markSent: (ids: ReadonlyArray<string>) => void;
   markUnsent: (id: string) => void;
+  /** Remove all sent comments, optionally limited to one view scope. */
+  clearSent: (scope?: string) => void;
   snapshotRanges: (filePath: string, snapshots: ReadonlyArray<RangeSnapshot>) => void;
   prune: (existingFilePaths: ReadonlySet<string>) => Promise<{ deleted: number }>;
 }
@@ -48,6 +50,17 @@ function stripById(
   const next: Record<string, DiffComment[]> = {};
   for (const [path, list] of Object.entries(byFile)) {
     const filtered = list.filter((c) => c.id !== id);
+    if (filtered.length > 0) next[path] = filtered;
+  }
+  return next;
+}
+function stripByIds(
+  byFile: Record<string, DiffComment[]>,
+  ids: ReadonlySet<string>,
+): Record<string, DiffComment[]> {
+  const next: Record<string, DiffComment[]> = {};
+  for (const [path, list] of Object.entries(byFile)) {
+    const filtered = list.filter((c) => !ids.has(c.id));
     if (filtered.length > 0) next[path] = filtered;
   }
   return next;
@@ -165,6 +178,20 @@ export const useCommentsStore = create<CommentsStore>((set, get) => ({
     set((s) => ({ byFile: mapAll(s.byFile, (c) => (c.id === id ? { ...c, sent: false } : c)) }));
     const existing = findById(get().byFile, id);
     if (existing) persist(existing, { sent: false });
+  },
+
+  clearSent: (scope) => {
+    if (!get().taskId) return;
+    const ids: string[] = [];
+    for (const list of Object.values(get().byFile)) {
+      for (const c of list) {
+        if (c.sent && (scope === undefined || c.viewScope === scope)) ids.push(c.id);
+      }
+    }
+    if (ids.length === 0) return;
+    const idSet = new Set(ids);
+    set((s) => ({ byFile: stripByIds(s.byFile, idSet) }));
+    for (const id of ids) void window.electronAPI.diffCommentsDelete({ id });
   },
 
   snapshotRanges: (filePath, snapshots) => {

--- a/src/renderer/stores/gitStore.ts
+++ b/src/renderer/stores/gitStore.ts
@@ -28,11 +28,17 @@ export interface GitState {
   /** PR per task for the ProjectView cards, keyed by task id (null = none). */
   prByTask: Record<string, PullRequestInfo | null>;
   showCommitGraph: boolean;
+  /** When set, the commit-graph modal selects + scrolls to this commit on open
+   *  (e.g. opened from the diff editor's blame card). Cleared on close. */
+  commitGraphFocusHash: string | null;
 }
 
 export interface GitActions {
   setDiffFile: (v: DiffFileTarget | null) => void;
   setShowCommitGraph: (v: Updater<boolean>) => void;
+  /** Open the commit-graph modal scrolled to a specific commit. */
+  openCommitGraphAtCommit: (hash: string) => void;
+  setCommitGraphFocusHash: (hash: string | null) => void;
   refreshGitStatus: (cwd: string) => Promise<void>;
   // Mutating ops — resolve the active task themselves, then refresh its status.
   stageFiles: (filePaths: string[]) => Promise<void>;
@@ -65,9 +71,12 @@ export const useGit = create<GitStore>((set, get) => ({
   prInfo: null,
   prByTask: {},
   showCommitGraph: false,
+  commitGraphFocusHash: null,
 
   setDiffFile: (v) => set({ diffFile: v }),
   setShowCommitGraph: (v) => set((s) => ({ showCommitGraph: apply(v, s.showCommitGraph) })),
+  openCommitGraphAtCommit: (hash) => set({ commitGraphFocusHash: hash, showCommitGraph: true }),
+  setCommitGraphFocusHash: (hash) => set({ commitGraphFocusHash: hash }),
 
   refreshGitStatus: async (cwd) => {
     set({ gitLoading: true });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -766,6 +766,10 @@ export interface EditorCommitListItem {
   authorDate: number;
   subject: string;
   body: string;
+  /** Lines added/removed by this commit (summed across its files). 0 for merge
+   *  commits, which carry no diffstat. */
+  additions: number;
+  deletions: number;
 }
 
 // ── Workspace ports ──────────────────────────────────────────


### PR DESCRIPTION
A renderer-focused sweep across the diff editor (one main-process change: per-commit LoC). Bumps to **0.13.4**; corrects the CLAUDE.md Node requirement 22 → 24 to match `.nvmrc`.

## File tree & commits
- Changed-only file-tree toggle, persisted to localStorage
- `+N −M` LoC totals in the file-tree header
- `+N −M` per commit row, via a single `git log --numstat` pass

## View
- Persist the open view (working/commit/branch) per repo across modal close, with a one-shot fallback to working when a stored commit/branch ref no longer resolves

## Comments
- "Clear sent" (global + per-scope) in the comments popover
- Reopen control on sent in-editor bubbles (`markUnsent`)
- Auto-remove a comment when an edit deletes its whole anchor block (pure deletion only; editing to a single line keeps the anchor)

## Blame
- Line range on the blame card; restyled card hierarchy
- Commit sha opens the commit graph focused on that commit; `Modal` gains an `elevated` z-index so the graph stacks above the diff editor

## Header
- Preview is now a single toggle (was a Code|Preview segmented control)
- Plain icon buttons: active toggles tint the icon, no filled pills
- Exit-branch-comparison moved into the branch picker dropdown
- Dash `Tooltip` on all header buttons
- Stronger diff-highlight opacity; background-less "Showing…" badge

## Tests
+29 (view persistence, clearSent, commit numstat parser, whole-block deletion). Full suite **899 passing**; type-check + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)