### PR TITLE
Windows: Toast popup when user presses ctrl+v

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Dash — Desktop app for Claude Code with git worktree management",
   "main": "dist/main/main/entry.js",
   "author": "mhenrichsen <mads@syv.ai>, nthomsencph <nicolai@syv.ai>, FabianScott <fabian@syv.ai>",

--- a/src/renderer/stores/settingsKeys.ts
+++ b/src/renderer/stores/settingsKeys.ts
@@ -47,6 +47,7 @@ export interface SettingsState {
   autoUpdateEnabled: boolean;
   updateNotificationsEnabled: boolean;
   lastSeenReleaseNotesVersion: string | undefined;
+  hasDismissedWindowsPasteToast: boolean;
 }
 
 /** One entry per managed setting: the store field, its existing localStorage
@@ -124,6 +125,7 @@ export const SETTINGS_REGISTRY: RegistryEntry[] = [
   entry('autoUpdateEnabled', 'autoUpdateEnabled', boolDefaultTrue()),
   entry('updateNotificationsEnabled', 'updateNotificationsEnabled', boolDefaultTrue()),
   entry('lastSeenReleaseNotesVersion', 'lastSeenReleaseNotesVersion', strOrUndefined()),
+  entry('hasDismissedWindowsPasteToast', 'hasDismissedWindowsPasteToast', boolDefaultFalse()),
 ];
 
 /** Initial state = every field decoded from an absent key (its default). */

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -14,6 +14,7 @@ import { clackBlock, clackExitBlock } from './clackLines';
 import { isPromptOnlySnapshot } from './snapshotFilter';
 import { FitScheduler } from './FitScheduler';
 import { TUI_COLS, TUI_ROWS } from '../../shared/tuiProtocol';
+import { maybeShowWindowsPasteToast } from './windowsPasteToast';
 
 // Heap mark above which a terminal trims its own scrollback to relieve pressure.
 // `performance.memory.usedJSHeapSize` is the WHOLE renderer heap (React, Monaco,
@@ -88,6 +89,9 @@ export class TerminalSessionManager {
   // the last non-empty selection on every change so Ctrl+Shift+C / Cmd+C can
   // still copy it even after xterm has cleared the highlight.
   private lastSelection = '';
+  // Cached: getPlatform() is a synchronous preload bridge; avoid reading it
+  // per-keystroke in the key handler. Gates the Windows paste nudge (Alt+V).
+  private readonly isWindows = window.electronAPI.getPlatform() === 'win32';
   constructor(opts: {
     id: string;
     cwd: string;
@@ -202,6 +206,13 @@ export class TerminalSessionManager {
       // Ctrl+Shift+C reports e.key as something other than 'C' still work.
       const isKeyC = e.code === 'KeyC';
       const isKeyV = e.code === 'KeyV';
+
+      // Nudge Windows users toward Alt+V (see windowsPasteToast). Side-effect
+      // only — no preventDefault/return, so existing paste handling still runs
+      // and Alt+V (excluded here) still passes through untouched.
+      if (this.isWindows && isKeyV && e.ctrlKey && !e.altKey && !e.metaKey) {
+        maybeShowWindowsPasteToast();
+      }
 
       // Copy: Cmd+C (macOS) or Ctrl+Shift+C (Linux) — copy terminal selection.
       // Also Ctrl+C on any platform when there's an active selection (matches

--- a/src/renderer/terminal/windowsPasteToast.tsx
+++ b/src/renderer/terminal/windowsPasteToast.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { Check, ClipboardPaste } from 'lucide-react';
+import { toast } from 'sonner';
+import { useSettings } from '../stores/settingsStore';
+
+// Fixed id so repeated Ctrl+V presses de-dupe onto one toast instead of stacking.
+const TOAST_ID = 'windows-paste-tip';
+
+// Closed without ticking "Don't show again": stay quiet for the rest of this
+// session, but nudge once more next launch. Ticking the box persists instead.
+let suppressedThisSession = false;
+
+function PasteTip({ onClose }: { onClose: (dontShowAgain: boolean) => void }) {
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+  return (
+    <div className="w-[300px] rounded-lg border border-border bg-[hsl(var(--surface-2))] shadow-lg px-3.5 py-3">
+      <div className="flex items-start gap-2.5">
+        <span className="mt-0.5 shrink-0">
+          <ClipboardPaste size={14} className="text-primary" strokeWidth={2} />
+        </span>
+        <div className="text-[13px] text-foreground/90 leading-snug">
+          <div className="font-medium text-foreground">Use Alt+V to paste on Windows</div>
+          <div className="mt-0.5 text-muted-foreground">
+            Ctrl+V and Ctrl+Shift+V silently drop text from long pastes. We recommend Alt+V — Claude
+            Code has supported it natively for text and images since v2.1.157 (May 2026).
+          </div>
+        </div>
+      </div>
+      <div className="mt-2.5 flex items-center gap-1.5">
+        {/* Mirrors the ports wizard's footer: the permanent opt-out sits left and
+            quiet, leaving the plain close as the obvious default action. */}
+        <label className="mr-auto flex cursor-pointer items-center gap-1.5 whitespace-nowrap text-[11px] text-muted-foreground/70 transition-colors hover:text-foreground">
+          {/* appearance-none so the unchecked box sits on the card's own
+              background behind a grey border, rather than native white. */}
+          <span className="relative inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+            <input
+              type="checkbox"
+              checked={dontShowAgain}
+              onChange={(e) => setDontShowAgain(e.target.checked)}
+              className="peer absolute inset-0 cursor-pointer appearance-none rounded-[3px] border border-border bg-[hsl(var(--surface-2))] transition-colors checked:border-primary checked:bg-primary"
+            />
+            <Check
+              size={10}
+              strokeWidth={3}
+              className="pointer-events-none relative text-primary-foreground opacity-0 transition-opacity peer-checked:opacity-100"
+            />
+          </span>
+          Don’t show again
+        </label>
+        <button
+          type="button"
+          onClick={() => onClose(dontShowAgain)}
+          className="rounded-md px-2.5 py-1 text-[12px] font-medium text-muted-foreground transition-colors duration-150 hover:bg-accent/60 hover:text-foreground"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Windows-only nudge: pasting into the Claude Code TUI with Ctrl+V / Ctrl+Shift+V
+ * is unreliable here — ConPTY silently drops writes past ~2 KB, so long pastes
+ * lose text with no error. Alt+V is handled natively by Claude Code (v2.1.157,
+ * May 2026) for both text and images, so we point users at it.
+ */
+export function maybeShowWindowsPasteToast(): void {
+  if (suppressedThisSession) return;
+  if (useSettings.getState().hasDismissedWindowsPasteToast) return;
+
+  toast.custom(
+    (id) => (
+      <PasteTip
+        onClose={(dontShowAgain) => {
+          if (dontShowAgain) useSettings.getState().setHasDismissedWindowsPasteToast(true);
+          suppressedThisSession = true;
+          toast.dismiss(id);
+        }}
+      />
+    ),
+    {
+      id: TOAST_ID,
+      duration: Infinity,
+      dismissible: true,
+      // Swipe/close without the box ticked counts as "not now", not "never".
+      onDismiss: () => {
+        suppressedThisSession = true;
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Introduce a dismissable toast when pressing ctrl+v on windows pointing users to natively supported and working alt+v

Windows users pasting into the Claude Code TUI via Dash hit silent data loss: **Ctrl+V and Ctrl+Shift+V drop text from long pastes silently**. The root cause is in our own PTY layer: on Windows/ConPTY, node-pty ignores the `Socket.write()` backpressure return, so writes past ~2 KB are silently discarded. Fixing that properly means chunking writes in `ptyManager` — real work, and we'd instead point users to already existing keybind that properly supports long text truncations and images. Claude Code handles Alt+V natively for both text and images, so the paste never traverses our broken write path.

Alt+V is a **Claude Code keybinding, not a Windows OS feature** — so it isn't tied to any Windows version; it works anywhere Claude Code runs (including WSL).

- It is the default for the `chat:imagePaste` action **on Windows and WSL**; macOS/Linux default that action to Ctrl+V instead. On WSL both are bound. ([keybindings docs](https://code.claude.com/docs/en/keybindings))
- Claude Code's customizable keybindings — where Alt+V is documented — require **v2.1.18+**.
- The Windows Alt+V **image**-paste fix specifically shipped in **v2.1.157 (May 29, 2026)**, alongside the Windows 11 screenshot-paste fix and drag-from-Explorer support.
- It exists because Windows Terminal reserves Ctrl+V for text paste and intercepts it before Claude Code sees it, so Alt+V is the native alternative.

## Changes

| File | What |
|---|---|
| `windowsPasteToast.tsx` | The toast: `maybeShowWindowsPasteToast()` + the `PasteTip` card |
| `TerminalSessionManager.ts` | Fires the toast on Windows Ctrl+V; caches the `isWindows` platform check |
| `settingsKeys.ts` | Registers `hasDismissedWindowsPasteToast` so the opt-out persists |

## Behaviour notes

- **Trigger** is a pure side effect in the key handler — no `preventDefault`/`return`, so existing paste handling is untouched and Alt+V passes through unaffected.
- **Windows-only**, gated on `getPlatform() === 'win32'`. Cached at construction rather than read per keystroke.
- **De-duped** onto a fixed toast id, so holding Ctrl+V doesn't stack toasts.
- **Dismissal is two-tier**: closing the toast stays quiet for the rest of the session but nudges once more next launch; ticking "Don't show again" persists via the new setting. The reasoning is that a user who dismisses without ticking probably hasn't internalised the tip yet.
- **Design** mirrors the existing ports-wizard toast (`PortsWizardToasts.tsx`): same `toast.custom` card shell, icon + title + muted body, quiet opt-out on the left and the plain close on the right.

## Testing

`pnpm type-check` passes; lint and the pre-commit hooks are green.

**Verified in the running app** (Windows 11): pressing Ctrl+V in a task terminal surfaces the toast. An earlier "the toast doesn't appear" report turned out to be environmental, not a code issue — a dev server from another checkout still held port 3000, so this worktree's Electron was loading the *other* renderer. (`vite.config.ts` sets `server.port: 3000` without `strictPort`, so Vite silently falls back to 3001 while `window.ts` still loads `localhost:3000` — a trap worth knowing if you run two Dash checkouts at once.)

Still worth a click-through before merge: the two dismissal paths — session-scoped (close/swipe, should re-nudge next launch) vs persisted (tick "Don't show again", reload, should stay gone).
