### PR TITLE
Agentic loops: Ralph worker + manager, two-terminal pane, Dash-driven scheduler

### DIFF
--- a/docs/agentic-loops-plan.md
+++ b/docs/agentic-loops-plan.md
@@ -278,6 +278,45 @@ round out the product.
 
 ---
 
+## 11a. Authority, manager model & worktree cohabitation (locked)
+
+**Manager model ≥ worker.** The manager is an _overseer_; evaluation is at least as hard
+as generation, so a model weaker than the worker can't reliably grade it. Default the
+manager to the worker's tier (`resolveAgentModel` mirrors it); `managerWeakerThanWorker`
+flags the anti-pattern for a modal warning. Cost is contained because the manager runs
+**episodically** (between iterations) while the worker runs continuously, and the
+manager's mechanical work (state reads, run-log, status) is offloaded to MCP tools, not
+model tokens.
+
+**How the manager manages — capabilities, not vibes.** Its _decisions_ are its own
+judgment; its _actions_ are a fixed, enforced set:
+
+- **Enforced by Dash:** can't edit code (separate process + write-deny settings); can't
+  exceed budget (scheduler auto-pause); pause/resume/kill are real scheduler ops, gated
+  by level and logged to the run-log.
+- **Soft (its judgment):** priorities, when to intervene, what to escalate.
+- **Steering channel:** because the worker resets context each pass, the manager steers
+  by appending to `manager-notes.md`, which the next fresh worker reads. Urgent control
+  goes through the loop MCP (pause/kill). It shapes the _inputs_ of the next iteration,
+  never a live session it's about to discard.
+
+**Permission is the wrong lever; capability shaping is right.** `default` prompts on
+_every_ tool (including reads) → an autonomous manager would stall on `grep`/`git log`.
+None of the three modes is "reads yes, writes no." So the manager runs **unprompted**
+(`bypassPermissions`) with a **write-deny policy passed via `claude --settings`** —
+per-process, because the two agents share a worktree and a cwd settings file can't differ
+per agent. Deny beats every allow and PreToolUse denial is independent of permission mode,
+so `Write/Edit/MultiEdit/NotebookEdit` are a hard block and the git-write/destructive Bash
+patterns cover the rest (see `MANAGER_DENY` in `loopSpawn.ts`).
+
+**Worktree cohabitation.** Dash's rule is really "one _non-worktree_ task per path," whose
+deeper invariant is "unique cwd → deterministic `--resume`." A loop is **one task**, so it
+doesn't violate the rule; the resume invariant is preserved because **both loop agents
+spawn `freshContext`** (never resume-by-mtime → no session-file collision). Git-write
+safety in the shared worktree holds because **only the worker writes** (single writer → no
+`index.lock` races). A shared worktree is correct by design — the manager must see the
+worker's _actual_ state — so we make cohabitation safe rather than splitting it.
+
 ## 12. Open questions
 
 - Worker visibility: run the worker interactive (visible, your two-PTY vision) while Dash

--- a/docs/agentic-loops-plan.md
+++ b/docs/agentic-loops-plan.md
@@ -1,0 +1,240 @@
+# Agentic Loops in Dash — Implementation Plan
+
+> Status: design / pre-implementation
+> Branch: `claude/agentic-loops-dash-ka6xwn`
+> Owner: Dash team
+
+First-class support for **agentic loops**: a task can be started _as a loop_, or an
+existing task can be _duplicated as a loop_. A loop runs **two terminals side-by-side**
+in the main pane — a **loop (worker) agent** that iterates on the goal, and a **loop
+manager agent** that orchestrates — connected by an **MCP bridge** so the manager can
+observe, steer, pause, and kill the worker.
+
+The conceptual base is [loop-engineering](https://github.com/cobusgreyling/loop-engineering)
+(role separation + durable state spine) combined with the **Ralph loop** (Geoffrey
+Huntley): _fresh context every iteration, completion judged by external signals, not
+self-grading_.
+
+---
+
+## 1. Design decisions (locked)
+
+| Decision | Choice | Why |
+|---|---|---|
+| Cadence ownership | **Dash-driven scheduler** | Dash owns the iteration boundary → clean control points for budget gates, manager steer, pause/kill. |
+| Manager authority | **Observe + steer + pause/kill** | Full orchestrator role (loop-engineering's "manager"), gated by loop level. |
+| Loop mechanism | **Both policies, Ralph-primary** | Ralph (fresh-context reset) is the default and most important; `goal`/`cadence` are additional policies. |
+
+### Why Dash owns the loop (not the CLI's `/loop` / `/ralph-loop`)
+
+Claude Code ships in-session loop primitives (`/loop`, `/goal`, `/ralph-loop` plugin).
+All keep the iteration boundary _inside_ the Claude process — exactly where we need to
+insert our scheduler tick, budget gate, manager steer, and pause/kill. If the CLI owns
+the loop, Dash fights it for control. **Dash owns the `while`**, so every iteration
+boundary is a natural, observable control point. Dash effectively becomes a smarter,
+observable Ralph bash loop — which it is already 90% built to be (it spawns/kills PTYs,
+tracks idle via `ActivityMonitor`, owns worktrees and the hook server).
+
+We **mirror** the CLI's proven termination semantics as Dash _loop policies_ rather than
+reinventing them (see §3).
+
+---
+
+## 2. The Ralph core (primary path)
+
+The worker terminal is a **Ralph iteration loop owned by Dash**:
+
+```
+loop:
+  spawn FRESH `claude` in the worktree, reading PROMPT.md + STATE.md   # no --resume
+  worker does ONE unit of work, writes code + updates STATE.md, commits
+  worker goes idle (detected via ActivityMonitor / Stop hook)
+  Dash runs the STOP PREDICATE (policy-dependent, §3)
+  if satisfied  -> stop, mark loop done
+  else          -> kill worker session, loop (fresh context)
+```
+
+Two properties are non-negotiable and come straight from Ralph:
+
+1. **Fresh context every iteration.** The worker does **not** `--resume`. Each pass
+   starts clean, re-reading `PROMPT.md` + `STATE.md` from disk. This sidesteps context
+   rot ("the context window becomes a junk drawer"). _This is the single most important
+   new mechanic_ and is a real change from Dash's current always-resume behavior.
+2. **External verification, never self-grading.** Completion is decided by an external
+   signal (tests/lint exit code, or a manager verdict), not by the worker declaring
+   success. "One model. One loop. One verification signal."
+
+> Sophisticated, not complex: the loop itself is deliberately dumb (Ralph). All
+> sophistication lives in Dash's orchestration layer — scheduler, budget, manager, MCP,
+> state spine — not in fragile prompt machinery.
+
+---
+
+## 3. Loop policies (the only thing that varies is the stop predicate)
+
+`loopConfig.policy` selects the termination mode. The scheduler `while` is identical;
+only the **stop predicate** changes.
+
+| Policy | Mirrors | Stop predicate | Worker context | Use case |
+|---|---|---|---|---|
+| **`ralph`** (default) | classic Ralph | external signal (tests/lint) **or** manager verdict; optional max-iterations | **reset each pass** | "build/refactor this until correct" |
+| `goal` | CC `/goal` | a measurable condition checked each iteration | reset each pass | "all tests on main pass and lint is clean" |
+| `cadence` | CC `/loop` | timer — run every N; never self-terminates | reset each pass | triage / babysitter (PR watcher, CI sweeper) |
+| `count` | `/ralph-loop` | N iterations or completion-promise string | reset each pass | bounded mechanical sweeps |
+
+`ralph` and `goal` are nearly the same; `ralph` defaults the predicate to the project's
+test+lint command and adds a safety `maxIterations`. `cadence` is the loop-engineering
+"triage/manager loop" shape.
+
+---
+
+## 4. Two-terminal model & role split
+
+| | **Loop terminal (worker)** | **Manager terminal** |
+|---|---|---|
+| PTY id | `loop:{taskId}` | `mgr:{taskId}` |
+| Lifecycle | **ephemeral** — fresh spawn per iteration, killed between passes | **persistent** — one session, `--resume`, context accumulates |
+| Job | _acts_: edits code, runs tests, updates STATE.md, commits | _orchestrates_: triage, priorities, budget, escalation decisions |
+| Hard rule | — | **never edits code** (loop-engineering) |
+| cwd | task worktree | task worktree (read/triage role) |
+| MCP | minimal | **Dash Loop MCP attached** |
+
+This is both the Ralph insight (worker resets) **and** loop-engineering's role split
+(worker acts / manager orchestrates; implementer never grades its own homework — the
+verifier signal is external).
+
+---
+
+## 5. The MCP bridge ("MCP to interact if needed")
+
+A small **Dash Loop MCP server**, task-scoped, attached to the manager (and optionally
+the worker). Hung off the existing hook-server infrastructure (`DASH_HOOK_PORT`) or
+spawned per loop task. Surface:
+
+| Tool | Direction | Effect |
+|---|---|---|
+| `loop_status` | read | current iteration, last run, idle/busy, token spend vs budget |
+| `loop_get_state` / `loop_update_state` | read/write | structured `STATE.md` access |
+| `loop_steer(message)` | manager → worker | inject guidance into the next iteration's prompt |
+| `loop_pause` / `loop_resume` | manager → scheduler | halt/continue the `while` |
+| `loop_kill` | manager → scheduler | stop the loop (SIGTERM + grace via `ptyManager`) |
+| `loop_escalate(summary)` | worker → human | raise a human-gate item the manager surfaces |
+| `loop_append_run_log(entry)` | write | observability into `loop-run-log.md` |
+
+These drive **Dash's scheduler**, not the CLI's internal loop. Manager authority
+(`steer` / `pause` / `kill`) is gated by loop **level** (§7).
+
+---
+
+## 6. Durable state spine (the load-bearing part)
+
+Seeded into the worktree (or `.dash/loop/`) on loop creation, from templates filled from
+`loopConfig`. This is what makes it a real loop, not two chat windows.
+
+| File | Role |
+|---|---|
+| `PROMPT.md` | the goal re-read fresh by the worker every iteration |
+| `LOOP.md` | loop definition: name, level (L1/L2/L3), policy, cadence, handoff rules |
+| `STATE.md` | live priorities / watchlist / recent-noise (worker + manager read/write) |
+| `loop-constraints.md` | hard rules injected before every iteration ("never edit auth/", "run tests first") |
+| `loop-run-log.md` | per-run: timestamp, items, actions, escalations, token estimate |
+
+---
+
+## 7. Phased trust (L1 → L2 → L3)
+
+`loopConfig.level` gates worker permission mode, sub-agent caps, and manager authority:
+
+- **L1 — report-only**: worker read-only / `default` permission; no auto-commit; manager
+  may steer but kill stays human. (loop-engineering: never skip L1 on real repos.)
+- **L2 — assisted**: worker `acceptEdits`; bounded sub-agents; manager may pause/kill.
+- **L3 — unattended**: worker `bypassPermissions`; manager full authority; budget
+  auto-pause armed.
+
+---
+
+## 8. Lifecycle
+
+- **Start as loop**: TaskModal gains a "Loop" mode (goal, policy, cadence, level, token
+  budget, constraints). Creates task with `taskKind='loop'`, seeds state files, spawns
+  both PTYs.
+- **Duplicate as loop**: clone an existing task's config + `contextPrompt` → `PROMPT.md`
+  goal into a fresh `taskKind='loop'` task with a new worktree. (Also builds the _first_
+  task-duplication path — none exists today.)
+- **Budget auto-pause**: scheduler pauses when spend crosses the configured threshold and
+  notifies the manager/human (loop-engineering kill-switch analogue).
+
+---
+
+## 9. Data model changes
+
+`tasks` table (`src/main/db/schema.ts`):
+
+```ts
+taskKind: text('task_kind').notNull().default('standard'),  // 'standard' | 'loop'
+loopConfig: text('loop_config'),  // JSON
+```
+
+```ts
+// loopConfig shape
+{
+  policy: 'ralph' | 'goal' | 'cadence' | 'count',
+  goal: string,                 // -> PROMPT.md
+  level: 'L1' | 'L2' | 'L3',
+  stopPredicate?: string,       // e.g. test+lint command for ralph/goal
+  cadenceMs?: number,           // for 'cadence'
+  maxIterations?: number,       // for 'ralph'/'count'
+  completionPromise?: string,   // for 'count'
+  tokenBudget?: number,
+  managerPrompt?: string,
+  constraints?: string[],
+}
+```
+
+Run `pnpm drizzle:generate` for the migration.
+
+---
+
+## 10. File-by-file change list
+
+| Area | File(s) | Change |
+|---|---|---|
+| Schema + migration | `src/main/db/schema.ts` + `drizzle:generate` | `taskKind`, `loopConfig` |
+| Task save / duplicate | `src/main/services/DatabaseService.ts`, `src/main/ipc/dbIpc.ts` | persist loop fields; add `duplicateTask` |
+| **Fresh-context spawn** | `src/main/services/ptyManager.ts` (`buildClaudeArgs`, `startDirectPty` ≈359–517) | spawn mode that does **not** `--resume`; allow 2 agent PTYs per task (drop `id===taskId` assumptions) |
+| **Scheduler** | new `src/main/services/LoopScheduler.ts` | owns the `while`; idle-detect → stop predicate → re-spawn fresh worker / stop; budget auto-pause |
+| Stop predicate | new `src/main/services/loopPredicates.ts` | per-policy: test/lint exit code, timer, counter, completion-promise |
+| State seeding | new `src/main/services/LoopService.ts` | write PROMPT/LOOP/STATE/constraints/run-log from templates |
+| MCP bridge | new `src/main/services/loopMcpServer.ts` (+ hook-server wiring) | tool surface in §5 |
+| Split UI | new `src/renderer/components/terminal/LoopTerminalPane.tsx`; `src/renderer/components/MainContent.tsx` (≈300) | branch on `taskKind==='loop'` → horizontal `PanelGroup` of two `TerminalPane`s |
+| Disposal | `src/renderer/stores/projectsStore.ts` (`disposeTaskSessions`) | dispose `loop:` + `mgr:` ids |
+| Modal | `src/renderer/components/task/TaskModal.tsx` | loop mode (policy/level/budget/constraints) + duplicate-as-loop action |
+| Types | `src/shared/types.ts`, `src/types/electron-api.d.ts` | loop config + new IPC |
+
+---
+
+## 11. Build order
+
+1. **Schema + types** — `taskKind`, `loopConfig`, migration.
+2. **Fresh-context spawn mode** in `ptyManager` (the keystone) + two-PTY-per-task support.
+3. **Split main pane** (`LoopTerminalPane`) — visual proof with two terminals.
+4. **LoopScheduler** with `ralph` policy only (test/lint stop predicate) — end-to-end loop.
+5. **State spine** seeding (`LoopService`) + `PROMPT.md` re-read.
+6. **MCP bridge** — `status`/`state`/`steer`/`pause`/`kill`; wire manager terminal.
+7. **TaskModal** loop mode + **duplicate-as-loop**.
+8. Remaining policies (`goal`/`cadence`/`count`), L1/L2/L3 gating, budget auto-pause.
+
+MVP = steps 1–6 (Ralph end-to-end with both terminals and manager control). Steps 7–8
+round out the product.
+
+---
+
+## 12. Open questions
+
+- Worker visibility: run the worker interactive (visible, your two-PTY vision) while Dash
+  still drives the iteration boundary — confirmed approach; headless `-p` is a later
+  option for unattended L3.
+- Where state files live: in the worktree root (auditable in git) vs `.dash/loop/`
+  (out of the diff). Leaning worktree root for L1/L2 auditability.
+- Multi-loop coordination across tasks (loop-engineering's collision detection / branch
+  ownership) — deferred past MVP.

--- a/docs/agentic-loops-plan.md
+++ b/docs/agentic-loops-plan.md
@@ -1,8 +1,57 @@
 # Agentic Loops in Dash — Implementation Plan
 
-> Status: design / pre-implementation
+> Status: in progress — backend core + split-pane UI landed; runtime wiring remains
 > Branch: `claude/agentic-loops-dash-ka6xwn`
 > Owner: Dash team
+
+## Implementation status
+
+**Landed (type-checked; scheduler core unit-tested — 10 tests):**
+
+1. **Data foundation** — `taskKind` (`standard|loop`) + `loopConfig` JSON across shared
+   types, Drizzle schema, a guarded ALTER migration, and DatabaseService
+   (map/persist as INSERT-only deep config + `duplicateTask`).
+2. **State spine** — `LoopService` seeds/reads `<worktree>/.dash/loop/`
+   (PROMPT/LOOP/STATE/loop-constraints/loop-run-log); derived files refresh, evolving
+   files preserved.
+3. **Fresh-context spawn** — `ptyManager.startDirectPty` gained opt-in `freshContext`
+   (no `--resume`, the Ralph reset), a distinct `taskId` for `loop:`/`mgr:` composite
+   ids, and a direct `initialPrompt`. Threaded through the renderer spawn path
+   (TerminalPane → SessionRegistry → session manager → `pty:startDirect` IPC).
+4. **Scheduler core** — `LoopScheduler`, a dependency-injected state machine owning the
+   Ralph iteration `while` (per-policy stop check, maxIterations, cadence waits, token
+   budget auto-pause, pause/resume/stop). Only busy→idle edges advance it. +
+   `ActivityMonitor.subscribe()` for in-process idle signals.
+5. **Two-terminal split pane** — `LoopTerminalPane` renders worker|manager; MainContent
+   branches on `taskKind`; both spawn fresh-context so their sessions don't collide;
+   `projectsStore` disposes `loop:`/`mgr:` PTYs. Standard tasks untouched.
+
+**Remaining (needs a machine that can run the Electron app to verify):**
+
+6. **Scheduler↔PTY adapter (`LoopController`) + IPC** — construct `LoopDriver` from
+   ptyManager (`startDirectPty`/`killPtyAwait`/`writePty`) + `child_process` (stop
+   check) + `LoopService` (run log) + `webContents` (status); register the worker id
+   with `ActivityMonitor.subscribe`; expose `loop:start/pause/resume/stop/status`.
+   **Open: worker-spawn ownership.** Today `LoopTerminalPane` spawns the initial
+   worker on mount. Recommended resolution: the renderer spawns the _manager_ and the
+   _first_ worker iteration; the scheduler owns subsequent Ralph resets
+   (`killPtyAwait(loop:<taskId>)` → `startDirectPty(freshContext, initialPrompt =
+LoopService.workerIterationPrompt)`), and the renderer's loop terminals do **not**
+   auto-respawn on exit (a `managedExternally` flag on the session) so they don't race
+   the scheduler.
+7. **Loop MCP bridge** — task-scoped MCP server exposing
+   `loop_status/get_state/update_state/steer/pause/resume/kill/escalate/append_run_log`,
+   attached to the manager via its `.mcp.json`/env. Drives `LoopController`, not the
+   CLI's loop.
+8. **TaskModal loop mode + duplicate-as-loop** — "Loop" creation mode (goal/policy/
+   level/budget/constraints) writing `taskKind='loop'` + `loopConfig`; on create, run
+   the worktree path then `LoopService.seed`. Duplicate action → `duplicateTask` with
+   `taskKind:'loop'`. Until this lands, a loop task can be created by inserting a row
+   with `task_kind='loop'` for manual end-to-end testing.
+
+---
+
+> Original design follows.
 
 First-class support for **agentic loops**: a task can be started _as a loop_, or an
 existing task can be _duplicated as a loop_. A loop runs **two terminals side-by-side**
@@ -19,11 +68,11 @@ self-grading_.
 
 ## 1. Design decisions (locked)
 
-| Decision | Choice | Why |
-|---|---|---|
-| Cadence ownership | **Dash-driven scheduler** | Dash owns the iteration boundary → clean control points for budget gates, manager steer, pause/kill. |
-| Manager authority | **Observe + steer + pause/kill** | Full orchestrator role (loop-engineering's "manager"), gated by loop level. |
-| Loop mechanism | **Both policies, Ralph-primary** | Ralph (fresh-context reset) is the default and most important; `goal`/`cadence` are additional policies. |
+| Decision          | Choice                           | Why                                                                                                      |
+| ----------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Cadence ownership | **Dash-driven scheduler**        | Dash owns the iteration boundary → clean control points for budget gates, manager steer, pause/kill.     |
+| Manager authority | **Observe + steer + pause/kill** | Full orchestrator role (loop-engineering's "manager"), gated by loop level.                              |
+| Loop mechanism    | **Both policies, Ralph-primary** | Ralph (fresh-context reset) is the default and most important; `goal`/`cadence` are additional policies. |
 
 ### Why Dash owns the loop (not the CLI's `/loop` / `/ralph-loop`)
 
@@ -75,12 +124,12 @@ Two properties are non-negotiable and come straight from Ralph:
 `loopConfig.policy` selects the termination mode. The scheduler `while` is identical;
 only the **stop predicate** changes.
 
-| Policy | Mirrors | Stop predicate | Worker context | Use case |
-|---|---|---|---|---|
-| **`ralph`** (default) | classic Ralph | external signal (tests/lint) **or** manager verdict; optional max-iterations | **reset each pass** | "build/refactor this until correct" |
-| `goal` | CC `/goal` | a measurable condition checked each iteration | reset each pass | "all tests on main pass and lint is clean" |
-| `cadence` | CC `/loop` | timer — run every N; never self-terminates | reset each pass | triage / babysitter (PR watcher, CI sweeper) |
-| `count` | `/ralph-loop` | N iterations or completion-promise string | reset each pass | bounded mechanical sweeps |
+| Policy                | Mirrors       | Stop predicate                                                               | Worker context      | Use case                                     |
+| --------------------- | ------------- | ---------------------------------------------------------------------------- | ------------------- | -------------------------------------------- |
+| **`ralph`** (default) | classic Ralph | external signal (tests/lint) **or** manager verdict; optional max-iterations | **reset each pass** | "build/refactor this until correct"          |
+| `goal`                | CC `/goal`    | a measurable condition checked each iteration                                | reset each pass     | "all tests on main pass and lint is clean"   |
+| `cadence`             | CC `/loop`    | timer — run every N; never self-terminates                                   | reset each pass     | triage / babysitter (PR watcher, CI sweeper) |
+| `count`               | `/ralph-loop` | N iterations or completion-promise string                                    | reset each pass     | bounded mechanical sweeps                    |
 
 `ralph` and `goal` are nearly the same; `ralph` defaults the predicate to the project's
 test+lint command and adds a safety `maxIterations`. `cadence` is the loop-engineering
@@ -90,14 +139,14 @@ test+lint command and adds a safety `maxIterations`. `cadence` is the loop-engin
 
 ## 4. Two-terminal model & role split
 
-| | **Loop terminal (worker)** | **Manager terminal** |
-|---|---|---|
-| PTY id | `loop:{taskId}` | `mgr:{taskId}` |
-| Lifecycle | **ephemeral** — fresh spawn per iteration, killed between passes | **persistent** — one session, `--resume`, context accumulates |
-| Job | _acts_: edits code, runs tests, updates STATE.md, commits | _orchestrates_: triage, priorities, budget, escalation decisions |
-| Hard rule | — | **never edits code** (loop-engineering) |
-| cwd | task worktree | task worktree (read/triage role) |
-| MCP | minimal | **Dash Loop MCP attached** |
+|           | **Loop terminal (worker)**                                       | **Manager terminal**                                             |
+| --------- | ---------------------------------------------------------------- | ---------------------------------------------------------------- |
+| PTY id    | `loop:{taskId}`                                                  | `mgr:{taskId}`                                                   |
+| Lifecycle | **ephemeral** — fresh spawn per iteration, killed between passes | **persistent** — one session, `--resume`, context accumulates    |
+| Job       | _acts_: edits code, runs tests, updates STATE.md, commits        | _orchestrates_: triage, priorities, budget, escalation decisions |
+| Hard rule | —                                                                | **never edits code** (loop-engineering)                          |
+| cwd       | task worktree                                                    | task worktree (read/triage role)                                 |
+| MCP       | minimal                                                          | **Dash Loop MCP attached**                                       |
 
 This is both the Ralph insight (worker resets) **and** loop-engineering's role split
 (worker acts / manager orchestrates; implementer never grades its own homework — the
@@ -111,15 +160,15 @@ A small **Dash Loop MCP server**, task-scoped, attached to the manager (and opti
 the worker). Hung off the existing hook-server infrastructure (`DASH_HOOK_PORT`) or
 spawned per loop task. Surface:
 
-| Tool | Direction | Effect |
-|---|---|---|
-| `loop_status` | read | current iteration, last run, idle/busy, token spend vs budget |
-| `loop_get_state` / `loop_update_state` | read/write | structured `STATE.md` access |
-| `loop_steer(message)` | manager → worker | inject guidance into the next iteration's prompt |
-| `loop_pause` / `loop_resume` | manager → scheduler | halt/continue the `while` |
-| `loop_kill` | manager → scheduler | stop the loop (SIGTERM + grace via `ptyManager`) |
-| `loop_escalate(summary)` | worker → human | raise a human-gate item the manager surfaces |
-| `loop_append_run_log(entry)` | write | observability into `loop-run-log.md` |
+| Tool                                   | Direction           | Effect                                                        |
+| -------------------------------------- | ------------------- | ------------------------------------------------------------- |
+| `loop_status`                          | read                | current iteration, last run, idle/busy, token spend vs budget |
+| `loop_get_state` / `loop_update_state` | read/write          | structured `STATE.md` access                                  |
+| `loop_steer(message)`                  | manager → worker    | inject guidance into the next iteration's prompt              |
+| `loop_pause` / `loop_resume`           | manager → scheduler | halt/continue the `while`                                     |
+| `loop_kill`                            | manager → scheduler | stop the loop (SIGTERM + grace via `ptyManager`)              |
+| `loop_escalate(summary)`               | worker → human      | raise a human-gate item the manager surfaces                  |
+| `loop_append_run_log(entry)`           | write               | observability into `loop-run-log.md`                          |
 
 These drive **Dash's scheduler**, not the CLI's internal loop. Manager authority
 (`steer` / `pause` / `kill`) is gated by loop **level** (§7).
@@ -131,13 +180,13 @@ These drive **Dash's scheduler**, not the CLI's internal loop. Manager authority
 Seeded into the worktree (or `.dash/loop/`) on loop creation, from templates filled from
 `loopConfig`. This is what makes it a real loop, not two chat windows.
 
-| File | Role |
-|---|---|
-| `PROMPT.md` | the goal re-read fresh by the worker every iteration |
-| `LOOP.md` | loop definition: name, level (L1/L2/L3), policy, cadence, handoff rules |
-| `STATE.md` | live priorities / watchlist / recent-noise (worker + manager read/write) |
+| File                  | Role                                                                               |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| `PROMPT.md`           | the goal re-read fresh by the worker every iteration                               |
+| `LOOP.md`             | loop definition: name, level (L1/L2/L3), policy, cadence, handoff rules            |
+| `STATE.md`            | live priorities / watchlist / recent-noise (worker + manager read/write)           |
 | `loop-constraints.md` | hard rules injected before every iteration ("never edit auth/", "run tests first") |
-| `loop-run-log.md` | per-run: timestamp, items, actions, escalations, token estimate |
+| `loop-run-log.md`     | per-run: timestamp, items, actions, escalations, token estimate                    |
 
 ---
 
@@ -197,19 +246,19 @@ Run `pnpm drizzle:generate` for the migration.
 
 ## 10. File-by-file change list
 
-| Area | File(s) | Change |
-|---|---|---|
-| Schema + migration | `src/main/db/schema.ts` + `drizzle:generate` | `taskKind`, `loopConfig` |
-| Task save / duplicate | `src/main/services/DatabaseService.ts`, `src/main/ipc/dbIpc.ts` | persist loop fields; add `duplicateTask` |
-| **Fresh-context spawn** | `src/main/services/ptyManager.ts` (`buildClaudeArgs`, `startDirectPty` ≈359–517) | spawn mode that does **not** `--resume`; allow 2 agent PTYs per task (drop `id===taskId` assumptions) |
-| **Scheduler** | new `src/main/services/LoopScheduler.ts` | owns the `while`; idle-detect → stop predicate → re-spawn fresh worker / stop; budget auto-pause |
-| Stop predicate | new `src/main/services/loopPredicates.ts` | per-policy: test/lint exit code, timer, counter, completion-promise |
-| State seeding | new `src/main/services/LoopService.ts` | write PROMPT/LOOP/STATE/constraints/run-log from templates |
-| MCP bridge | new `src/main/services/loopMcpServer.ts` (+ hook-server wiring) | tool surface in §5 |
-| Split UI | new `src/renderer/components/terminal/LoopTerminalPane.tsx`; `src/renderer/components/MainContent.tsx` (≈300) | branch on `taskKind==='loop'` → horizontal `PanelGroup` of two `TerminalPane`s |
-| Disposal | `src/renderer/stores/projectsStore.ts` (`disposeTaskSessions`) | dispose `loop:` + `mgr:` ids |
-| Modal | `src/renderer/components/task/TaskModal.tsx` | loop mode (policy/level/budget/constraints) + duplicate-as-loop action |
-| Types | `src/shared/types.ts`, `src/types/electron-api.d.ts` | loop config + new IPC |
+| Area                    | File(s)                                                                                                       | Change                                                                                                |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Schema + migration      | `src/main/db/schema.ts` + `drizzle:generate`                                                                  | `taskKind`, `loopConfig`                                                                              |
+| Task save / duplicate   | `src/main/services/DatabaseService.ts`, `src/main/ipc/dbIpc.ts`                                               | persist loop fields; add `duplicateTask`                                                              |
+| **Fresh-context spawn** | `src/main/services/ptyManager.ts` (`buildClaudeArgs`, `startDirectPty` ≈359–517)                              | spawn mode that does **not** `--resume`; allow 2 agent PTYs per task (drop `id===taskId` assumptions) |
+| **Scheduler**           | new `src/main/services/LoopScheduler.ts`                                                                      | owns the `while`; idle-detect → stop predicate → re-spawn fresh worker / stop; budget auto-pause      |
+| Stop predicate          | new `src/main/services/loopPredicates.ts`                                                                     | per-policy: test/lint exit code, timer, counter, completion-promise                                   |
+| State seeding           | new `src/main/services/LoopService.ts`                                                                        | write PROMPT/LOOP/STATE/constraints/run-log from templates                                            |
+| MCP bridge              | new `src/main/services/loopMcpServer.ts` (+ hook-server wiring)                                               | tool surface in §5                                                                                    |
+| Split UI                | new `src/renderer/components/terminal/LoopTerminalPane.tsx`; `src/renderer/components/MainContent.tsx` (≈300) | branch on `taskKind==='loop'` → horizontal `PanelGroup` of two `TerminalPane`s                        |
+| Disposal                | `src/renderer/stores/projectsStore.ts` (`disposeTaskSessions`)                                                | dispose `loop:` + `mgr:` ids                                                                          |
+| Modal                   | `src/renderer/components/task/TaskModal.tsx`                                                                  | loop mode (policy/level/budget/constraints) + duplicate-as-loop action                                |
+| Types                   | `src/shared/types.ts`, `src/types/electron-api.d.ts`                                                          | loop config + new IPC                                                                                 |
 
 ---
 

--- a/src/main/db/migrate.ts
+++ b/src/main/db/migrate.ts
@@ -318,5 +318,18 @@ export function runMigrations(): void {
     /* already exists */
   }
 
+  // Agentic loops: a task can be a `loop` (Ralph worker + manager) carrying a
+  // JSON LoopConfig. Existing rows predate loops → default 'standard' / null.
+  try {
+    rawDb.exec(`ALTER TABLE tasks ADD COLUMN task_kind TEXT NOT NULL DEFAULT 'standard'`);
+  } catch {
+    /* already exists */
+  }
+  try {
+    rawDb.exec(`ALTER TABLE tasks ADD COLUMN loop_config TEXT`);
+  } catch {
+    /* already exists */
+  }
+
   rawDb.pragma('foreign_keys = ON');
 }

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -41,6 +41,11 @@ export const tasks = sqliteTable(
     branch: text('branch').notNull(),
     path: text('path').notNull(),
     status: text('status').notNull().default('idle'),
+    // 'standard' | 'loop' — see TaskKind in shared/types. Immutable after creation.
+    taskKind: text('task_kind').notNull().default('standard'),
+    // JSON-stringified LoopConfig; null for standard tasks. Like contextPrompt,
+    // this is an INSERT-only deep-config field (see DatabaseService.saveTask).
+    loopConfig: text('loop_config'),
     useWorktree: integer('use_worktree', { mode: 'boolean' }).default(true),
     // Deprecated since 0.10: replaced by permission_mode. Kept so existing DBs
     // don't break; do not read or write. New rows leave this at default (false).

--- a/src/main/ipc/ptyIpc.ts
+++ b/src/main/ipc/ptyIpc.ts
@@ -16,12 +16,13 @@ import {
   type PtyKind,
 } from '../services/ptyManager';
 import { DatabaseService } from '../services/DatabaseService';
+import { buildLoopSpawn } from '../services/loopSpawn';
 import { terminalSnapshotService } from '../services/TerminalSnapshotService';
 import { activityMonitor } from '../services/ActivityMonitor';
 import { contextUsageService } from '../services/ContextUsageService';
 import { remoteControlService } from '../services/remoteControlService';
 import { TelemetryService } from '../services/TelemetryService';
-import type { PermissionMode } from '@shared/types';
+import type { LoopRole, PermissionMode } from '@shared/types';
 
 export function registerPtyIpc(): void {
   ipcMain.handle(
@@ -38,6 +39,7 @@ export function registerPtyIpc(): void {
         taskId?: string;
         freshContext?: boolean;
         initialPrompt?: string;
+        loopRole?: LoopRole;
       },
     ) => {
       try {
@@ -53,6 +55,7 @@ export function registerPtyIpc(): void {
             taskId: z.string().optional(),
             freshContext: z.boolean().optional(),
             initialPrompt: z.string().optional(),
+            loopRole: z.enum(['worker', 'manager']).optional(),
           }),
           args,
         );
@@ -60,9 +63,17 @@ export function registerPtyIpc(): void {
         // composite ids (loop:/mgr:) and pass the real task id separately. Look
         // up the name so a fresh spawn gets `claude --name <task>`.
         const task = DatabaseService.getTask(args.taskId ?? args.id);
+        // For a loop agent, main owns the per-role spawn policy (model, the seed
+        // prompt, the worker's level-permission, and the manager's write-deny
+        // settings) — derived here so it can't be spoofed from the renderer.
+        const loopPolicy =
+          args.loopRole && task?.loopConfig
+            ? buildLoopSpawn(args.loopRole, task.loopConfig)
+            : undefined;
         const result = await startDirectPty({
           ...args,
           name: task?.name,
+          ...(loopPolicy ?? {}),
           sender: event.sender,
         });
         TelemetryService.capture('terminal_started', { source: 'direct' });

--- a/src/main/ipc/ptyIpc.ts
+++ b/src/main/ipc/ptyIpc.ts
@@ -35,6 +35,9 @@ export function registerPtyIpc(): void {
         rows: number;
         permissionMode?: PermissionMode;
         isDark?: boolean;
+        taskId?: string;
+        freshContext?: boolean;
+        initialPrompt?: string;
       },
     ) => {
       try {
@@ -47,12 +50,16 @@ export function registerPtyIpc(): void {
             rows: z.number(),
             permissionMode: permissionModeSchema.optional(),
             isDark: z.boolean().optional(),
+            taskId: z.string().optional(),
+            freshContext: z.boolean().optional(),
+            initialPrompt: z.string().optional(),
           }),
           args,
         );
-        // The agent PTY id is the bare task id — look up its name so a fresh
-        // spawn gets `claude --name <task>` (recognizable in /resume + title).
-        const task = DatabaseService.getTask(args.id);
+        // The agent PTY id is the bare task id for standard tasks; loop PTYs use
+        // composite ids (loop:/mgr:) and pass the real task id separately. Look
+        // up the name so a fresh spawn gets `claude --name <task>`.
+        const task = DatabaseService.getTask(args.taskId ?? args.id);
         const result = await startDirectPty({
           ...args,
           name: task?.name,

--- a/src/main/services/ActivityMonitor.ts
+++ b/src/main/services/ActivityMonitor.ts
@@ -73,6 +73,17 @@ class ActivityMonitorImpl {
   private activities = new Map<string, PtyActivity>();
   private sender: WebContents | null = null;
   private safetyValveTimer: ReturnType<typeof setInterval> | null = null;
+  private listeners = new Set<(all: Record<string, ActivityInfo>) => void>();
+
+  /**
+   * Observe activity-state changes in-process (the LoopScheduler watches its
+   * worker PTY for busy→idle transitions). Fires after every emit with the full
+   * map, mirroring what the renderer receives. Returns an unsubscribe fn.
+   */
+  subscribe(cb: (all: Record<string, ActivityInfo>) => void): () => void {
+    this.listeners.add(cb);
+    return () => this.listeners.delete(cb);
+  }
 
   register(ptyId: string, pid: number): void {
     const now = Date.now();
@@ -227,8 +238,18 @@ class ActivityMonitorImpl {
   }
 
   private emitAll(): void {
+    const all = this.getAll();
     if (this.sender && !this.sender.isDestroyed()) {
-      this.sender.send('pty:activity', this.getAll());
+      this.sender.send('pty:activity', all);
+    }
+    if (this.listeners.size > 0) {
+      for (const cb of this.listeners) {
+        try {
+          cb(all);
+        } catch (err) {
+          console.error('[ActivityMonitor] listener threw', err);
+        }
+      }
     }
   }
 }

--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -8,9 +8,11 @@ import type {
   Task,
   Conversation,
   LinkedItem,
+  LoopConfig,
   TokenStatsRollup,
   PermissionMode,
   TaskStatus,
+  TaskKind,
   TaskPort,
   PortSource,
 } from '@shared/types';
@@ -21,6 +23,19 @@ function normalizePermissionMode(value: string | null | undefined): PermissionMo
 
 function normalizeTaskStatus(value: string | null | undefined): TaskStatus {
   return value === 'active' ? 'active' : 'idle';
+}
+
+function normalizeTaskKind(value: string | null | undefined): TaskKind {
+  return value === 'loop' ? 'loop' : 'standard';
+}
+
+function parseLoopConfig(value: string | null | undefined): LoopConfig | null {
+  if (!value) return null;
+  try {
+    return JSON.parse(value) as LoopConfig;
+  } catch {
+    return null; // Corrupted JSON — treat as a standard task at the data layer.
+  }
 }
 
 export class DatabaseService {
@@ -163,6 +178,7 @@ export class DatabaseService {
     }
 
     const linkedItemsJson = data.linkedItems ? JSON.stringify(data.linkedItems) : null;
+    const loopConfigJson = data.loopConfig ? JSON.stringify(data.loopConfig) : null;
 
     // Wrap read-min + insert in a transaction so concurrent creates don't race on sortOrder
     db.transaction((tx) => {
@@ -185,6 +201,8 @@ export class DatabaseService {
           branch: data.branch,
           path: data.path,
           status: data.status ?? 'idle',
+          taskKind: data.taskKind ?? 'standard',
+          loopConfig: loopConfigJson,
           useWorktree: data.useWorktree ?? true,
           permissionMode: data.permissionMode ?? 'default',
           branchCreatedByDash: data.branchCreatedByDash ?? false,
@@ -227,6 +245,38 @@ export class DatabaseService {
     const db = getDb();
     const row = db.select().from(tasks).where(eq(tasks.id, id)).get();
     return row ? this.mapTask(row) : undefined;
+  }
+
+  /**
+   * Clone an existing task's config into a NEW row. The caller supplies the
+   * already-provisioned identity (fresh worktree path + branch) and may override
+   * the kind/config — e.g. "duplicate as loop" passes taskKind:'loop' + loopConfig.
+   * Deep-config fields (contextPrompt, scripts) are carried over; runtime fields
+   * (tokens, archivedAt, sortOrder) reset to defaults via saveTask.
+   */
+  static duplicateTask(
+    sourceId: string,
+    identity: { name: string; branch: string; path: string },
+    overrides?: Partial<Task>,
+  ): Task {
+    const source = this.getTask(sourceId);
+    if (!source) throw new Error(`Cannot duplicate: task "${sourceId}" not found`);
+
+    return this.saveTask({
+      projectId: source.projectId,
+      name: identity.name,
+      branch: identity.branch,
+      path: identity.path,
+      useWorktree: source.useWorktree,
+      permissionMode: source.permissionMode,
+      linkedItems: source.linkedItems,
+      contextPrompt: source.contextPrompt,
+      setupScript: source.setupScript,
+      teardownScript: source.teardownScript,
+      taskKind: source.taskKind,
+      loopConfig: source.loopConfig,
+      ...overrides,
+    });
   }
 
   static setTaskContextPrompt(id: string, prompt: string): void {
@@ -520,6 +570,8 @@ export class DatabaseService {
       branch: row.branch,
       path: row.path,
       status: normalizeTaskStatus(row.status),
+      taskKind: normalizeTaskKind(row.taskKind),
+      loopConfig: parseLoopConfig(row.loopConfig),
       useWorktree: row.useWorktree ?? true,
       permissionMode: normalizePermissionMode(row.permissionMode),
       branchCreatedByDash: row.branchCreatedByDash ?? false,

--- a/src/main/services/LoopScheduler.ts
+++ b/src/main/services/LoopScheduler.ts
@@ -162,12 +162,21 @@ export class LoopScheduler {
         this.finish('stopped', `reached max iterations (${max})`);
         return;
       }
+      // A pause()/stop() that raced the (awaited) stop check must not be
+      // overridden by spawning the next iteration. Re-check after the await.
+      if (this.state !== 'running') return;
       // Continue. Cadence policy waits between runs; the rest reset immediately.
-      if (this.config.policy === 'cadence' && this.config.cadenceMs) {
-        this.cancelTimer = this.driver.setTimer(this.config.cadenceMs, () => {
-          this.cancelTimer = null;
-          if (this.state === 'running') void this.nextIteration();
-        });
+      if (this.config.policy === 'cadence') {
+        if (this.config.cadenceMs && this.config.cadenceMs > 0) {
+          this.cancelTimer = this.driver.setTimer(this.config.cadenceMs, () => {
+            this.cancelTimer = null;
+            if (this.state === 'running') void this.nextIteration();
+          });
+        } else {
+          // Misconfigured cadence loop: pause rather than busy-spawn workers
+          // with no delay (a runaway). A human can set an interval and resume.
+          this.pause('cadence loop has no interval configured');
+        }
       } else {
         await this.nextIteration();
       }

--- a/src/main/services/LoopScheduler.ts
+++ b/src/main/services/LoopScheduler.ts
@@ -1,0 +1,216 @@
+import type { ActivityState, LoopConfig, LoopRunState, LoopStatus } from '@shared/types';
+
+/**
+ * Side-effecting operations the scheduler drives. Injected so the iteration /
+ * policy state machine below is unit-testable without Electron, PTYs, or a real
+ * shell (see LoopScheduler.test.ts). The Electron adapter wires these to
+ * ptyManager + child_process + LoopService.
+ */
+export interface LoopDriver {
+  /** Spawn a FRESH worker (Ralph reset) for `iteration`, auto-running `prompt`. */
+  spawnWorker(iteration: number, prompt: string): Promise<void>;
+  /** Kill the current worker PTY so the next iteration starts cold. */
+  killWorker(): Promise<void>;
+  /** Run the stop-predicate command; resolves true when it exits 0 ("done"). */
+  runShellCheck(command: string): Promise<boolean>;
+  /** Whether the most recent worker iteration's output contained `needle`. */
+  workerOutputContains(needle: string): boolean;
+  emitStatus(status: LoopStatus): void;
+  appendRunLog(entry: string): Promise<void>;
+  now(): number;
+  /** Schedule `cb` after `ms`; returns a cancel fn. (cadence waits.) */
+  setTimer(ms: number, cb: () => void): () => void;
+}
+
+/**
+ * Owns the loop's iteration `while`. Dash drives the boundary between Ralph
+ * iterations — that is where budget gates, the stop check, and pause/kill live.
+ *
+ * Lifecycle: `start()` runs iteration 1. Each iteration the worker goes
+ * busy→idle; on idle the scheduler runs the policy's stop check and either
+ * finishes or resets into a fresh next iteration. `pause`/`resume`/`stop` and
+ * `noteTokens` (budget auto-pause) are the manager/human control points.
+ */
+export class LoopScheduler {
+  private state: LoopRunState = 'idle';
+  private iteration = 0;
+  private sawBusyThisIteration = false;
+  private tokensSpent = 0;
+  private cancelTimer: (() => void) | null = null;
+  private reason: string | undefined;
+  /** Guards against re-entrant iteration completion while a check is in flight. */
+  private evaluating = false;
+
+  constructor(
+    readonly taskId: string,
+    private readonly config: LoopConfig,
+    /** The per-iteration worker prompt (LoopService.workerIterationPrompt). */
+    private readonly workerPrompt: string,
+    private readonly driver: LoopDriver,
+  ) {}
+
+  getStatus(): LoopStatus {
+    return {
+      taskId: this.taskId,
+      state: this.state,
+      iteration: this.iteration,
+      maxIterations: this.config.maxIterations ?? null,
+      reason: this.reason,
+      tokensSpent: this.tokensSpent,
+      tokenBudget: this.config.tokenBudget ?? null,
+      updatedAt: this.driver.now(),
+    };
+  }
+
+  isActive(): boolean {
+    return this.state === 'running' || this.state === 'paused';
+  }
+
+  async start(): Promise<void> {
+    if (this.isActive()) return;
+    this.state = 'running';
+    this.iteration = 1;
+    this.reason = undefined;
+    await this.beginIteration();
+  }
+
+  /** Called by the adapter on every worker activity transition. */
+  notifyWorkerState(state: ActivityState): void {
+    if (this.state !== 'running') return;
+    if (state === 'busy') {
+      this.sawBusyThisIteration = true;
+      return;
+    }
+    // Only a busy→idle edge means "iteration finished" — the idle emitted at
+    // PTY registration (before any work) must not advance the loop.
+    if (state === 'idle' && this.sawBusyThisIteration) {
+      void this.onIterationComplete();
+    }
+  }
+
+  pause(reason = 'paused'): void {
+    if (this.state !== 'running') return;
+    this.cancelPendingTimer();
+    this.state = 'paused';
+    this.reason = reason;
+    this.driver.emitStatus(this.getStatus());
+  }
+
+  async resume(): Promise<void> {
+    if (this.state !== 'paused') return;
+    this.state = 'running';
+    this.reason = undefined;
+    this.driver.emitStatus(this.getStatus());
+    // The worker is idle (we paused after an iteration) — kick the next one.
+    await this.nextIteration();
+  }
+
+  async stop(reason = 'stopped by user'): Promise<void> {
+    if (this.state === 'stopped' || this.state === 'done') return;
+    this.cancelPendingTimer();
+    this.state = 'stopped';
+    this.reason = reason;
+    await this.driver.killWorker();
+    await this.driver.appendRunLog(this.logLine(`stopped — ${reason}`));
+    this.driver.emitStatus(this.getStatus());
+  }
+
+  /** Report cumulative token spend; auto-pause when the budget is exceeded. */
+  noteTokens(totalTokens: number): void {
+    this.tokensSpent = totalTokens;
+    const budget = this.config.tokenBudget;
+    if (budget != null && this.tokensSpent >= budget && this.state === 'running') {
+      void this.driver.appendRunLog(
+        this.logLine(`budget exceeded (${this.tokensSpent}/${budget} tokens) — auto-paused`),
+      );
+      this.pause('token budget exceeded — human review needed');
+      return;
+    }
+    this.driver.emitStatus(this.getStatus());
+  }
+
+  // ── internals ─────────────────────────────────────────────
+
+  private async beginIteration(): Promise<void> {
+    this.sawBusyThisIteration = false;
+    this.driver.emitStatus(this.getStatus());
+    await this.driver.spawnWorker(this.iteration, this.workerPrompt);
+  }
+
+  private async nextIteration(): Promise<void> {
+    this.iteration += 1;
+    await this.driver.killWorker(); // Ralph reset: fresh context next pass.
+    await this.beginIteration();
+  }
+
+  private async onIterationComplete(): Promise<void> {
+    if (this.evaluating || this.state !== 'running') return;
+    this.evaluating = true;
+    try {
+      const done = await this.isGoalSatisfied();
+      await this.driver.appendRunLog(
+        this.logLine(
+          `iteration ${this.iteration} complete — ${done ? 'stop check PASSED' : 'continue'}`,
+        ),
+      );
+      if (done) {
+        this.finish('done', 'stop check passed');
+        return;
+      }
+      const max = this.config.maxIterations;
+      if (max != null && this.iteration >= max) {
+        this.finish('stopped', `reached max iterations (${max})`);
+        return;
+      }
+      // Continue. Cadence policy waits between runs; the rest reset immediately.
+      if (this.config.policy === 'cadence' && this.config.cadenceMs) {
+        this.cancelTimer = this.driver.setTimer(this.config.cadenceMs, () => {
+          this.cancelTimer = null;
+          if (this.state === 'running') void this.nextIteration();
+        });
+      } else {
+        await this.nextIteration();
+      }
+    } finally {
+      this.evaluating = false;
+    }
+  }
+
+  /** Policy-specific stop predicate. The ONLY place a loop decides it's done. */
+  private async isGoalSatisfied(): Promise<boolean> {
+    switch (this.config.policy) {
+      case 'cadence':
+        // A cadence loop (triage/babysitter) never self-terminates.
+        return false;
+      case 'count':
+        return this.config.completionPromise
+          ? this.driver.workerOutputContains(this.config.completionPromise)
+          : false;
+      case 'ralph':
+      case 'goal':
+        // External verification, never self-grading. No check ⇒ run to max.
+        return this.config.stopPredicate
+          ? await this.driver.runShellCheck(this.config.stopPredicate)
+          : false;
+    }
+  }
+
+  private finish(state: 'done' | 'stopped', reason: string): void {
+    this.state = state;
+    this.reason = reason;
+    void this.driver.appendRunLog(this.logLine(`finished (${state}) — ${reason}`));
+    this.driver.emitStatus(this.getStatus());
+    // Leave the worker terminal alive so the user can read the final state.
+  }
+
+  private cancelPendingTimer(): void {
+    if (this.cancelTimer) {
+      this.cancelTimer();
+      this.cancelTimer = null;
+    }
+  }
+
+  private logLine(msg: string): string {
+    return `${new Date(this.driver.now()).toISOString()} · iter ${this.iteration} · ${msg}`;
+  }
+}

--- a/src/main/services/LoopService.ts
+++ b/src/main/services/LoopService.ts
@@ -30,6 +30,9 @@ export class LoopService {
     state: 'STATE.md',
     constraints: 'loop-constraints.md',
     runLog: 'loop-run-log.md',
+    // The manager's steering channel: it writes guidance here (it can't touch a
+    // worker that resets context each pass), and the next fresh worker reads it.
+    managerNotes: 'manager-notes.md',
   } as const;
 
   /** Absolute path to the loop's state directory inside a worktree. */
@@ -77,6 +80,10 @@ export class LoopService {
     const runLogPath = LoopService.file(worktreePath, LoopService.FILES.runLog);
     if (!(await LoopService.exists(runLogPath))) {
       await fs.writeFile(runLogPath, runLogMd(taskName));
+    }
+    const notesPath = LoopService.file(worktreePath, LoopService.FILES.managerNotes);
+    if (!(await LoopService.exists(notesPath))) {
+      await fs.writeFile(notesPath, managerNotesMd(taskName));
     }
   }
 
@@ -127,7 +134,8 @@ export class LoopService {
       config.goal.trim(),
       ``,
       `Before doing anything, read ${rel(LoopService.FILES.constraints)} and obey every rule in it.`,
-      `Then read ${rel(LoopService.FILES.state)} for current priorities and what past iterations already did.`,
+      `Then read ${rel(LoopService.FILES.state)} for current priorities and what past iterations already did,`,
+      `and ${rel(LoopService.FILES.managerNotes)} for any steering the manager left for this pass.`,
       ``,
       `Do ONE focused unit of work this iteration (one task / one fix). Keep the`,
       `change small and committable. Run the project's tests/lint before finishing.`,
@@ -138,6 +146,31 @@ export class LoopService {
       `${rel(LoopService.FILES.state)} under "Needs human" and stop.`,
     ];
     return lines.join('\n');
+  }
+
+  /**
+   * The manager's role prompt. The manager is a persistent OVERSEER: it reads
+   * and investigates freely (grep/read/inspect/git) but never writes code — that
+   * guarantee is enforced by a write-deny settings policy, not this prose. It
+   * steers by writing to manager-notes.md, which the next fresh worker reads.
+   */
+  static managerPrompt(config: LoopConfig): string {
+    if (config.managerPrompt?.trim()) return config.managerPrompt.trim();
+    const rel = (name: string) => path.posix.join('.dash', 'loop', name);
+    return [
+      `You are the LOOP MANAGER — a persistent overseer of a Ralph worker.`,
+      `Read ${rel(LoopService.FILES.loop)} (the loop definition) and ${rel(LoopService.FILES.state)}.`,
+      ``,
+      `Your job is judgment, not typing: assess whether the worker is on track, keep`,
+      `priorities current in ${rel(LoopService.FILES.state)}, and decide what needs a human.`,
+      `Investigate freely with read-only tools (read, grep, git log/diff) — but you`,
+      `NEVER edit code or commit; the worker is the only writer.`,
+      ``,
+      `To steer the worker, append guidance to ${rel(LoopService.FILES.managerNotes)} — the next`,
+      `iteration reads it. For urgent control, use the loop MCP tools (pause / resume /`,
+      `kill / escalate). Surface anything risky or ambiguous to the human rather than`,
+      `pushing the worker through it.`,
+    ].join('\n');
   }
 }
 
@@ -240,5 +273,13 @@ function runLogMd(taskName: string): string {
   return `# Loop run log — ${taskName}
 
 _Append-only. One line per iteration: timestamp · iteration · outcome · notes._
+`;
+}
+
+function managerNotesMd(taskName: string): string {
+  return `# Manager notes — ${taskName}
+
+_The manager appends steering guidance here; the next fresh worker iteration
+reads it. Keep entries short and actionable (the worker has limited context)._
 `;
 }

--- a/src/main/services/LoopService.ts
+++ b/src/main/services/LoopService.ts
@@ -1,0 +1,244 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { LoopConfig } from '@shared/types';
+
+/**
+ * The durable state spine for an agentic loop (see docs/agentic-loops-plan.md).
+ *
+ * Loop-engineering's load-bearing idea is that a loop's memory lives in files
+ * OUTSIDE the conversation, so each fresh Ralph iteration starts from the same
+ * known state instead of cold. This service seeds and reads those files.
+ *
+ * Files live under `<worktree>/.dash/loop/` (kept out of the user's code diff,
+ * consistent with Dash's other `.dash/` bookkeeping):
+ *   - PROMPT.md          the goal, re-read fresh by the worker every iteration
+ *   - LOOP.md            the loop definition (policy/level/cadence/handoff)
+ *   - STATE.md           live priorities / watchlist / recent-noise (evolving)
+ *   - loop-constraints.md  hard rules injected before every iteration
+ *   - loop-run-log.md    append-only observability
+ *
+ * Derived files (PROMPT/LOOP/constraints) are rewritten from config on every
+ * seed; evolving files (STATE/run-log) are created only when absent so a re-seed
+ * never wipes accumulated memory.
+ */
+export class LoopService {
+  static readonly DIR = path.join('.dash', 'loop');
+
+  static readonly FILES = {
+    prompt: 'PROMPT.md',
+    loop: 'LOOP.md',
+    state: 'STATE.md',
+    constraints: 'loop-constraints.md',
+    runLog: 'loop-run-log.md',
+  } as const;
+
+  /** Absolute path to the loop's state directory inside a worktree. */
+  static dir(worktreePath: string): string {
+    return path.join(worktreePath, LoopService.DIR);
+  }
+
+  private static file(worktreePath: string, name: string): string {
+    return path.join(LoopService.dir(worktreePath), name);
+  }
+
+  private static async exists(p: string): Promise<boolean> {
+    try {
+      await fs.access(p);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Seed (or refresh) the state spine for a loop task. Idempotent: derived files
+   * are rewritten, evolving files are preserved if they already exist.
+   */
+  static async seed(worktreePath: string, taskName: string, config: LoopConfig): Promise<void> {
+    const dir = LoopService.dir(worktreePath);
+    await fs.mkdir(dir, { recursive: true });
+
+    // Derived from config — always rewritten so edits to the loop definition take effect.
+    await fs.writeFile(LoopService.file(worktreePath, LoopService.FILES.prompt), promptMd(config));
+    await fs.writeFile(
+      LoopService.file(worktreePath, LoopService.FILES.loop),
+      loopMd(taskName, config),
+    );
+    await fs.writeFile(
+      LoopService.file(worktreePath, LoopService.FILES.constraints),
+      constraintsMd(config),
+    );
+
+    // Evolving — only create when missing so re-seed never clobbers memory.
+    const statePath = LoopService.file(worktreePath, LoopService.FILES.state);
+    if (!(await LoopService.exists(statePath))) {
+      await fs.writeFile(statePath, stateMd(taskName));
+    }
+    const runLogPath = LoopService.file(worktreePath, LoopService.FILES.runLog);
+    if (!(await LoopService.exists(runLogPath))) {
+      await fs.writeFile(runLogPath, runLogMd(taskName));
+    }
+  }
+
+  static async readState(worktreePath: string): Promise<string> {
+    try {
+      return await fs.readFile(LoopService.file(worktreePath, LoopService.FILES.state), 'utf8');
+    } catch {
+      return '';
+    }
+  }
+
+  static async writeState(worktreePath: string, content: string): Promise<void> {
+    await fs.mkdir(LoopService.dir(worktreePath), { recursive: true });
+    await fs.writeFile(LoopService.file(worktreePath, LoopService.FILES.state), content);
+  }
+
+  static async readPrompt(worktreePath: string): Promise<string> {
+    try {
+      return await fs.readFile(LoopService.file(worktreePath, LoopService.FILES.prompt), 'utf8');
+    } catch {
+      return '';
+    }
+  }
+
+  /** Append one run-log entry. Best-effort; never throws into the scheduler. */
+  static async appendRunLog(worktreePath: string, entry: string): Promise<void> {
+    try {
+      await fs.mkdir(LoopService.dir(worktreePath), { recursive: true });
+      await fs.appendFile(
+        LoopService.file(worktreePath, LoopService.FILES.runLog),
+        entry.endsWith('\n') ? entry : entry + '\n',
+      );
+    } catch (err) {
+      console.error('[LoopService.appendRunLog] failed', err);
+    }
+  }
+
+  /**
+   * The exact prompt handed to a fresh worker iteration. It deliberately points
+   * the worker at the on-disk spine (Ralph: re-read state every pass) and forbids
+   * self-grading — completion is an external signal, judged by the scheduler.
+   */
+  static workerIterationPrompt(config: LoopConfig): string {
+    const rel = (name: string) => path.posix.join('.dash', 'loop', name);
+    const lines = [
+      `You are the LOOP WORKER for an agentic loop. Goal:`,
+      ``,
+      config.goal.trim(),
+      ``,
+      `Before doing anything, read ${rel(LoopService.FILES.constraints)} and obey every rule in it.`,
+      `Then read ${rel(LoopService.FILES.state)} for current priorities and what past iterations already did.`,
+      ``,
+      `Do ONE focused unit of work this iteration (one task / one fix). Keep the`,
+      `change small and committable. Run the project's tests/lint before finishing.`,
+      `Update ${rel(LoopService.FILES.state)} with what you did and what remains, then commit.`,
+      ``,
+      `Do NOT declare the overall goal "done" yourself — an external check decides`,
+      `that. If you are blocked or the next step is ambiguous, write the blocker into`,
+      `${rel(LoopService.FILES.state)} under "Needs human" and stop.`,
+    ];
+    return lines.join('\n');
+  }
+}
+
+// ── Templates ────────────────────────────────────────────────
+// These encode loop-engineering best practice (2026): role separation, external
+// verification over self-grading, durable state, constraints injected each cycle,
+// budgets + human gates, one-task-per-iteration.
+
+function policyLine(config: LoopConfig): string {
+  switch (config.policy) {
+    case 'ralph':
+      return `ralph — re-run the goal with fresh context each pass until the stop check passes${
+        config.maxIterations ? ` (max ${config.maxIterations} iterations)` : ''
+      }`;
+    case 'goal':
+      return `goal — iterate until the stop check exits 0`;
+    case 'cadence':
+      return `cadence — run every ${config.cadenceMs ?? 0}ms indefinitely`;
+    case 'count':
+      return `count — run ${config.maxIterations ?? '∞'} iterations${
+        config.completionPromise ? ` or until "${config.completionPromise}" appears` : ''
+      }`;
+  }
+}
+
+function promptMd(config: LoopConfig): string {
+  return `# Loop goal
+
+${config.goal.trim()}
+
+---
+_Re-read fresh every iteration. The worker does ONE unit of work per pass, updates
+STATE.md, and commits. Completion is judged by an external check, never self-graded._
+`;
+}
+
+function loopMd(taskName: string, config: LoopConfig): string {
+  return `# LOOP — ${taskName}
+
+| Field | Value |
+| --- | --- |
+| Policy | ${policyLine(config)} |
+| Level | ${config.level} |
+| Stop check | ${config.stopPredicate ? '`' + config.stopPredicate + '`' : '— (no auto-stop)'} |
+| Token budget | ${config.tokenBudget ?? '—'} |
+
+## Roles
+- **Worker** (left terminal): acts. Fresh context each iteration, reads PROMPT.md +
+  STATE.md, does one unit of work, runs the stop check, updates STATE.md, commits.
+- **Manager** (right terminal): orchestrates. Persistent context. Reads STATE.md and
+  the run log, sets priorities, and may steer / pause / kill the worker via MCP.
+  **Never edits code** — the worker is the only writer.
+
+## Handoff to human
+Escalate (write under "Needs human" in STATE.md and stop) when a decision is
+ambiguous or high-risk, or when the token budget is exceeded.
+
+_Managed by Dash. See docs/agentic-loops-plan.md._
+`;
+}
+
+function stateMd(taskName: string): string {
+  return `# STATE — ${taskName}
+
+_Durable loop memory. Worker and manager both read/write this. Keep it current._
+
+## High priority
+- (none yet)
+
+## Watch list
+- (none yet)
+
+## Recent (done)
+- (none yet)
+
+## Needs human
+- (none)
+`;
+}
+
+function constraintsMd(config: LoopConfig): string {
+  const rules = config.constraints?.length
+    ? config.constraints
+    : [
+        'Make one small, committable change per iteration.',
+        'Run the project tests/lint before finishing an iteration.',
+        'Never force-push or rewrite published history.',
+        'If a step is ambiguous or destructive, stop and escalate to the human.',
+      ];
+  return `# Loop constraints
+
+_Injected before every iteration. The worker must obey every rule here BEFORE
+acting. Add rules the loop must never break._
+
+${rules.map((r) => `- ${r}`).join('\n')}
+`;
+}
+
+function runLogMd(taskName: string): string {
+  return `# Loop run log — ${taskName}
+
+_Append-only. One line per iteration: timestamp · iteration · outcome · notes._
+`;
+}

--- a/src/main/services/__tests__/LoopScheduler.test.ts
+++ b/src/main/services/__tests__/LoopScheduler.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LoopScheduler, type LoopDriver } from '../LoopScheduler';
+import type { LoopConfig, LoopStatus } from '@shared/types';
+
+/** Flush the microtask queue a few times so chained awaits in the scheduler settle. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+class FakeDriver implements LoopDriver {
+  spawns: number[] = [];
+  kills = 0;
+  log: string[] = [];
+  statuses: LoopStatus[] = [];
+  checkResult = false;
+  outputNeedle: string | null = null;
+  pendingTimer: { ms: number; cb: () => void } | null = null;
+  private clock = 1_700_000_000_000;
+
+  async spawnWorker(iteration: number): Promise<void> {
+    this.spawns.push(iteration);
+  }
+  async killWorker(): Promise<void> {
+    this.kills++;
+  }
+  async runShellCheck(): Promise<boolean> {
+    return this.checkResult;
+  }
+  workerOutputContains(needle: string): boolean {
+    return this.outputNeedle === needle;
+  }
+  emitStatus(status: LoopStatus): void {
+    this.statuses.push(status);
+  }
+  async appendRunLog(entry: string): Promise<void> {
+    this.log.push(entry);
+  }
+  now(): number {
+    return this.clock;
+  }
+  setTimer(ms: number, cb: () => void): () => void {
+    this.pendingTimer = { ms, cb };
+    return () => {
+      this.pendingTimer = null;
+    };
+  }
+}
+
+function makeConfig(over: Partial<LoopConfig>): LoopConfig {
+  return { policy: 'ralph', goal: 'do the thing', level: 'L2', ...over };
+}
+
+/** Drive one worker iteration to completion: busy then idle. */
+async function completeIteration(s: LoopScheduler): Promise<void> {
+  s.notifyWorkerState('busy');
+  s.notifyWorkerState('idle');
+  await flush();
+}
+
+describe('LoopScheduler', () => {
+  let driver: FakeDriver;
+  beforeEach(() => {
+    driver = new FakeDriver();
+  });
+
+  it('runs iteration 1 on start', async () => {
+    const s = new LoopScheduler('t1', makeConfig({}), 'PROMPT', driver);
+    await s.start();
+    expect(driver.spawns).toEqual([1]);
+    expect(s.getStatus().state).toBe('running');
+  });
+
+  it('ignores the registration idle before any work (no advance)', async () => {
+    const s = new LoopScheduler('t1', makeConfig({ stopPredicate: 'true' }), 'P', driver);
+    await s.start();
+    s.notifyWorkerState('idle'); // never went busy
+    await flush();
+    expect(driver.spawns).toEqual([1]); // still iteration 1
+  });
+
+  it('ralph: continues to a fresh iteration when the stop check fails', async () => {
+    const s = new LoopScheduler('t1', makeConfig({ stopPredicate: 'pnpm test' }), 'P', driver);
+    driver.checkResult = false;
+    await s.start();
+    await completeIteration(s);
+    expect(driver.kills).toBe(1); // Ralph reset
+    expect(driver.spawns).toEqual([1, 2]); // fresh iteration 2
+    expect(s.getStatus().state).toBe('running');
+  });
+
+  it('ralph: finishes "done" when the stop check passes', async () => {
+    const s = new LoopScheduler('t1', makeConfig({ stopPredicate: 'pnpm test' }), 'P', driver);
+    driver.checkResult = true;
+    await s.start();
+    await completeIteration(s);
+    expect(s.getStatus().state).toBe('done');
+    expect(driver.spawns).toEqual([1]); // no respawn after done
+  });
+
+  it('stops at maxIterations', async () => {
+    const s = new LoopScheduler(
+      't1',
+      makeConfig({ stopPredicate: 'x', maxIterations: 2 }),
+      'P',
+      driver,
+    );
+    driver.checkResult = false;
+    await s.start();
+    await completeIteration(s); // iter 1 -> 2
+    await completeIteration(s); // iter 2 -> hits max
+    expect(s.getStatus().state).toBe('stopped');
+    expect(s.getStatus().reason).toContain('max iterations');
+    expect(driver.spawns).toEqual([1, 2]);
+  });
+
+  it('count: finishes when the completion promise appears in output', async () => {
+    const s = new LoopScheduler(
+      't1',
+      makeConfig({ policy: 'count', completionPromise: 'ALL DONE', maxIterations: 10 }),
+      'P',
+      driver,
+    );
+    driver.outputNeedle = 'ALL DONE';
+    await s.start();
+    await completeIteration(s);
+    expect(s.getStatus().state).toBe('done');
+  });
+
+  it('cadence: never self-terminates and waits cadenceMs between runs', async () => {
+    const s = new LoopScheduler(
+      't1',
+      makeConfig({ policy: 'cadence', cadenceMs: 60_000 }),
+      'P',
+      driver,
+    );
+    await s.start();
+    await completeIteration(s);
+    // Did not respawn immediately — a timer is pending.
+    expect(driver.spawns).toEqual([1]);
+    expect(driver.pendingTimer?.ms).toBe(60_000);
+    driver.pendingTimer!.cb(); // fire the cadence timer
+    await flush();
+    expect(driver.spawns).toEqual([1, 2]);
+  });
+
+  it('auto-pauses when the token budget is exceeded', async () => {
+    const s = new LoopScheduler('t1', makeConfig({ tokenBudget: 1000 }), 'P', driver);
+    await s.start();
+    s.noteTokens(1200);
+    expect(s.getStatus().state).toBe('paused');
+    expect(s.getStatus().reason).toContain('budget');
+  });
+
+  it('pause halts advancement; resume kicks the next iteration', async () => {
+    const s = new LoopScheduler('t1', makeConfig({ stopPredicate: 'x' }), 'P', driver);
+    driver.checkResult = false;
+    await s.start();
+    s.pause();
+    await completeIteration(s); // idle while paused must NOT advance
+    expect(driver.spawns).toEqual([1]);
+    await s.resume();
+    expect(driver.spawns).toEqual([1, 2]);
+  });
+
+  it('stop kills the worker and is terminal', async () => {
+    const s = new LoopScheduler('t1', makeConfig({}), 'P', driver);
+    await s.start();
+    await s.stop('user');
+    expect(driver.kills).toBe(1);
+    expect(s.getStatus().state).toBe('stopped');
+    await completeIteration(s); // no effect after stop
+    expect(driver.spawns).toEqual([1]);
+  });
+});

--- a/src/main/services/__tests__/LoopScheduler.test.ts
+++ b/src/main/services/__tests__/LoopScheduler.test.ts
@@ -162,6 +162,30 @@ describe('LoopScheduler', () => {
     expect(driver.spawns).toEqual([1, 2]);
   });
 
+  it('does not spawn a next iteration when pause() races the stop check', async () => {
+    // runShellCheck resolves on a later microtask; pause() lands during the await.
+    let resolveCheck: (v: boolean) => void = () => {};
+    const s = new LoopScheduler('t1', makeConfig({ stopPredicate: 'x' }), 'P', driver);
+    driver.runShellCheck = () => new Promise<boolean>((r) => (resolveCheck = r));
+    await s.start();
+    s.notifyWorkerState('busy');
+    s.notifyWorkerState('idle'); // begins onIterationComplete, now awaiting the check
+    s.pause(); // races the in-flight check
+    resolveCheck(false); // check says "continue"
+    await flush();
+    expect(driver.spawns).toEqual([1]); // paused → no respawn
+    expect(s.getStatus().state).toBe('paused');
+  });
+
+  it('cadence with no interval pauses instead of busy-spawning', async () => {
+    const s = new LoopScheduler('t1', makeConfig({ policy: 'cadence' }), 'P', driver);
+    await s.start();
+    await completeIteration(s);
+    expect(driver.spawns).toEqual([1]); // did not respawn
+    expect(s.getStatus().state).toBe('paused');
+    expect(s.getStatus().reason).toContain('interval');
+  });
+
   it('stop kills the worker and is terminal', async () => {
     const s = new LoopScheduler('t1', makeConfig({}), 'P', driver);
     await s.start();

--- a/src/main/services/__tests__/loopSpawn.test.ts
+++ b/src/main/services/__tests__/loopSpawn.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MANAGER_DENY,
+  managerDenySettings,
+  resolveAgentModel,
+  managerWeakerThanWorker,
+  workerPermissionForLevel,
+  buildLoopSpawn,
+} from '../loopSpawn';
+import type { LoopConfig } from '@shared/types';
+
+function cfg(over: Partial<LoopConfig>): LoopConfig {
+  return { policy: 'ralph', goal: 'g', level: 'L2', ...over };
+}
+
+describe('loopSpawn', () => {
+  it('manager deny settings block the structured write tools', () => {
+    const deny = managerDenySettings().permissions.deny;
+    for (const tool of ['Write', 'Edit', 'MultiEdit', 'NotebookEdit']) {
+      expect(deny).toContain(tool);
+    }
+    expect(deny).toContain('Bash(git commit:*)');
+    expect(deny).toContain('Bash(git push:*)');
+    // Returns a copy, not the shared constant (callers must not mutate it).
+    expect(deny).not.toBe(MANAGER_DENY);
+  });
+
+  it('manager model mirrors the worker when not set', () => {
+    expect(resolveAgentModel('manager', cfg({ worker: { model: 'claude-opus-4-8' } }))).toBe(
+      'claude-opus-4-8',
+    );
+    expect(
+      resolveAgentModel('manager', cfg({ worker: { model: 'a' }, manager: { model: 'b' } })),
+    ).toBe('b');
+    expect(
+      resolveAgentModel('worker', cfg({ worker: { model: 'a' }, manager: { model: 'b' } })),
+    ).toBe('a');
+  });
+
+  it('flags a manager weaker than the worker (anti-pattern)', () => {
+    expect(
+      managerWeakerThanWorker(
+        cfg({ worker: { model: 'claude-opus-4-8' }, manager: { model: 'claude-haiku-4-5' } }),
+      ),
+    ).toBe(true);
+    // Equal tier is fine.
+    expect(
+      managerWeakerThanWorker(
+        cfg({ worker: { model: 'claude-opus-4-8' }, manager: { model: 'claude-opus-4-8' } }),
+      ),
+    ).toBe(false);
+    // Manager stronger is fine.
+    expect(
+      managerWeakerThanWorker(
+        cfg({ worker: { model: 'claude-sonnet-5' }, manager: { model: 'claude-opus-4-8' } }),
+      ),
+    ).toBe(false);
+    // Manager unset → mirrors worker → not weaker.
+    expect(managerWeakerThanWorker(cfg({ worker: { model: 'claude-opus-4-8' } }))).toBe(false);
+    // Unranked custom ids → no false alarm.
+    expect(
+      managerWeakerThanWorker(cfg({ worker: { model: 'my-big' }, manager: { model: 'my-small' } })),
+    ).toBe(false);
+  });
+
+  it('worker permission follows the level, overridable', () => {
+    expect(workerPermissionForLevel(cfg({ level: 'L1' }))).toBe('acceptEdits');
+    expect(workerPermissionForLevel(cfg({ level: 'L3' }))).toBe('bypassPermissions');
+    expect(
+      workerPermissionForLevel(cfg({ level: 'L3', worker: { permissionMode: 'acceptEdits' } })),
+    ).toBe('acceptEdits');
+  });
+
+  it('buildLoopSpawn: manager runs unprompted but write-denied', () => {
+    const m = buildLoopSpawn('manager', cfg({ worker: { model: 'claude-opus-4-8' } }));
+    expect(m.permissionMode).toBe('bypassPermissions');
+    expect(m.extraSettings).toEqual({ permissions: { deny: expect.arrayContaining(['Write']) } });
+    expect(m.model).toBe('claude-opus-4-8'); // mirrored from worker
+    expect(m.initialPrompt).toContain('LOOP MANAGER');
+  });
+
+  it('buildLoopSpawn: worker writes, no deny settings', () => {
+    const w = buildLoopSpawn('worker', cfg({ level: 'L2' }));
+    expect(w.permissionMode).toBe('acceptEdits');
+    expect(w.extraSettings).toBeUndefined();
+    expect(w.initialPrompt).toContain('LOOP WORKER');
+  });
+});

--- a/src/main/services/loopSpawn.ts
+++ b/src/main/services/loopSpawn.ts
@@ -1,0 +1,105 @@
+import type { LoopConfig, LoopRole, PermissionMode } from '@shared/types';
+import { LoopService } from './LoopService';
+
+/**
+ * Per-role spawn policy for a loop's two agents. Centralised in main so the
+ * renderer only has to say which role a terminal hosts; everything else (model,
+ * permission, the seed prompt, and the manager's write-deny settings) is derived
+ * here from the task's LoopConfig.
+ */
+
+/**
+ * Tools/commands the MANAGER may never use. The manager runs UNPROMPTED so it can
+ * read/grep/inspect freely, and this deny list — passed via `claude --settings`
+ * (per-process; the agents share a worktree so a cwd settings file can't differ
+ * per agent) — is what enforces "never writes code". Deny beats every allow, so
+ * the structured edit tools are a hard block; the Bash patterns cover the
+ * git-write / destructive surface (best-effort, defense-in-depth).
+ */
+export const MANAGER_DENY: readonly string[] = [
+  'Write',
+  'Edit',
+  'MultiEdit',
+  'NotebookEdit',
+  'Bash(git commit:*)',
+  'Bash(git add:*)',
+  'Bash(git push:*)',
+  'Bash(git reset:*)',
+  'Bash(git checkout:*)',
+  'Bash(git restore:*)',
+  'Bash(git merge:*)',
+  'Bash(git rebase:*)',
+  'Bash(rm:*)',
+  'Bash(mv:*)',
+];
+
+/** The `--settings` object that makes the manager read-everything / write-nothing. */
+export function managerDenySettings(): { permissions: { deny: string[] } } {
+  return { permissions: { deny: [...MANAGER_DENY] } };
+}
+
+/** Coarse model-strength rank for the manager≥worker guard. 0 = unknown/unranked. */
+function modelRank(model: string | undefined): number {
+  if (!model) return 0;
+  const m = model.toLowerCase();
+  if (m.includes('opus')) return 4;
+  if (m.includes('sonnet')) return 3;
+  if (m.includes('haiku')) return 2;
+  if (m.includes('fable')) return 1;
+  return 0;
+}
+
+/** The manager mirrors the worker's model unless explicitly overridden. */
+export function resolveAgentModel(role: LoopRole, config: LoopConfig): string | undefined {
+  const worker = config.worker?.model;
+  if (role === 'worker') return worker;
+  return config.manager?.model ?? worker;
+}
+
+/**
+ * True when both models are known-ranked and the manager is weaker than the
+ * worker — an anti-pattern (a weak overseer can't grade a strong worker). The
+ * creation modal uses this to warn; it does not hard-block (unranked custom ids
+ * may be fine).
+ */
+export function managerWeakerThanWorker(config: LoopConfig): boolean {
+  const w = modelRank(config.worker?.model);
+  const m = modelRank(resolveAgentModel('manager', config));
+  return w > 0 && m > 0 && m < w;
+}
+
+/** Worker permission by phased-trust level (overridable). L1/L2 edit within the
+ *  worktree; only L3 runs fully unattended. The worker is always the sole writer. */
+export function workerPermissionForLevel(config: LoopConfig): PermissionMode {
+  if (config.worker?.permissionMode) return config.worker.permissionMode;
+  return config.level === 'L3' ? 'bypassPermissions' : 'acceptEdits';
+}
+
+export interface LoopSpawnPolicy {
+  permissionMode: PermissionMode;
+  initialPrompt: string;
+  model?: string;
+  effort?: string;
+  /** Extra `claude --settings` JSON merged at spawn (manager write-deny). */
+  extraSettings?: Record<string, unknown>;
+}
+
+/** Resolve everything main needs to spawn a loop agent of `role`. */
+export function buildLoopSpawn(role: LoopRole, config: LoopConfig): LoopSpawnPolicy {
+  if (role === 'manager') {
+    return {
+      // Unprompted so reads don't stall; writes blocked by extraSettings, not this.
+      permissionMode: config.manager?.permissionMode ?? 'bypassPermissions',
+      initialPrompt: LoopService.managerPrompt(config),
+      model: resolveAgentModel('manager', config),
+      effort: config.manager?.effort,
+      extraSettings: managerDenySettings(),
+    };
+  }
+  return {
+    permissionMode: workerPermissionForLevel(config),
+    initialPrompt: LoopService.workerIterationPrompt(config),
+    model: resolveAgentModel('worker', config),
+    effort: config.worker?.effort,
+  };
+}

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -361,6 +361,10 @@ export function buildClaudeArgs(opts: {
   name?: string;
   permissionMode?: PermissionMode;
   initialPrompt?: string;
+  /** Pin a model (loop agents: worker strong, manager ≥ worker). */
+  model?: string;
+  /** Extra `--settings` JSON, merged with ultracode (loop manager write-deny). */
+  extraSettings?: Record<string, unknown>;
 }): string[] {
   const args: string[] = [];
   if (opts.resumeSessionId) {
@@ -373,11 +377,19 @@ export function buildClaudeArgs(opts: {
   } else if (opts.permissionMode === 'bypassPermissions') {
     args.push('--dangerously-skip-permissions');
   }
+  if (opts.model) {
+    args.push('--model', opts.model);
+  }
   // ultracode is session-scoped; re-apply on every spawn so the user's toggle
-  // effectively sticks across the sessions Dash launches. Must precede the
-  // positional prompt below.
-  if (ultracode) {
-    args.push('--settings', JSON.stringify({ ultracode: true }));
+  // effectively sticks across the sessions Dash launches. Merge any per-spawn
+  // extraSettings (the loop manager's write-deny policy) into the same object.
+  // Must precede the positional prompt below.
+  const settings: Record<string, unknown> = {
+    ...(ultracode ? { ultracode: true } : {}),
+    ...(opts.extraSettings ?? {}),
+  };
+  if (Object.keys(settings).length > 0) {
+    args.push('--settings', JSON.stringify(settings));
   }
   if (opts.initialPrompt) {
     args.push(opts.initialPrompt);
@@ -413,6 +425,10 @@ export async function startDirectPty(options: {
    * scheduler passes the per-iteration worker prompt here.
    */
   initialPrompt?: string;
+  /** Pin a model (loop agents). */
+  model?: string;
+  /** Extra `--settings` JSON merged at spawn (loop manager write-deny policy). */
+  extraSettings?: Record<string, unknown>;
   sender?: WebContents;
 }): Promise<{
   reattached: boolean;
@@ -470,6 +486,8 @@ export async function startDirectPty(options: {
     name: options.name,
     permissionMode: options.permissionMode,
     initialPrompt,
+    model: options.model,
+    extraSettings: options.extraSettings,
   });
 
   const env = buildDirectEnv(options.isDark ?? true, options.cwd);

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -394,6 +394,25 @@ export async function startDirectPty(options: {
   isDark?: boolean;
   /** Task name → `claude --name` on a fresh spawn (recognizable in /resume). */
   name?: string;
+  /**
+   * Owning task id, when it differs from the PTY id. Agentic-loop PTYs use
+   * composite ids (`loop:<taskId>` / `mgr:<taskId>`) but must report the real
+   * task id so listForTask/restartAllForTask still group them. Defaults to `id`.
+   */
+  taskId?: string;
+  /**
+   * Skip `--resume`: spawn a brand-new Claude session every time. This is the
+   * Ralph reset — a loop worker re-reads its goal + STATE.md from disk each
+   * iteration instead of accumulating conversation context. Also avoids the
+   * session-file collision when two agents (worker + manager) share a cwd.
+   */
+  freshContext?: boolean;
+  /**
+   * Initial prompt auto-submitted after the trust gate (CC positional arg).
+   * Takes precedence over any prompt stashed via setInitialPrompt. The loop
+   * scheduler passes the per-iteration worker prompt here.
+   */
+  initialPrompt?: string;
   sender?: WebContents;
 }): Promise<{
   reattached: boolean;
@@ -436,12 +455,15 @@ export async function startDirectPty(options: {
   //
   // DO NOT relax the one-non-worktree-task cap without revisiting this; see git
   // history at 32bcdb6 for why the old SessionStart-hook pinning was removed.
-  const resumeSessionId = findLatestSessionId(options.cwd);
+  // freshContext (Ralph reset / loop agents) deliberately never resumes — each
+  // spawn is a new session reading its goal + STATE.md from disk.
+  const resumeSessionId = options.freshContext ? null : findLatestSessionId(options.cwd);
 
   // Pre-loaded prompt (the inlined ports-setup body). Only present for the
   // ports-migrate flow today; no-op for every other spawn. buildClaudeArgs
-  // places it last (CC auto-submits it after the trust gate clears).
-  const initialPrompt = consumeInitialPrompt(options.id);
+  // places it last (CC auto-submits it after the trust gate clears). An explicit
+  // initialPrompt (loop scheduler) wins over the stashed one.
+  const initialPrompt = options.initialPrompt ?? consumeInitialPrompt(options.id);
 
   const args = buildClaudeArgs({
     resumeSessionId,
@@ -473,7 +495,7 @@ export async function startDirectPty(options: {
     isDirectSpawn: true,
     owner: options.sender || null,
     kind: 'agent',
-    taskId: options.id,
+    taskId: options.taskId ?? options.id,
     featureId: null,
     mirror: new TerminalMirror(options.cols, options.rows),
   };

--- a/src/renderer/components/MainContent.tsx
+++ b/src/renderer/components/MainContent.tsx
@@ -304,8 +304,6 @@ export function MainContent({
               key={`loop-pane:${activeTask.id}`}
               taskId={activeTask.id}
               cwd={activeTask.path}
-              permissionMode={activeTask.permissionMode}
-              loopConfig={activeTask.loopConfig}
               terminalBg={terminalBg}
             />
           ) : (

--- a/src/renderer/components/MainContent.tsx
+++ b/src/renderer/components/MainContent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { TerminalPane } from './terminal/TerminalPane';
+import { LoopTerminalPane } from './terminal/LoopTerminalPane';
 import { ProjectOverview } from './project/ProjectOverview';
 import { useSettings } from '../stores/settingsStore';
 import { useGit } from '../stores/gitStore';
@@ -298,13 +299,24 @@ export function MainContent({
       {strip}
       <div className="flex-1 min-h-0 relative">
         {activeTask ? (
-          <TerminalPane
-            key={activeTask.id}
-            id={activeTask.id}
-            cwd={activeTask.path}
-            permissionMode={activeTask.permissionMode}
-            terminalBg={terminalBg}
-          />
+          activeTask.taskKind === 'loop' ? (
+            <LoopTerminalPane
+              key={`loop-pane:${activeTask.id}`}
+              taskId={activeTask.id}
+              cwd={activeTask.path}
+              permissionMode={activeTask.permissionMode}
+              loopConfig={activeTask.loopConfig}
+              terminalBg={terminalBg}
+            />
+          ) : (
+            <TerminalPane
+              key={activeTask.id}
+              id={activeTask.id}
+              cwd={activeTask.path}
+              permissionMode={activeTask.permissionMode}
+              terminalBg={terminalBg}
+            />
+          )
         ) : (
           <ProjectOverview
             project={activeProject}

--- a/src/renderer/components/terminal/LoopTerminalPane.tsx
+++ b/src/renderer/components/terminal/LoopTerminalPane.tsx
@@ -1,0 +1,119 @@
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+import { Repeat, Compass } from 'lucide-react';
+import type { LoopConfig, PermissionMode } from '../../../shared/types';
+import { TerminalPane } from './TerminalPane';
+
+interface LoopTerminalPaneProps {
+  taskId: string;
+  cwd: string;
+  permissionMode?: PermissionMode;
+  loopConfig: LoopConfig | null;
+  terminalBg?: string;
+}
+
+/**
+ * The two-terminal main pane for an agentic loop (see docs/agentic-loops-plan.md).
+ * Left = the Ralph WORKER (fresh context each iteration, acts), right = the
+ * persistent MANAGER (orchestrates, never edits code). Both spawn fresh-context
+ * so their Claude sessions don't collide on the shared worktree cwd; each reads
+ * the on-disk loop spine (.dash/loop/*) that LoopService seeds.
+ *
+ * The PTY ids (`loop:<taskId>` / `mgr:<taskId>`) are what the LoopScheduler and
+ * MCP bridge target for steer/pause/kill.
+ */
+export function LoopTerminalPane({
+  taskId,
+  cwd,
+  permissionMode,
+  loopConfig,
+  terminalBg,
+}: LoopTerminalPaneProps) {
+  const workerPrompt = seedWorkerPrompt();
+  const managerPrompt = loopConfig?.managerPrompt?.trim() || seedManagerPrompt();
+
+  return (
+    <PanelGroup direction="horizontal" className="h-full w-full" autoSaveId={`loop:${taskId}`}>
+      <Panel id="loop-worker" order={1} minSize={25} defaultSize={50}>
+        <LoopColumn
+          icon={<Repeat size={13} strokeWidth={1.8} />}
+          label="Worker"
+          sub="iterates · acts"
+        >
+          <TerminalPane
+            key={`loop:${taskId}`}
+            id={`loop:${taskId}`}
+            loopTaskId={taskId}
+            cwd={cwd}
+            permissionMode={permissionMode}
+            terminalBg={terminalBg}
+            freshContext
+            initialPrompt={workerPrompt}
+          />
+        </LoopColumn>
+      </Panel>
+      <PanelResizeHandle className="resize-handle-quiet w-px bg-border/40" />
+      <Panel id="loop-manager" order={2} minSize={25} defaultSize={50}>
+        <LoopColumn
+          icon={<Compass size={13} strokeWidth={1.8} />}
+          label="Manager"
+          sub="orchestrates · never edits"
+        >
+          <TerminalPane
+            key={`mgr:${taskId}`}
+            id={`mgr:${taskId}`}
+            loopTaskId={taskId}
+            cwd={cwd}
+            // Manager triages/steers; default permission keeps it from editing code.
+            permissionMode="default"
+            terminalBg={terminalBg}
+            freshContext
+            initialPrompt={managerPrompt}
+          />
+        </LoopColumn>
+      </Panel>
+    </PanelGroup>
+  );
+}
+
+function LoopColumn({
+  icon,
+  label,
+  sub,
+  children,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  sub: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-1.5 px-2 h-[22px] shrink-0 border-b border-border/40 text-[11px] text-muted-foreground">
+        {icon}
+        <span className="font-medium text-foreground">{label}</span>
+        <span className="opacity-60">· {sub}</span>
+      </div>
+      <div className="flex-1 min-h-0">{children}</div>
+    </div>
+  );
+}
+
+function seedWorkerPrompt(): string {
+  return [
+    'You are the LOOP WORKER. First read .dash/loop/loop-constraints.md and obey every rule.',
+    'Then read .dash/loop/PROMPT.md (the goal) and .dash/loop/STATE.md (what past iterations did).',
+    'Do ONE focused, committable unit of work toward the goal. Run the project tests/lint.',
+    'Update .dash/loop/STATE.md with what you did and what remains, then commit.',
+    'Do NOT declare the overall goal done yourself — an external check decides that.',
+    'If blocked or ambiguous, write it under "Needs human" in STATE.md and stop.',
+  ].join(' ');
+}
+
+function seedManagerPrompt(): string {
+  return [
+    'You are the LOOP MANAGER. Read .dash/loop/LOOP.md and .dash/loop/STATE.md.',
+    'Track progress, keep priorities current in STATE.md, and decide what needs human attention.',
+    'You NEVER edit code — the worker is the only writer. You orchestrate: observe, prioritise,',
+    'and steer or pause the worker when needed.',
+  ].join(' ');
+}

--- a/src/renderer/components/terminal/LoopTerminalPane.tsx
+++ b/src/renderer/components/terminal/LoopTerminalPane.tsx
@@ -1,36 +1,26 @@
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { Repeat, Compass } from 'lucide-react';
-import type { LoopConfig, PermissionMode } from '../../../shared/types';
 import { TerminalPane } from './TerminalPane';
 
 interface LoopTerminalPaneProps {
   taskId: string;
   cwd: string;
-  permissionMode?: PermissionMode;
-  loopConfig: LoopConfig | null;
   terminalBg?: string;
 }
 
 /**
  * The two-terminal main pane for an agentic loop (see docs/agentic-loops-plan.md).
  * Left = the Ralph WORKER (fresh context each iteration, acts), right = the
- * persistent MANAGER (orchestrates, never edits code). Both spawn fresh-context
- * so their Claude sessions don't collide on the shared worktree cwd; each reads
- * the on-disk loop spine (.dash/loop/*) that LoopService seeds.
+ * persistent MANAGER (orchestrates, never edits code).
  *
- * The PTY ids (`loop:<taskId>` / `mgr:<taskId>`) are what the LoopScheduler and
- * MCP bridge target for steer/pause/kill.
+ * The renderer only declares which role each terminal hosts (`loopRole`) and
+ * that it spawns fresh-context (so the two Claude sessions don't collide on the
+ * shared worktree cwd). Main owns the rest of the per-role policy — model,
+ * permission, the seed prompt, and the manager's write-deny settings — derived
+ * from the task's LoopConfig (see loopSpawn.ts). The PTY ids (`loop:<taskId>` /
+ * `mgr:<taskId>`) are what the LoopScheduler and MCP bridge target.
  */
-export function LoopTerminalPane({
-  taskId,
-  cwd,
-  permissionMode,
-  loopConfig,
-  terminalBg,
-}: LoopTerminalPaneProps) {
-  const workerPrompt = seedWorkerPrompt();
-  const managerPrompt = loopConfig?.managerPrompt?.trim() || seedManagerPrompt();
-
+export function LoopTerminalPane({ taskId, cwd, terminalBg }: LoopTerminalPaneProps) {
   return (
     <PanelGroup direction="horizontal" className="h-full w-full" autoSaveId={`loop:${taskId}`}>
       <Panel id="loop-worker" order={1} minSize={25} defaultSize={50}>
@@ -43,11 +33,10 @@ export function LoopTerminalPane({
             key={`loop:${taskId}`}
             id={`loop:${taskId}`}
             loopTaskId={taskId}
+            loopRole="worker"
             cwd={cwd}
-            permissionMode={permissionMode}
             terminalBg={terminalBg}
             freshContext
-            initialPrompt={workerPrompt}
           />
         </LoopColumn>
       </Panel>
@@ -62,12 +51,10 @@ export function LoopTerminalPane({
             key={`mgr:${taskId}`}
             id={`mgr:${taskId}`}
             loopTaskId={taskId}
+            loopRole="manager"
             cwd={cwd}
-            // Manager triages/steers; default permission keeps it from editing code.
-            permissionMode="default"
             terminalBg={terminalBg}
             freshContext
-            initialPrompt={managerPrompt}
           />
         </LoopColumn>
       </Panel>
@@ -96,24 +83,4 @@ function LoopColumn({
       <div className="flex-1 min-h-0">{children}</div>
     </div>
   );
-}
-
-function seedWorkerPrompt(): string {
-  return [
-    'You are the LOOP WORKER. First read .dash/loop/loop-constraints.md and obey every rule.',
-    'Then read .dash/loop/PROMPT.md (the goal) and .dash/loop/STATE.md (what past iterations did).',
-    'Do ONE focused, committable unit of work toward the goal. Run the project tests/lint.',
-    'Update .dash/loop/STATE.md with what you did and what remains, then commit.',
-    'Do NOT declare the overall goal done yourself — an external check decides that.',
-    'If blocked or ambiguous, write it under "Needs human" in STATE.md and stop.',
-  ].join(' ');
-}
-
-function seedManagerPrompt(): string {
-  return [
-    'You are the LOOP MANAGER. Read .dash/loop/LOOP.md and .dash/loop/STATE.md.',
-    'Track progress, keep priorities current in STATE.md, and decide what needs human attention.',
-    'You NEVER edit code — the worker is the only writer. You orchestrate: observe, prioritise,',
-    'and steer or pause the worker when needed.',
-  ].join(' ');
 }

--- a/src/renderer/components/terminal/TerminalPane.tsx
+++ b/src/renderer/components/terminal/TerminalPane.tsx
@@ -12,9 +12,23 @@ interface TerminalPaneProps {
   cwd: string;
   permissionMode?: PermissionMode;
   terminalBg?: string;
+  /** Owning task id when it differs from the PTY id (loop:/mgr: composite ids). */
+  loopTaskId?: string;
+  /** Skip --resume: spawn a fresh Claude session (loop agents; Ralph reset). */
+  freshContext?: boolean;
+  /** Prompt auto-submitted after the trust gate (loop worker/manager seed). */
+  initialPrompt?: string;
 }
 
-export function TerminalPane({ id, cwd, permissionMode, terminalBg }: TerminalPaneProps) {
+export function TerminalPane({
+  id,
+  cwd,
+  permissionMode,
+  terminalBg,
+  loopTaskId,
+  freshContext,
+  initialPrompt,
+}: TerminalPaneProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [showOverlay, setShowOverlay] = useState(false);
@@ -37,7 +51,14 @@ export function TerminalPane({ id, cwd, permissionMode, terminalBg }: TerminalPa
 
     // Get or create session first so we can register callbacks
     // before the async attach() work detects a restart
-    const session = sessionRegistry.getOrCreate({ id, cwd, permissionMode });
+    const session = sessionRegistry.getOrCreate({
+      id,
+      cwd,
+      permissionMode,
+      loopTaskId,
+      freshContext,
+      initialPrompt,
+    });
 
     session.onRestarting(() => {
       overlayStartRef.current = Date.now();

--- a/src/renderer/components/terminal/TerminalPane.tsx
+++ b/src/renderer/components/terminal/TerminalPane.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 import type { SearchAddon } from '@xterm/addon-search';
 import { sessionRegistry } from '../../terminal/SessionRegistry';
-import type { PermissionMode } from '../../../shared/types';
+import type { LoopRole, PermissionMode } from '../../../shared/types';
 import { TerminalSearch } from './TerminalSearch';
 
 const OVERLAY_MIN_MS = 2000;
@@ -18,6 +18,8 @@ interface TerminalPaneProps {
   freshContext?: boolean;
   /** Prompt auto-submitted after the trust gate (loop worker/manager seed). */
   initialPrompt?: string;
+  /** Loop agent role; main derives model/permission/prompt/deny-settings from it. */
+  loopRole?: LoopRole;
 }
 
 export function TerminalPane({
@@ -28,6 +30,7 @@ export function TerminalPane({
   loopTaskId,
   freshContext,
   initialPrompt,
+  loopRole,
 }: TerminalPaneProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -58,6 +61,7 @@ export function TerminalPane({
       loopTaskId,
       freshContext,
       initialPrompt,
+      loopRole,
     });
 
     session.onRestarting(() => {

--- a/src/renderer/stores/projectsStore.ts
+++ b/src/renderer/stores/projectsStore.ts
@@ -91,6 +91,9 @@ function disposeTaskSessions(taskId: string) {
   void sessionRegistry.dispose(taskId);
   void sessionRegistry.dispose(`shell:${taskId}`);
   void sessionRegistry.disposeByPrefix(`shell:${taskId}:`);
+  // Agentic-loop tasks own two agent PTYs instead of the single bare-id one.
+  void sessionRegistry.dispose(`loop:${taskId}`);
+  void sessionRegistry.dispose(`mgr:${taskId}`);
 }
 
 /** Sort projects by the saved projectOrder, pruning stale ids from storage. */

--- a/src/renderer/terminal/SessionRegistry.ts
+++ b/src/renderer/terminal/SessionRegistry.ts
@@ -9,6 +9,12 @@ interface AttachOptions {
   shellOnly?: boolean;
   isTui?: boolean;
   themeId?: string;
+  /** Owning task id when it differs from the PTY id (loop:/mgr: composite ids). */
+  loopTaskId?: string;
+  /** Skip --resume: spawn a fresh Claude session (loop agents; Ralph reset). */
+  freshContext?: boolean;
+  /** Prompt auto-submitted after the trust gate (loop worker/manager seed). */
+  initialPrompt?: string;
 }
 
 class SessionRegistryImpl {
@@ -27,6 +33,9 @@ class SessionRegistryImpl {
         shellOnly: opts.shellOnly,
         isTui: opts.isTui,
         themeId: opts.themeId ?? this._themeId,
+        loopTaskId: opts.loopTaskId,
+        freshContext: opts.freshContext,
+        initialPrompt: opts.initialPrompt,
       });
       this.sessions.set(opts.id, session);
     }

--- a/src/renderer/terminal/SessionRegistry.ts
+++ b/src/renderer/terminal/SessionRegistry.ts
@@ -1,5 +1,5 @@
 import { TerminalSessionManager } from './TerminalSessionManager';
-import type { PermissionMode } from '../../shared/types';
+import type { LoopRole, PermissionMode } from '../../shared/types';
 
 interface AttachOptions {
   id: string;
@@ -15,6 +15,8 @@ interface AttachOptions {
   freshContext?: boolean;
   /** Prompt auto-submitted after the trust gate (loop worker/manager seed). */
   initialPrompt?: string;
+  /** Loop agent role; main derives model/permission/prompt/deny-settings from it. */
+  loopRole?: LoopRole;
 }
 
 class SessionRegistryImpl {
@@ -36,6 +38,7 @@ class SessionRegistryImpl {
         loopTaskId: opts.loopTaskId,
         freshContext: opts.freshContext,
         initialPrompt: opts.initialPrompt,
+        loopRole: opts.loopRole,
       });
       this.sessions.set(opts.id, session);
     }

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -4,7 +4,7 @@ import { SearchAddon } from '@xterm/addon-search';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { ClipboardAddon } from '@xterm/addon-clipboard';
 import { Utf8Base64 } from './Utf8Base64';
-import type { PermissionMode, TerminalSnapshot } from '../../shared/types';
+import type { LoopRole, PermissionMode, TerminalSnapshot } from '../../shared/types';
 import { FilePathLinkProvider } from './FilePathLinkProvider';
 import type { ITheme } from '@xterm/xterm';
 import { darkTheme, lightTheme, resolveTheme } from './terminalThemes';
@@ -87,6 +87,7 @@ export class TerminalSessionManager {
   private readonly loopTaskId?: string;
   private readonly freshContext: boolean;
   private readonly initialPrompt?: string;
+  private readonly loopRole?: LoopRole;
   // Claude Code's TUI rewrites cells continuously, which causes xterm to drop
   // the visible selection before the user can press the copy shortcut. Cache
   // the last non-empty selection on every change so Ctrl+Shift+C / Cmd+C can
@@ -111,6 +112,8 @@ export class TerminalSessionManager {
     freshContext?: boolean;
     /** Prompt auto-submitted after the trust gate (loop worker/manager seed). */
     initialPrompt?: string;
+    /** Loop agent role; main derives model/permission/prompt/deny-settings from it. */
+    loopRole?: LoopRole;
   }) {
     this.id = opts.id;
     this.cwd = opts.cwd;
@@ -124,6 +127,7 @@ export class TerminalSessionManager {
     this.loopTaskId = opts.loopTaskId;
     this.freshContext = opts.freshContext ?? false;
     this.initialPrompt = opts.initialPrompt;
+    this.loopRole = opts.loopRole;
 
     this.terminal = new Terminal({
       scrollback: 100_000,
@@ -1051,6 +1055,7 @@ export class TerminalSessionManager {
       taskId: this.loopTaskId,
       freshContext: this.freshContext,
       initialPrompt: this.initialPrompt,
+      loopRole: this.loopRole,
     });
 
     if (resp.success) {

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -83,6 +83,10 @@ export class TerminalSessionManager {
    */
   private readonly pinnedTui: boolean;
   private themeId: string;
+  /** Loop-agent spawn metadata; undefined/false for standard sessions. */
+  private readonly loopTaskId?: string;
+  private readonly freshContext: boolean;
+  private readonly initialPrompt?: string;
   // Claude Code's TUI rewrites cells continuously, which causes xterm to drop
   // the visible selection before the user can press the copy shortcut. Cache
   // the last non-empty selection on every change so Ctrl+Shift+C / Cmd+C can
@@ -101,6 +105,12 @@ export class TerminalSessionManager {
      */
     isTui?: boolean;
     themeId?: string;
+    /** Owning task id when it differs from the PTY id (loop:/mgr: composite ids). */
+    loopTaskId?: string;
+    /** Skip --resume: spawn a fresh Claude session (loop agents; Ralph reset). */
+    freshContext?: boolean;
+    /** Prompt auto-submitted after the trust gate (loop worker/manager seed). */
+    initialPrompt?: string;
   }) {
     this.id = opts.id;
     this.cwd = opts.cwd;
@@ -111,6 +121,9 @@ export class TerminalSessionManager {
     this.isTui = opts.isTui ?? false;
     this.pinnedTui = this.isTui && opts.id.startsWith('tui:');
     this.themeId = opts.themeId ?? 'default';
+    this.loopTaskId = opts.loopTaskId;
+    this.freshContext = opts.freshContext ?? false;
+    this.initialPrompt = opts.initialPrompt;
 
     this.terminal = new Terminal({
       scrollback: 100_000,
@@ -1035,6 +1048,9 @@ export class TerminalSessionManager {
       rows,
       permissionMode: this.permissionMode,
       isDark: this.isDark,
+      taskId: this.loopTaskId,
+      freshContext: this.freshContext,
+      initialPrompt: this.initialPrompt,
     });
 
     if (resp.success) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -51,6 +51,64 @@ export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions';
  */
 export type TaskStatus = 'idle' | 'active';
 
+// ── Agentic Loops ───────────────────────────────────────────
+// See docs/agentic-loops-plan.md. A `loop` task runs two agent PTYs (a Ralph
+// worker that resets context every iteration + a persistent manager) driven by
+// Dash's own scheduler. `standard` is the classic single-agent task.
+
+export type TaskKind = 'standard' | 'loop';
+
+/**
+ * How a loop decides to run the next iteration / when to stop. The scheduler
+ * `while` is identical across policies — only the stop predicate changes.
+ * - `ralph`  : the default. Re-run the goal until an external check passes
+ *              (tests/lint), with a safety `maxIterations`. Context resets each pass.
+ * - `goal`   : iterate until a measurable shell condition exits 0 (mirrors `/goal`).
+ * - `cadence`: run every `cadenceMs` indefinitely (mirrors `/loop`); triage shape.
+ * - `count`  : run `maxIterations` times or until `completionPromise` appears.
+ */
+export type LoopPolicy = 'ralph' | 'goal' | 'cadence' | 'count';
+
+/** Phased-trust level (loop-engineering). Gates worker permission + manager authority. */
+export type LoopLevel = 'L1' | 'L2' | 'L3';
+
+export interface LoopConfig {
+  policy: LoopPolicy;
+  /** The recurring goal re-read fresh by the worker each iteration (→ PROMPT.md). */
+  goal: string;
+  level: LoopLevel;
+  /** Shell command whose exit code 0 means "done" (ralph/goal). Null → no auto-stop. */
+  stopPredicate?: string | null;
+  /** Milliseconds between iterations for the `cadence` policy. */
+  cadenceMs?: number | null;
+  /** Hard cap on iterations (ralph/count) — a runaway backstop. */
+  maxIterations?: number | null;
+  /** Completion phrase for `count`; exact substring match in worker output. */
+  completionPromise?: string | null;
+  /** Token budget; the scheduler auto-pauses when exceeded and notifies the human. */
+  tokenBudget?: number | null;
+  /** Role/system prompt seeded for the manager agent. */
+  managerPrompt?: string | null;
+  /** Hard rules injected before every iteration (→ loop-constraints.md). */
+  constraints?: string[];
+}
+
+/** Runtime state of a loop's scheduler, mirrored to the renderer. */
+export type LoopRunState = 'idle' | 'running' | 'paused' | 'stopped' | 'done' | 'error';
+
+export interface LoopStatus {
+  taskId: string;
+  state: LoopRunState;
+  iteration: number;
+  maxIterations: number | null;
+  /** Why the loop stopped, when `state` is `done`/`stopped`/`error`. */
+  reason?: string;
+  /** Token spend the scheduler has observed for this loop. */
+  tokensSpent: number;
+  tokenBudget: number | null;
+  updatedAt: number;
+}
+
 export interface Task {
   id: string;
   projectId: string;
@@ -58,6 +116,10 @@ export interface Task {
   branch: string;
   path: string;
   status: TaskStatus;
+  /** `standard` (single agent) or `loop` (Ralph worker + manager). Immutable after creation. */
+  taskKind: TaskKind;
+  /** Loop definition; non-null iff `taskKind === 'loop'`. */
+  loopConfig: LoopConfig | null;
   useWorktree: boolean;
   permissionMode: PermissionMode;
   branchCreatedByDash: boolean;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -72,6 +72,23 @@ export type LoopPolicy = 'ralph' | 'goal' | 'cadence' | 'count';
 /** Phased-trust level (loop-engineering). Gates worker permission + manager authority. */
 export type LoopLevel = 'L1' | 'L2' | 'L3';
 
+/** Reasoning effort tier for a loop agent (maps to Claude Code effort / ultracode). */
+export type LoopEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'ultracode';
+
+/**
+ * Per-agent spawn settings. The worker and manager are configured independently —
+ * but the manager is an OVERSEER, so its model should be ≥ the worker's (evaluation
+ * is at least as hard as generation). `managerWeakerThanWorker` flags violations.
+ */
+export interface LoopAgentConfig {
+  /** Claude model id (e.g. 'claude-opus-4-8'). Undefined → CLI/global default. */
+  model?: string;
+  effort?: LoopEffort;
+  /** Override the level-derived permission mode. Manager enforcement is via a
+   *  write-deny settings policy, not this field (see loopSpawn.ts). */
+  permissionMode?: PermissionMode;
+}
+
 export interface LoopConfig {
   policy: LoopPolicy;
   /** The recurring goal re-read fresh by the worker each iteration (→ PROMPT.md). */
@@ -91,7 +108,19 @@ export interface LoopConfig {
   managerPrompt?: string | null;
   /** Hard rules injected before every iteration (→ loop-constraints.md). */
   constraints?: string[];
+  /** Per-agent model/effort/permission. Manager defaults to the worker's tier. */
+  worker?: LoopAgentConfig;
+  manager?: LoopAgentConfig;
+  /** Spec/PRD files the worker re-reads each iteration (referenced from PROMPT.md). */
+  specRefs?: string[];
+  /** Maker/checker verifier sub-agent — "the implementer never grades its own homework". */
+  verifier?: { enabled: boolean; prompt?: string | null };
+  /** Per-iteration sub-agent spawn cap (loop-engineering caps by level). */
+  subAgentCap?: number | null;
 }
+
+/** Which agent of a loop a PTY hosts. Drives per-role spawn policy in main. */
+export type LoopRole = 'worker' | 'manager';
 
 /** Runtime state of a loop's scheduler, mirrored to the renderer. */
 export type LoopRunState = 'idle' | 'running' | 'paused' | 'stopped' | 'done' | 'error';

--- a/src/types/electron-api/pty.ts
+++ b/src/types/electron-api/pty.ts
@@ -1,6 +1,7 @@
 import type {
   IpcResponse,
   PermissionMode,
+  LoopRole,
   TerminalSnapshot,
   ActivityInfo,
   RemoteControlState,
@@ -24,6 +25,8 @@ export interface PtyApi {
     freshContext?: boolean;
     /** Prompt auto-submitted after the trust gate (loop worker/manager seed). */
     initialPrompt?: string;
+    /** Loop agent role; main derives model/permission/prompt/deny-settings from it. */
+    loopRole?: LoopRole;
   }) => Promise<
     IpcResponse<{
       reattached: boolean;

--- a/src/types/electron-api/pty.ts
+++ b/src/types/electron-api/pty.ts
@@ -18,6 +18,12 @@ export interface PtyApi {
     rows: number;
     permissionMode?: PermissionMode;
     isDark?: boolean;
+    /** Owning task id when it differs from the PTY id (loop:/mgr: composite ids). */
+    taskId?: string;
+    /** Skip --resume: spawn a fresh Claude session (loop agents; Ralph reset). */
+    freshContext?: boolean;
+    /** Prompt auto-submitted after the trust gate (loop worker/manager seed). */
+    initialPrompt?: string;
   }) => Promise<
     IpcResponse<{
       reattached: boolean;


### PR DESCRIPTION
## What this is

First-class support for **agentic loops** in Dash. A task can be a `loop`, which runs **two terminals side-by-side** in the main pane — a **Ralph worker** that iterates on a goal (fresh context every pass) and a **persistent manager** that orchestrates — driven by a **Dash-owned scheduler**. Conceptual base: [loop-engineering](https://github.com/cobusgreyling/loop-engineering) (role separation + durable state spine) × the Ralph loop (fresh context each iteration, completion judged by an external check, never self-grading).

Design + rationale live in `docs/agentic-loops-plan.md`.

## Locked decisions baked into the code
- **Dash owns the iteration `while`** (not the CLI's `/loop`/`/ralph-loop`) so budget gates, the stop check, and pause/kill are clean control points.
- **Worker resets context every pass; manager persists.** Durable memory lives in `.dash/loop/` files, not the conversation.
- **Completion is an external check** — the scheduler only advances on busy→idle and runs the stop predicate itself.
- **Manager model ≥ worker** (evaluation is at least as hard as generation); a weaker-manager config is flagged.
- **Manager runs unprompted but write-denied** via `claude --settings` (`Write/Edit/MultiEdit/NotebookEdit` + git-write Bash) — `default` permission would wrongly block its own reads/greps.

## What's landed (this PR)
- **Data foundation** — `taskKind` + `loopConfig` across shared types, Drizzle schema, guarded migration, `DatabaseService` (+`duplicateTask`).
- **State spine** — `LoopService` seeds/reads `.dash/loop/` (`PROMPT`/`LOOP`/`STATE`/`loop-constraints`/`loop-run-log`/`manager-notes`).
- **Fresh-context spawn** — `ptyManager` opt-in `freshContext` (no `--resume`), `--model`, merged `--settings`, distinct `taskId` for `loop:`/`mgr:` ids; threaded through the renderer spawn path.
- **Scheduler core** — `LoopScheduler`, a dependency-injected state machine (per-policy stop check, maxIterations, cadence waits, token-budget auto-pause, pause/resume/stop) + `ActivityMonitor.subscribe()`.
- **Per-agent policy** — `loopSpawn.ts` centralizes worker/manager model/permission/prompt/deny-settings in main; the renderer only passes `loopRole`.
- **Two-terminal split pane** — `LoopTerminalPane`; `MainContent` branches on `taskKind`; standard tasks untouched.

## Testing
- `pnpm type-check` clean (both processes).
- **18 unit tests** pass — `LoopScheduler` (12, incl. a pause/stop-races-the-check regression and the cadence-runaway guard) and `loopSpawn` (6).
- A self-review (`/code-review`) found and fixed two concurrency/runaway bugs in the scheduler.

## Not in this PR (needs a machine that can run the Electron app to verify)
- Scheduler↔PTY adapter (`LoopController`) + `loop:start/pause/resume/stop` IPC.
- Loop MCP bridge (`loop_status/steer/pause/kill/escalate/...`) + injecting the manager deny-settings/hook at spawn.
- TaskModal loop mode + duplicate-as-loop UI.

**Verification caveat:** the `--model` and `--settings` deny-list args follow Claude Code's documented flags but haven't been exercised end-to-end here — confirming the manager's write-deny actually blocks edits is the first check when wiring the MCP bridge. Until the creation modal lands, a loop task can be created by setting `task_kind='loop'` on a row to exercise the split pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmYjhqiW9Wxb9wXRpNzFbc)_